### PR TITLE
feat: support Hysteria2 port hopping

### DIFF
--- a/crates/honk-config/src/node.rs
+++ b/crates/honk-config/src/node.rs
@@ -29,6 +29,25 @@ where
 
 use crate::types::NodeProtocol;
 
+/// An inclusive UDP port range.
+///
+/// Hysteria2 accepts a comma-separated union of individual ports and port
+/// ranges in its URI authority (for example `:443,8443,40000-50000`).  Keep
+/// the compact representation in configuration and expand it only when the
+/// QUIC client needs to choose a hop target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PortRange {
+    pub start: u16,
+    pub end: u16,
+}
+
+impl PortRange {
+    /// Iterate over every port in this inclusive range.
+    pub fn ports(self) -> std::ops::RangeInclusive<u16> {
+        self.start..=self.end
+    }
+}
+
 /// A proxy node definition.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Node {
@@ -90,6 +109,10 @@ pub struct Node {
     /// Hysteria2 authentication
     #[serde(default)]
     pub hy2_auth: Option<String>,
+    /// Hysteria2 remote UDP port union used for QUIC port hopping. Empty
+    /// means the regular single [`Self::port`] endpoint.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub hy2_port_ranges: Vec<PortRange>,
     /// Hysteria2 obfuscation
     #[serde(default)]
     pub hy2_obfs: Option<String>,
@@ -188,6 +211,22 @@ impl Node {
         } else {
             &self.host
         }
+    }
+
+    /// Expand and de-duplicate configured Hysteria2 hop ranges.
+    ///
+    /// This is intentionally only used by the Hysteria2 outbound. Other
+    /// protocols continue to use the stable, single [`Self::port`] field.
+    pub fn hy2_port_hopping_ports(&self) -> Vec<u16> {
+        let mut ports: Vec<u16> = self
+            .hy2_port_ranges
+            .iter()
+            .copied()
+            .flat_map(PortRange::ports)
+            .collect();
+        ports.sort_unstable();
+        ports.dedup();
+        ports
     }
 }
 

--- a/crates/honk-config/src/share_link.rs
+++ b/crates/honk-config/src/share_link.rs
@@ -28,7 +28,7 @@ use std::collections::HashMap;
 use base64::Engine as _;
 
 use crate::error::ConfigError;
-use crate::node::Node;
+use crate::node::{Node, PortRange};
 use crate::types::NodeProtocol;
 
 impl Node {
@@ -63,6 +63,19 @@ impl Node {
             None => first,
         };
 
+        // Hysteria2 extends the URI authority with a comma-separated port
+        // union (for example `:443,8443,40000-50000`). `url::Url` correctly
+        // rejects that non-standard port syntax, so normalize it to one
+        // representative port for ordinary URL parsing while retaining the
+        // full union on the Node for the QUIC port-hopper.
+        let mut normalized_hy2 = None;
+        let mut hy2_port_ranges = Vec::new();
+        if let Some((normalized, ranges)) = normalize_hysteria2_port_hopping_uri(first)? {
+            normalized_hy2 = Some(normalized);
+            hy2_port_ranges = ranges;
+        }
+        let first = normalized_hy2.as_deref().unwrap_or(first);
+
         let url = url::Url::parse(first)
             .map_err(|e| ConfigError::Parse(format!("invalid share link '{}': {}", first, e)))?;
         let scheme = url.scheme();
@@ -75,7 +88,7 @@ impl Node {
             "anytls" => NodeProtocol::AnyTLS,
             "vmess" => NodeProtocol::VMess,
             "vless" => NodeProtocol::VLess,
-            "hysteria2" | "hysteria" => NodeProtocol::Hysteria2,
+            "hysteria2" | "hysteria" | "hy2" => NodeProtocol::Hysteria2,
             "tuic" => NodeProtocol::Tuic,
             "juicity" => NodeProtocol::Juicity,
             "http" | "https" => NodeProtocol::HTTP,
@@ -97,6 +110,7 @@ impl Node {
             host: host.clone(),
             address: format!("{}:{}", host, port),
             port,
+            hy2_port_ranges,
             ..Default::default()
         };
 
@@ -112,6 +126,19 @@ impl Node {
             }
             if let Some(pw) = url.password() {
                 node.password = Some(percent_decode_str(pw));
+            }
+
+            // Hysteria2 puts `auth` in the URI userinfo. Unlike Trojan-like
+            // links, it may deliberately be a `username:password` pair, so
+            // preserve both components as one protocol-level auth value.
+            if protocol == NodeProtocol::Hysteria2 && !url.username().is_empty() {
+                let username = percent_decode_str(url.username());
+                node.hy2_auth = Some(match url.password() {
+                    Some(password) => {
+                        format!("{}:{}", username, percent_decode_str(password))
+                    }
+                    None => username,
+                });
             }
 
             // Trojan, Trojan-Go and AnyTLS put the authentication secret in the
@@ -302,8 +329,151 @@ impl Node {
             }
         }
 
+        if protocol == NodeProtocol::Hysteria2
+            && query
+                .get("obfs")
+                .is_some_and(|kind| kind.eq_ignore_ascii_case("salamander"))
+            && let Some(password) = query
+                .get("obfs-password")
+                .filter(|password| !password.is_empty())
+        {
+            node.hy2_obfs = Some(password.clone());
+        }
+
         Ok(node)
     }
+}
+
+/// Normalize Hysteria2's non-standard multi-port URI authority before it is
+/// handed to `url::Url`. The original port union is returned separately so
+/// the caller can retain it for actual QUIC hopping.
+fn normalize_hysteria2_port_hopping_uri(
+    link: &str,
+) -> Result<Option<(String, Vec<PortRange>)>, ConfigError> {
+    let Some((scheme, after_scheme)) = link.split_once("://") else {
+        return Ok(None);
+    };
+    if !matches!(
+        scheme.to_ascii_lowercase().as_str(),
+        "hysteria2" | "hysteria" | "hy2"
+    ) {
+        return Ok(None);
+    }
+
+    let authority_end = after_scheme
+        .char_indices()
+        .find_map(|(idx, ch)| matches!(ch, '/' | '?' | '#').then_some(idx))
+        .unwrap_or(after_scheme.len());
+    let authority = &after_scheme[..authority_end];
+    let suffix = &after_scheme[authority_end..];
+    let (userinfo, host_port) = match authority.rsplit_once('@') {
+        Some((userinfo, host_port)) => (format!("{userinfo}@"), host_port),
+        None => (String::new(), authority),
+    };
+    let Some((host, port_spec)) = split_hysteria2_host_port(host_port)? else {
+        // Keep the generic parser's normal `:443` fallback for an ordinary
+        // Hysteria2 URI that omits a port altogether.
+        return Ok(None);
+    };
+
+    if !port_spec.contains(',') && !port_spec.contains('-') {
+        return Ok(None);
+    }
+
+    let ranges = parse_hysteria2_port_union(port_spec)?;
+    let representative = ranges
+        .first()
+        .expect("validated Hysteria2 port union is non-empty")
+        .start;
+    Ok(Some((
+        format!("{scheme}://{userinfo}{host}:{representative}{suffix}"),
+        ranges,
+    )))
+}
+
+/// Split a Hysteria2 URI authority into the host (including IPv6 brackets)
+/// and an optional port expression.
+///
+/// A normal URI may omit its port and rely on the Hysteria2 default of 443;
+/// only a port expression containing a union needs special normalization.
+fn split_hysteria2_host_port(authority: &str) -> Result<Option<(&str, &str)>, ConfigError> {
+    let (host, port) = if authority.starts_with('[') {
+        let close = authority.find(']').ok_or_else(|| {
+            ConfigError::Parse("invalid Hysteria2 URI: unterminated IPv6 host".into())
+        })?;
+        let host = &authority[..=close];
+        let suffix = &authority[close + 1..];
+        if suffix.is_empty() {
+            return Ok(None);
+        }
+        let port = suffix.strip_prefix(':').ok_or_else(|| {
+            ConfigError::Parse("invalid Hysteria2 URI: invalid text after IPv6 host".into())
+        })?;
+        (host, port)
+    } else {
+        match authority.rsplit_once(':') {
+            Some(parts) => parts,
+            None => return Ok(None),
+        }
+    };
+    if host.is_empty() || port.is_empty() {
+        return Err(ConfigError::Parse(
+            "invalid Hysteria2 URI: empty host or port".into(),
+        ));
+    }
+    Ok(Some((host, port)))
+}
+
+/// Parse Hysteria2's comma-separated union of individual ports and inclusive
+/// port ranges. Port zero is invalid for an outbound UDP peer.
+fn parse_hysteria2_port_union(port_spec: &str) -> Result<Vec<PortRange>, ConfigError> {
+    fn parse_port(raw: &str, port_spec: &str) -> Result<u16, ConfigError> {
+        let port = raw.trim().parse::<u16>().map_err(|_| {
+            ConfigError::Parse(format!("invalid Hysteria2 port union '{port_spec}'"))
+        })?;
+        if port == 0 {
+            return Err(ConfigError::Parse(format!(
+                "invalid Hysteria2 port union '{port_spec}': port 0 is not allowed"
+            )));
+        }
+        Ok(port)
+    }
+
+    let mut ranges = Vec::new();
+    for raw_item in port_spec.split(',') {
+        let item = raw_item.trim();
+        if item.is_empty() {
+            return Err(ConfigError::Parse(format!(
+                "invalid Hysteria2 port union '{port_spec}'"
+            )));
+        }
+        let range = match item.split_once('-') {
+            Some((start, end)) if !end.contains('-') => {
+                let start = parse_port(start, port_spec)?;
+                let end = parse_port(end, port_spec)?;
+                if start > end {
+                    return Err(ConfigError::Parse(format!(
+                        "invalid Hysteria2 port range '{item}': start exceeds end"
+                    )));
+                }
+                PortRange { start, end }
+            }
+            Some(_) => {
+                return Err(ConfigError::Parse(format!(
+                    "invalid Hysteria2 port range '{item}'"
+                )));
+            }
+            None => {
+                let port = parse_port(item, port_spec)?;
+                PortRange {
+                    start: port,
+                    end: port,
+                }
+            }
+        };
+        ranges.push(range);
+    }
+    Ok(ranges)
 }
 
 /// Parse a `vmess://` share link: base64 of a JSON object (v2rayN schema).
@@ -685,4 +855,94 @@ fn hex_to_byte(h: u8, l: u8) -> Result<u8, ()> {
     let hi = hex_val(h).ok_or(())?;
     let lo = hex_val(l).ok_or(())?;
     Ok(hi << 4 | lo)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_hysteria2_port_range_and_obfuscation() {
+        let node = Node::from_share_link(
+            "hysteria2://secret@[2001:db8::1]:40000-40002/?sni=example.com&obfs=salamander&obfs-password=obfs",
+        )
+        .expect("valid Hysteria2 port-hopping URI");
+
+        assert_eq!(node.protocol, NodeProtocol::Hysteria2);
+        assert_eq!(node.host, "[2001:db8::1]");
+        assert_eq!(node.port, 40000);
+        assert_eq!(node.hy2_auth.as_deref(), Some("secret"));
+        assert_eq!(node.hy2_obfs.as_deref(), Some("obfs"));
+        assert_eq!(node.sni.as_deref(), Some("example.com"));
+        assert_eq!(
+            node.hy2_port_ranges,
+            vec![PortRange {
+                start: 40000,
+                end: 40002,
+            }]
+        );
+        assert_eq!(node.hy2_port_hopping_ports(), vec![40000, 40001, 40002]);
+    }
+
+    #[test]
+    fn parses_hy2_port_union_and_auth_pair() {
+        let node =
+            Node::from_share_link("hy2://user:pass@example.com:443,8443,10000-10002/?insecure=1")
+                .expect("valid HY2 port union URI");
+
+        assert_eq!(node.protocol, NodeProtocol::Hysteria2);
+        assert_eq!(node.port, 443);
+        assert_eq!(node.hy2_auth.as_deref(), Some("user:pass"));
+        assert!(node.skip_cert_verify);
+        assert_eq!(
+            node.hy2_port_hopping_ports(),
+            vec![443, 8443, 10000, 10001, 10002]
+        );
+    }
+
+    #[test]
+    fn hysteria2_single_or_missing_port_remains_a_normal_uri() {
+        let single = Node::from_share_link("hysteria2://secret@example.com:443/?sni=example.com")
+            .expect("single-port URI remains supported");
+        assert!(single.hy2_port_ranges.is_empty());
+        assert_eq!(single.port, 443);
+
+        let implicit = Node::from_share_link("hysteria2://secret@example.com/?sni=example.com")
+            .expect("implicit default port remains supported");
+        assert!(implicit.hy2_port_ranges.is_empty());
+        assert_eq!(implicit.port, 443);
+    }
+
+    #[test]
+    fn rejects_invalid_hysteria2_port_union() {
+        for link in [
+            "hysteria2://secret@example.com:40002-40000/",
+            "hysteria2://secret@example.com:0,443/",
+            "hysteria2://secret@example.com:443,,8443/",
+            "hysteria2://secret@example.com:443-444-445/",
+        ] {
+            assert!(Node::from_share_link(link).is_err(), "{link}");
+        }
+    }
+
+    #[test]
+    fn serializes_hysteria2_port_ranges_in_toml_node_tables() {
+        #[derive(serde::Serialize, serde::Deserialize)]
+        struct NodeList {
+            nodes: Vec<Node>,
+        }
+
+        let source = Node::from_share_link("hy2://secret@example.com:443,8443,10000-10001/")
+            .expect("valid Hysteria2 port union");
+        let text = toml::to_string(&NodeList {
+            nodes: vec![source.clone()],
+        })
+        .expect("serialize node table");
+        assert!(text.contains("hy2_port_ranges"));
+        let restored: NodeList = toml::from_str(&text).expect("deserialize node table");
+        assert_eq!(
+            restored.nodes[0].hy2_port_hopping_ports(),
+            source.hy2_port_hopping_ports()
+        );
+    }
 }

--- a/crates/honk-core/src/control/connection.rs
+++ b/crates/honk-core/src/control/connection.rs
@@ -379,9 +379,9 @@ impl ControlPlaneHandle {
         // mode takes the handoff decision as-is.
         let reroute_by_sniffed_domain = !matches!(dial_mode, DialMode::Ip)
             && domain.is_some()
-            && handoff.as_ref().is_some_and(|ho| {
-                ho.must == 0 && ho.outbound != OutboundIndex::Block as u8
-            });
+            && handoff
+                .as_ref()
+                .is_some_and(|ho| ho.must == 0 && ho.outbound != OutboundIndex::Block as u8);
         let (outbound_name, must) = if let Some(ref ho) = handoff {
             debug!(
                 "eBPF handoff: outbound={}, mark=0x{:x}, dscp={}",

--- a/crates/honk-core/src/ebpf/real/attach.rs
+++ b/crates/honk-core/src/ebpf/real/attach.rs
@@ -169,9 +169,11 @@ impl RealEbpfBackend {
                         .and_then(|p| p.try_into().ok())
                         .ok_or_else(|| anyhow::anyhow!("{} program not found", name))?;
                     p.load()?;
-                    let link_id =
-                        p.attach(&cgroup_file, aya::programs::CgroupAttachMode::Single)?;
-                    let _link = p.take_link(link_id)?;
+                    // Keep the link owned by the program inside `Ebpf`.
+                    // `take_link()` transfers ownership out of aya; dropping
+                    // that temporary link immediately detaches the cgroup
+                    // program, which silently disables pname routing.
+                    p.attach(&cgroup_file, aya::programs::CgroupAttachMode::Single)?;
                 }
                 let cg_addr_names = [
                     "tproxy_wan_cg_connect4",
@@ -185,9 +187,9 @@ impl RealEbpfBackend {
                         .and_then(|p| p.try_into().ok())
                         .ok_or_else(|| anyhow::anyhow!("{} program not found", name))?;
                     p.load()?;
-                    let link_id =
-                        p.attach(&cgroup_file, aya::programs::CgroupAttachMode::Single)?;
-                    let _link = p.take_link(link_id)?;
+                    // See the CgroupSock branch above: keep this link in the
+                    // program's managed-link set for the backend lifetime.
+                    p.attach(&cgroup_file, aya::programs::CgroupAttachMode::Single)?;
                 }
                 info!("Attached 6 cgroup programs to {}", cgroup_path);
             }

--- a/crates/honk-core/src/ebpf/real/events.rs
+++ b/crates/honk-core/src/ebpf/real/events.rs
@@ -72,14 +72,18 @@ pub async fn consume_dae_events(
                 let dip = event_ip(&ev.dip);
                 let is_overflow = ev.type_ == DaeEventType::UdpConnOverflow as u32
                     || ev.type_ == DaeEventType::TcpConnOverflow as u32;
+                let is_tproxy_assign_failure = ev.type_ == DaeEventType::TproxyAssignFailure as u32;
                 let kind = match ev.type_ {
                     t if t == DaeEventType::UdpConnOverflow as u32 => "udp_conn_overflow",
                     t if t == DaeEventType::TcpConnOverflow as u32 => "tcp_conn_overflow",
+                    t if t == DaeEventType::TproxyAssignFailure as u32 => "tproxy_assign_failure",
                     t if t == DaeEventType::Blocked as u32 => "blocked",
                     _ => "unknown",
                 };
                 if is_overflow {
                     warn!(target: "honk-ebpf", event = kind, pid = ev.pid, pname = %pname, l4proto = ev.l4proto, %sip, sport = ev.sport, %dip, dport = ev.dport, outbound = ev.outbound, "eBPF conntrack overflow");
+                } else if is_tproxy_assign_failure {
+                    warn!(target: "honk-ebpf", event = kind, errno = ev.pid, l4proto = ev.l4proto, "eBPF TPROXY listener assignment failed");
                 } else {
                     info!(target: "honk-ebpf", event = kind, pid = ev.pid, pname = %pname, l4proto = ev.l4proto, %sip, sport = ev.sport, %dip, dport = ev.dport, outbound = ev.outbound, "eBPF datapath event");
                 }

--- a/crates/honk-core/src/routing/mod.rs
+++ b/crates/honk-core/src/routing/mod.rs
@@ -204,7 +204,7 @@ impl Router {
                 .condition
                 .ip
                 .iter()
-                .filter_map(|c| c.parse().ok())
+                .filter_map(|c| parse_ip_net(c))
                 .collect();
             ip_nets.extend(assets.geoip_nets(&rule.condition.geo_ip));
 
@@ -212,7 +212,7 @@ impl Router {
                 .condition
                 .source_ip
                 .iter()
-                .filter_map(|c| c.parse().ok())
+                .filter_map(|c| parse_ip_net(c))
                 .collect();
 
             let ports = parse_port_ranges(&rule.condition.port)?;
@@ -600,6 +600,24 @@ fn parse_ip_version(s: &str) -> Option<u8> {
         "6" | "ipv6" => Some(6),
         _ => None,
     }
+}
+
+/// Parse a routing IP matcher, accepting both CIDRs and a single host IP.
+///
+/// dae configuration commonly writes `dip(203.0.113.7)` for an exact host.
+/// `ipnet` only accepts the CIDR spelling, so treating a bare address as
+/// `/32` or `/128` here keeps the userspace router and the eBPF LPM compiler
+/// in agreement.
+fn parse_ip_net(value: &str) -> Option<ipnet::IpNet> {
+    value.parse::<ipnet::IpNet>().ok().or_else(|| {
+        value.parse::<IpAddr>().ok().and_then(|ip| {
+            let prefix_len = match ip {
+                IpAddr::V4(_) => 32,
+                IpAddr::V6(_) => 128,
+            };
+            ipnet::IpNet::new(ip, prefix_len).ok()
+        })
+    })
 }
 
 fn parse_port_ranges(ports: &[String]) -> anyhow::Result<Vec<PortRange>> {

--- a/crates/honk-core/src/routing/tests.rs
+++ b/crates/honk-core/src/routing/tests.rs
@@ -162,6 +162,48 @@ fn test_ip_cidr_route() {
 }
 
 #[test]
+fn test_bare_ip_route_is_an_exact_host_match() {
+    let rules = vec![RoutingRule {
+        name: "exact-host".into(),
+        condition: RoutingCondition {
+            // dae's `dip(203.0.113.7)` syntax reaches the router as a bare
+            // address, not as an explicit `/32` CIDR.
+            ip: vec!["203.0.113.7".into()],
+            ..Default::default()
+        },
+        outbound: RoutingOutbound::Simple("proxy".into()),
+        priority: 0,
+        must: false,
+        mark: 0,
+    }];
+
+    let router = Router::new(&rules, "direct").unwrap();
+    let mut conn = make_conn(None, None);
+
+    conn.dst_ip = "203.0.113.7".parse().unwrap();
+    assert_eq!(router.route(&conn), "proxy");
+    conn.dst_ip = "203.0.113.8".parse().unwrap();
+    assert_eq!(router.route(&conn), "direct");
+
+    let ipv6_rule = RoutingRule {
+        name: "exact-v6-host".into(),
+        condition: RoutingCondition {
+            ip: vec!["2001:db8::7".into()],
+            ..Default::default()
+        },
+        outbound: RoutingOutbound::Simple("proxy".into()),
+        priority: 0,
+        must: false,
+        mark: 0,
+    };
+    let ipv6_router = Router::new(&[ipv6_rule], "direct").unwrap();
+    conn.dst_ip = "2001:db8::7".parse().unwrap();
+    assert_eq!(ipv6_router.route(&conn), "proxy");
+    conn.dst_ip = "2001:db8::8".parse().unwrap();
+    assert_eq!(ipv6_router.route(&conn), "direct");
+}
+
+#[test]
 fn test_port_route() {
     let rules = vec![RoutingRule {
         name: "web-traffic".into(),

--- a/crates/honk-ebpf-common/src/event.rs
+++ b/crates/honk-ebpf-common/src/event.rs
@@ -5,6 +5,9 @@ pub enum DaeEventType {
     Blocked = 0,         // DAE_EVENT_BLOCKED
     UdpConnOverflow = 1, // DAE_EVENT_UDP_CONN_OVERFLOW
     TcpConnOverflow = 2, // DAE_EVENT_TCP_CONN_OVERFLOW
+    /// A TC ingress packet could not be assigned to the transparent
+    /// listener. For this event only, [`DaeEvent::pid`] carries `-errno`.
+    TproxyAssignFailure = 3,
 }
 
 // Matches the C struct dae_event.

--- a/crates/honk-ebpf/src/egress.rs
+++ b/crates/honk-ebpf/src/egress.rs
@@ -37,7 +37,7 @@ use crate::{
     },
     route::{OUTBOUND_BLOCK, OUTBOUND_DIRECT},
     transport::{
-        ETH_HLEN, ETH_P_IP, IPPROTO_ICMPV6, IPPROTO_TCP, IPPROTO_UDP, parse_packet,
+        ETH_HLEN, ETH_P_IP, ETH_P_IPV6, IPPROTO_ICMPV6, IPPROTO_TCP, IPPROTO_UDP, parse_packet,
         tcp_listener_l4proto,
     },
 };
@@ -537,6 +537,12 @@ fn do_tproxy_wan_egress_tcp(
     }
 
     // Set cb marks for dae0peer_ingress.
+    // `skb->cb` is scratch storage and is not preserved consistently when a
+    // packet crosses the dae0 veth pair.  Mirror the listener protocol in
+    // the low byte of skb->mark (the same encoding used by lan_ingress) so
+    // dae0peer_ingress can still assign the TPROXY listener after the veth
+    // handoff.
+    ctx.set_mark(TPROXY_MARK | (tcp_listener_l4proto(tcph) as u32));
     unsafe {
         (*ctx.skb.skb).cb[0] = TPROXY_MARK;
         (*ctx.skb.skb).cb[1] = tcp_listener_l4proto(tcph) as u32;
@@ -595,6 +601,9 @@ fn fast_path_decision(
         return Err(TC_ACT_OK);
     }
 
+    // See the TCP path above: preserve the listener type in skb->mark as
+    // well as cb[] because veth delivery may clear the control buffer.
+    ctx.set_mark(TPROXY_MARK | (IPPROTO_UDP as u32));
     unsafe {
         (*ctx.skb.skb).cb[0] = TPROXY_MARK;
         (*ctx.skb.skb).cb[1] = IPPROTO_UDP as u32;
@@ -867,6 +876,49 @@ fn do_tproxy_wan_egress(ctx: &TcContext, link_h_len: u32) -> Verdict {
     }
 }
 
+/// Choose the actual header layout of a locally-originated WAN packet.
+///
+/// `ARPHRD_ETHER` is normally a good attachment-time predictor, but it is
+/// not an invariant: some drivers expose a packet before the Ethernet header
+/// is pushed, while others expose the fully-framed skb.  Parsing with the
+/// wrong offset fails open, silently bypassing the transparent proxy.  Probe
+/// both the EtherType at byte 12 and the matching IP version at byte 14 so
+/// an L3 packet cannot be mistaken for Ethernet merely because payload bytes
+/// happen to resemble an EtherType.
+#[inline(always)]
+fn wan_egress_link_h_len(ctx: &TcContext, fallback_link_h_len: u32) -> u32 {
+    let skb = ctx.skb.skb as *mut _;
+    let mut ether_type: u16 = 0;
+    let ether_type_ok = unsafe {
+        bpf_skb_load_bytes(
+            skb,
+            12,
+            &mut ether_type as *mut u16 as *mut _,
+            mem::size_of::<u16>() as u32,
+        )
+    } == 0;
+
+    if ether_type_ok && (ether_type == ETH_P_IP.to_be() || ether_type == ETH_P_IPV6.to_be()) {
+        let expected_version = if ether_type == ETH_P_IP.to_be() { 4 } else { 6 };
+        let mut l2_ip_version = 0u8;
+        let version_ok = unsafe {
+            bpf_skb_load_bytes(skb, ETH_HLEN, &mut l2_ip_version as *mut u8 as *mut _, 1)
+        } == 0;
+        if version_ok && l2_ip_version >> 4 == expected_version {
+            return ETH_HLEN;
+        }
+    }
+
+    let mut l3_ip_version = 0u8;
+    let version_ok =
+        unsafe { bpf_skb_load_bytes(skb, 0, &mut l3_ip_version as *mut u8 as *mut _, 1) } == 0;
+    if version_ok && matches!(l3_ip_version >> 4, 4 | 6) {
+        return 0;
+    }
+
+    fallback_link_h_len
+}
+
 // TC entry points use raw __sk_buff pointer for verifier compatibility.
 
 #[unsafe(no_mangle)]
@@ -884,11 +936,16 @@ pub fn lan_egress_l3(ctx: *mut __sk_buff) -> i32 {
 #[unsafe(no_mangle)]
 #[unsafe(link_section = "classifier")]
 pub fn wan_egress_l2(ctx: *mut __sk_buff) -> i32 {
-    flatten(do_tproxy_wan_egress(&TcContext::new(ctx), 14))
+    let ctx = TcContext::new(ctx);
+    flatten(do_tproxy_wan_egress(
+        &ctx,
+        wan_egress_link_h_len(&ctx, ETH_HLEN),
+    ))
 }
 
 #[unsafe(no_mangle)]
 #[unsafe(link_section = "classifier")]
 pub fn wan_egress_l3(ctx: *mut __sk_buff) -> i32 {
-    flatten(do_tproxy_wan_egress(&TcContext::new(ctx), 0))
+    let ctx = TcContext::new(ctx);
+    flatten(do_tproxy_wan_egress(&ctx, wan_egress_link_h_len(&ctx, 0)))
 }

--- a/crates/honk-ebpf/src/ingress.rs
+++ b/crates/honk-ebpf/src/ingress.rs
@@ -14,6 +14,7 @@ use core::{
 
 use crate::{
     action::{TC_ACT_OK, TC_ACT_PIPE, TC_ACT_SHOT, Verdict, flatten},
+    event::send_dae_event,
     log_shim::*,
     maps::LISTEN_SOCKET_MAP,
     transport::ParsedPacket,
@@ -25,15 +26,15 @@ use aya_ebpf_bindings::{
         bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2,
     },
     helpers::{
-        bpf_ktime_get_ns, bpf_redirect, bpf_redirect_peer, bpf_skb_load_bytes,
-        bpf_skb_store_bytes,
+        bpf_ktime_get_ns, bpf_redirect, bpf_redirect_peer, bpf_skb_load_bytes, bpf_skb_store_bytes,
     },
 };
 use honk_ebpf_common::{
+    RedirectEntry, RedirectTuple, RoutingMeta, TPROXY_MARK,
     conn::ConnState,
     dae_ip::In6Addr,
+    event::DaeEventType,
     redirect_need::{RoutingHandoffEntry, TuplesKey},
-    RedirectEntry, RedirectTuple, RoutingMeta, TPROXY_MARK,
 };
 use network_types::{
     eth::EthHdr,
@@ -42,12 +43,12 @@ use network_types::{
 
 use crate::{
     maps::{
-        OUTBOUND_CONNECTIVITY_MAP, PARAM, PKT_SCRATCH_KEY, REDIRECT_TRACK, ROUTE_CTX_SCRATCH_MAP,
-        ROUTING_HANDOFF_MAP, ROUTING_META_MAP,
+        CONN_STATE_MAP, OUTBOUND_CONNECTIVITY_MAP, PARAM, PKT_SCRATCH_KEY, REDIRECT_TRACK,
+        ROUTE_CTX_SCRATCH_MAP, ROUTING_HANDOFF_MAP, ROUTING_META_MAP,
     },
-    route::{RouteCtx, OUTBOUND_BLOCK, OUTBOUND_DIRECT},
+    route::{OUTBOUND_BLOCK, OUTBOUND_DIRECT, RouteCtx},
     sk,
-    transport::{parse_packet, ETH_HLEN, ETH_P_IP, ETH_P_IPV6, IPPROTO_TCP, IPPROTO_UDP},
+    transport::{ETH_HLEN, ETH_P_IP, ETH_P_IPV6, IPPROTO_TCP, IPPROTO_UDP, parse_packet},
 };
 
 const IPV6_BYTE_LENGTH: usize = 16;
@@ -956,23 +957,64 @@ fn do_tproxy_wan_ingress(ctx: &TcContext, link_h_len: u32) -> Verdict {
 }
 
 // #[inline(never)]: standalone program, no deep call chain.
+/// Recover the listener protocol when veth delivery has cleared both
+/// `skb->cb` and `skb->mark`.
+///
+/// The host-side ingress/egress programs record every redirected flow in
+/// `CONN_STATE_MAP` before sending it to dae0.  This gives the dedicated
+/// dae0peer ingress hook a durable, per-flow proof that the packet belongs to
+/// honk, without accepting unrelated traffic injected into the namespace.
+#[inline(always)]
+fn recover_dae0peer_listener_l4proto(ctx: &TcContext) -> Option<u8> {
+    let scratch_key: u32 = 0;
+    let pkt = match PKT_SCRATCH_KEY.get_ptr_mut(scratch_key) {
+        Some(ptr) => unsafe { &mut *ptr },
+        None => return None,
+    };
+
+    if parse_packet(ctx, ETH_HLEN, pkt) != 0 {
+        return None;
+    }
+
+    let state = CONN_STATE_MAP.get_ptr_mut(pkt.tuples.five)?;
+    let has_routing = ((unsafe { (*state).meta.raw } >> 56) & 1) != 0;
+    has_routing.then_some(pkt.listener_l4proto)
+}
+
+// #[inline(never)]: standalone program, no deep call chain.
 #[inline(never)]
 fn do_tproxy_dae0peer_ingress(ctx: &TcContext) -> Verdict {
-    // Only packets redirected from wan_egress or lan_ingress carry this cb
-    // mark.  Other traffic (e.g. replies to locally-generated proxy outbound
-    // connections) must be passed through so the daens IP stack can deliver it
-    // to the correct local socket.
+    // Only packets redirected from wan_egress or lan_ingress carry the
+    // TPROXY marker. `skb->cb` is scratch storage and can be cleared when a
+    // packet crosses the dae0 veth pair, so the redirect path mirrors the
+    // marker and listener L4 protocol in skb->mark as a durable fallback.
+    // Other traffic (e.g. replies to locally-generated proxy outbound
+    // connections) must be dropped here rather than accidentally assigned to
+    // the transparent listener.
     let cb0 = unsafe { (*ctx.skb.skb).cb[0] };
-    if cb0 != TPROXY_MARK {
-        return Err(TC_ACT_SHOT);
-    }
+    let packet_mark = unsafe { (*ctx.skb.skb).mark };
+    let mark_is_tproxy = (packet_mark & TPROXY_MARK) == TPROXY_MARK;
 
     // listener_l4proto is stored in cb[1] only when the control-plane handoff
     // needs an explicit listener assignment (UDP or TCP SYN, including first
-    // fragments that still expose those headers).  Established TCP can return
-    // to the stack without bpf_sk_assign; the kernel will find the child
-    // socket via normal socket lookup.
-    let listener_l4proto = (unsafe { (*ctx.skb.skb).cb[1] }) as u8;
+    // fragments that still expose those headers). If cb[] was cleared by the
+    // veth handoff, recover it from the low byte of skb->mark. Established TCP
+    // has a zero protocol marker and can return to the stack without
+    // bpf_sk_assign; the kernel will find the child socket via normal socket
+    // lookup.
+    let listener_l4proto = if cb0 == TPROXY_MARK || mark_is_tproxy {
+        let listener_l4proto = (unsafe { (*ctx.skb.skb).cb[1] }) as u8;
+        if listener_l4proto != 0 {
+            listener_l4proto
+        } else {
+            packet_mark as u8
+        }
+    } else {
+        match recover_dae0peer_listener_l4proto(ctx) {
+            Some(listener_l4proto) => listener_l4proto,
+            None => return Err(TC_ACT_SHOT),
+        }
+    };
     ctx.set_mark(TPROXY_MARK);
     // Force the packet type to HOST so the IP stack accepts it and returns
     // it to the stack, letting the netfilter PREROUTING TPROXY rule (or the
@@ -982,7 +1024,22 @@ fn do_tproxy_dae0peer_ingress(ctx: &TcContext) -> Verdict {
     // creating proper child sockets for intercepted TCP flows.
     let _ = ctx.change_type(0);
     if listener_l4proto != 0 {
-        let _ = assign_listener(ctx, listener_l4proto);
+        if let Err(errno) = assign_listener(ctx, listener_l4proto) {
+            // Do not silently turn a broken listener handoff into a timeout.
+            // `DaeEvent` has no dedicated errno field; for this event type its
+            // `pid` field carries the positive errno instead.
+            let _ = send_dae_event(
+                DaeEventType::TproxyAssignFailure as u32,
+                errno.wrapping_neg() as u32,
+                None,
+                0,
+                listener_l4proto,
+                None,
+                None,
+                0,
+                0,
+            );
+        }
     }
 
     Ok(TC_ACT_OK)
@@ -1010,17 +1067,9 @@ fn assign_listener(ctx: &TcContext, listener_l4proto: u8) -> Result<(), c_long> 
     // listeners published by userspace.
     let is_v6 = unsafe { (*ctx.skb.skb).protocol as u16 } == ETH_P_IPV6.to_be();
     let key = if listener_l4proto == IPPROTO_TCP as u8 {
-        if is_v6 {
-            KEY_TCP6
-        } else {
-            KEY_TCP4
-        }
+        if is_v6 { KEY_TCP6 } else { KEY_TCP4 }
     } else {
-        if is_v6 {
-            KEY_UDP6
-        } else {
-            KEY_UDP4
-        }
+        if is_v6 { KEY_UDP6 } else { KEY_UDP4 }
     };
 
     let map_ptr = ptr::from_ref(&LISTEN_SOCKET_MAP).cast::<c_void>();

--- a/crates/honk-ebpf/src/maps.rs
+++ b/crates/honk-ebpf/src/maps.rs
@@ -67,8 +67,12 @@ pub static REDIRECT_TRACK: HashMap<RedirectTuple, RedirectEntry, 65536, 1> = Has
 #[btf_map]
 /// Plain hash with BPF_F_NO_PREALLOC: swept by the userspace janitor (30 s
 /// timeout).
-pub static ROUTING_HANDOFF_MAP: HashMap<TuplesKey, RoutingHandoffEntry, MAX_ROUTING_HANDOFF_NUM, 1> =
-    HashMap::new();
+pub static ROUTING_HANDOFF_MAP: HashMap<
+    TuplesKey,
+    RoutingHandoffEntry,
+    MAX_ROUTING_HANDOFF_NUM,
+    1,
+> = HashMap::new();
 
 #[btf_map]
 pub static ROUTING_MAP: Array<MatchSet, MAX_MATCH_SET_LEN, 0> = Array::new();

--- a/crates/honk-ebpf/src/routing.rs
+++ b/crates/honk-ebpf/src/routing.rs
@@ -12,4 +12,3 @@ pub fn bpf_sock_is_dae_socket(sock: *const bpf_sock) -> bool {
     }
     unsafe { (*fullsock).mark == crate::maps::PARAM.load().dae_socket_mark }
 }
-

--- a/crates/honk-ebpf/src/sk.rs
+++ b/crates/honk-ebpf/src/sk.rs
@@ -28,7 +28,8 @@ pub(crate) fn sk_assign_by_index(
     index: &u32,
     flags: u64,
 ) -> Result<(), c_long> {
-    let sk = unsafe { bpf_map_lookup_elem(map as *mut c_void, index as *const u32 as *const c_void) };
+    let sk =
+        unsafe { bpf_map_lookup_elem(map as *mut c_void, index as *const u32 as *const c_void) };
     if sk.is_null() {
         return Err(-(ENOENT as c_long));
     }

--- a/crates/honk-outbound/src/proxy/hysteria2/mod.rs
+++ b/crates/honk-outbound/src/proxy/hysteria2/mod.rs
@@ -64,7 +64,7 @@ use tokio::io::ReadBuf;
 use tokio::sync::mpsc;
 use tracing::debug;
 
-use crate::quic::{QuicBiStream, QuicClient};
+use crate::quic::{PortHoppingConfig, QuicBiStream, QuicClient};
 
 use super::{ProxyHandler, ProxyStream, UdpProxySocket};
 
@@ -97,6 +97,8 @@ const TCP_PADDING_MAX: usize = 512;
 
 /// QUIC keep-alive (`hysteria/protocol.go:21`).
 const KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(10);
+/// Hysteria2's documented default UDP port-hop interval.
+const PORT_HOP_INTERVAL: Duration = Duration::from_secs(30);
 /// Close the shared QUIC connection after this long without open streams.
 const CONN_IDLE_TIMEOUT: Duration = Duration::from_secs(120);
 /// Tear down a UDP session bridge after this long without traffic.
@@ -663,30 +665,41 @@ impl Hysteria2Handler {
         let obfs = node.hy2_obfs.as_deref().filter(|s| !s.is_empty());
         // Receive bandwidth for the auth header, bits/s (0 = unset).
         let rx_bps = u64::from(node.hy2_down_mbps.unwrap_or(0)) * 1_000_000;
-        // Port hopping (`mport`/`mhop`): destination port rotates among the
-        // list every interval (default 30s, official client parity).
-        let hop = node
-            .hy2_port_hopping
-            .as_deref()
-            .and_then(parse_port_hopping)
-            .map(|ports| {
-                (
-                    ports,
-                    Duration::from_secs(node.hy2_hop_interval.unwrap_or(30).max(1)),
-                )
-            });
+        // Both accepted Hysteria2 syntaxes describe the same hop set: the
+        // multi-port URI authority (`:443,8443,40000-50000`) and `mport`.
+        // Combine them so a subscription using either spelling keeps the
+        // stable-socket port-hopping path below.
+        let mut hop_ports = node.hy2_port_hopping_ports();
+        if let Some(spec) = node.hy2_port_hopping.as_deref().filter(|s| !s.is_empty()) {
+            let mut parsed = parse_port_hopping(spec)
+                .ok_or_else(|| anyhow!("invalid Hysteria2 mport value: {spec}"))?;
+            hop_ports.append(&mut parsed);
+        }
+        hop_ports.sort_unstable();
+        hop_ports.dedup();
+        let hop_interval =
+            Duration::from_secs(node.hy2_hop_interval.unwrap_or(PORT_HOP_INTERVAL.as_secs()));
+        let hop_key = hop_ports
+            .iter()
+            .map(u16::to_string)
+            .collect::<Vec<_>>()
+            .join(",");
         let key = format!(
-            "{}|{}|{}|{}|{}|{}|{}|{}|{}|{}",
+            "{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}",
             node.host(),
             node.port,
             password,
             node.sni.as_deref().unwrap_or(""),
             node.skip_cert_verify,
             obfs.unwrap_or(""),
+            hop_key,
+            hop_interval.as_secs(),
             node.hy2_up_mbps.unwrap_or(0),
             rx_bps,
-            node.hy2_port_hopping.as_deref().unwrap_or(""),
-            node.hy2_hop_interval.unwrap_or(0),
+            node.hy2_init_stream_recv_window.unwrap_or(0),
+            node.hy2_init_conn_recv_window.unwrap_or(0),
+            node.hy2_disable_mtu_discovery.unwrap_or(false),
+            node.tls_pin_sha256.as_deref().unwrap_or(""),
         );
         if let Some(client) = CLIENTS.lock().get(&key) {
             return Ok(Arc::clone(client));
@@ -717,12 +730,31 @@ impl Hysteria2Handler {
         )
         .await?;
         let quic = QuicClient::new(node.host().to_string(), node.port, server_name, config);
-        let quic = match (obfs, hop) {
-            (None, None) => quic,
-            (obfs, hop) => quic.with_endpoint_factory(hy2_endpoint_factory(
-                obfs.map(|p| Arc::from(p.as_bytes())),
-                hop,
-            )),
+        let quic = if hop_ports.len() > 1 {
+            let port_hopping = PortHoppingConfig::fixed(hop_ports, hop_interval)
+                .context("invalid Hysteria2 port-hopping configuration")?;
+            let obfs_password = obfs.map(|value| Arc::<[u8]>::from(value.as_bytes()));
+            quic.with_port_hopping(
+                port_hopping,
+                move |ipv6| -> std::io::Result<Arc<dyn AsyncUdpSocket>> {
+                    match &obfs_password {
+                        Some(password) => Ok(Arc::new(Hy2UdpSocket::new(
+                            ipv6,
+                            Some(Arc::clone(password)),
+                            None,
+                        )?)),
+                        None => crate::quic::marked_async_udp_socket(ipv6),
+                    }
+                },
+            )
+        } else {
+            match obfs {
+                Some(obfs_password) => quic.with_endpoint_factory(hy2_endpoint_factory(
+                    Some(Arc::from(obfs_password.as_bytes())),
+                    None,
+                )),
+                None => quic,
+            }
         };
         let client = Arc::new(Hy2Client {
             quic,

--- a/crates/honk-outbound/src/proxy/hysteria2/salamander.rs
+++ b/crates/honk-outbound/src/proxy/hysteria2/salamander.rs
@@ -153,7 +153,7 @@ pub(super) struct Hy2UdpSocket {
 }
 
 impl Hy2UdpSocket {
-    fn new(
+    pub(super) fn new(
         ipv6: bool,
         obfs: Option<Arc<[u8]>>,
         hop: Option<(Vec<u16>, Duration)>,

--- a/crates/honk-outbound/src/proxy/hysteria2/tests.rs
+++ b/crates/honk-outbound/src/proxy/hysteria2/tests.rs
@@ -754,9 +754,7 @@ fn e2e_node() -> Option<Node> {
         hy2_hop_interval: std::env::var("HONK_HY2_MHOP")
             .ok()
             .and_then(|v| v.parse().ok()),
-        tls_pin_sha256: std::env::var("HONK_HY2_PIN")
-            .ok()
-            .filter(|s| !s.is_empty()),
+        tls_pin_sha256: std::env::var("HONK_HY2_PIN").ok().filter(|s| !s.is_empty()),
         hy2_init_stream_recv_window: std::env::var("HONK_HY2_STREAM_RWND")
             .ok()
             .and_then(|v| v.parse().ok()),

--- a/crates/honk-outbound/src/quic.rs
+++ b/crates/honk-outbound/src/quic.rs
@@ -17,22 +17,24 @@
 //!   [`SendStream`]/[`RecvStream`] so it can be boxed into a
 //!   [`crate::proxy::ProxyStream`].
 
-use std::io;
+use std::io::{self, IoSliceMut};
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU16, Ordering};
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context as _, anyhow};
 use quinn::congestion;
 use quinn::{
-    ClientConfig, Connection, Endpoint, EndpointConfig, RecvStream, SendStream, TransportConfig,
-    VarInt,
+    AsyncUdpSocket, ClientConfig, Connection, Endpoint, EndpointConfig, RecvStream, SendStream,
+    TransportConfig, UdpPoller, VarInt,
 };
+use rand::RngExt;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
-use tokio::sync::Mutex;
-use tracing::warn;
+use tokio::sync::{Mutex, oneshot};
+use tracing::{debug, warn};
 
 /// Map a congestion-control name (`cubic` / `new_reno` / `bbr`, as used by
 /// sing-box and dae node configs) to a quinn controller factory.
@@ -211,8 +213,8 @@ pub async fn client_config(
         }
         None => None,
     };
-    let crypto = crate::quic_boring::BoringQuicClientConfig::new(
-        crate::quic_boring::BoringQuicOptions {
+    let crypto =
+        crate::quic_boring::BoringQuicClientConfig::new(crate::quic_boring::BoringQuicOptions {
             alpn_wire,
             skip_cert_verify: node.skip_cert_verify,
             chrome: crate::tls::chrome_mode(),
@@ -221,14 +223,15 @@ pub async fn client_config(
                 .tls_pin_sha256
                 .as_deref()
                 .and_then(crate::tls::parse_pin_sha256),
-        },
-    )?;
+        })?;
     let mut cfg = ClientConfig::new(Arc::new(crypto));
 
     let mut transport = TransportConfig::default();
     transport
         .congestion_controller_factory(
-            options.congestion.unwrap_or_else(|| congestion_factory(None)),
+            options
+                .congestion
+                .unwrap_or_else(|| congestion_factory(None)),
         )
         // Protocols like TUIC deliver inbound UDP packets on server-initiated
         // uni streams (one stream per packet) — allow a generous number
@@ -276,6 +279,26 @@ pub fn marked_udp_socket(ipv6: bool) -> io::Result<std::net::UdpSocket> {
     Ok(socket.into())
 }
 
+/// Wrap a marked UDP socket in Quinn's runtime abstraction.
+///
+/// This is useful for protocols that must layer a custom [`AsyncUdpSocket`]
+/// wrapper over a regular marked socket (such as Hysteria2 port hopping).
+pub fn marked_async_udp_socket(ipv6: bool) -> io::Result<Arc<dyn AsyncUdpSocket>> {
+    let socket = marked_udp_socket(ipv6)?;
+    let runtime = quinn::default_runtime()
+        .ok_or_else(|| io::Error::other("no async runtime available for QUIC"))?;
+    runtime.wrap_udp_socket(socket)
+}
+
+/// Create a client-only endpoint over an already-abstract QUIC UDP socket.
+///
+/// Hysteria2 uses this for salamander obfuscation and port-hopping wrappers.
+pub fn client_endpoint_with_socket(socket: Arc<dyn AsyncUdpSocket>) -> io::Result<Endpoint> {
+    let runtime = quinn::default_runtime()
+        .ok_or_else(|| io::Error::other("no async runtime available for QUIC"))?;
+    Endpoint::new_with_abstract_socket(EndpointConfig::default(), None, socket, runtime)
+}
+
 /// Create a client-only quinn [`Endpoint`] on a marked UDP socket for the
 /// given address family.
 pub fn client_endpoint(ipv6: bool) -> io::Result<Endpoint> {
@@ -285,11 +308,190 @@ pub fn client_endpoint(ipv6: bool) -> io::Result<Endpoint> {
     Endpoint::new(EndpointConfig::default(), None, socket, runtime)
 }
 
+/// Hysteria2 port-hopping parameters.
+///
+/// A port-hopping connection has a stable, internal QUIC peer address while
+/// its UDP wrapper rewrites packets to a randomly selected real server port.
+/// This is important because Quinn intentionally rejects remote-address
+/// migration for clients; responses are normalized back to the stable port.
+#[derive(Debug, Clone)]
+pub struct PortHoppingConfig {
+    ports: Arc<[u16]>,
+    min_interval: Duration,
+    max_interval: Duration,
+}
+
+impl PortHoppingConfig {
+    /// Construct a fixed-interval port-hopping configuration.
+    ///
+    /// Hysteria2 requires two or more target ports and documents a five-second
+    /// lower bound for hop intervals. The official default is 30 seconds.
+    pub fn fixed(mut ports: Vec<u16>, interval: Duration) -> anyhow::Result<Self> {
+        ports.sort_unstable();
+        ports.dedup();
+        if ports.len() < 2 {
+            anyhow::bail!("Hysteria2 port hopping requires at least two distinct ports");
+        }
+        if ports.contains(&0) {
+            anyhow::bail!("Hysteria2 port hopping does not permit port 0");
+        }
+        if interval < Duration::from_secs(5) {
+            anyhow::bail!("Hysteria2 port-hop interval must be at least 5 seconds");
+        }
+        Ok(Self {
+            ports: ports.into(),
+            min_interval: interval,
+            max_interval: interval,
+        })
+    }
+
+    fn next_interval(&self) -> Duration {
+        if self.min_interval == self.max_interval {
+            return self.min_interval;
+        }
+        let min_ms = self.min_interval.as_millis() as u64;
+        let max_ms = self.max_interval.as_millis() as u64;
+        Duration::from_millis(rand::rng().random_range(min_ms..=max_ms))
+    }
+}
+
+/// The currently selected real UDP destination from a Hysteria2 port union.
+#[derive(Debug)]
+struct PortHopper {
+    ports: Arc<[u16]>,
+}
+
+impl PortHopper {
+    fn new(config: &PortHoppingConfig) -> Self {
+        Self {
+            ports: Arc::clone(&config.ports),
+        }
+    }
+
+    fn initial_port(&self) -> u16 {
+        self.ports[rand::rng().random_range(0..self.ports.len())]
+    }
+
+    /// Pick a member different from `current`.
+    fn next_port(&self, current: u16) -> u16 {
+        let Some(old_index) = self.ports.iter().position(|port| *port == current) else {
+            return self.initial_port();
+        };
+        let offset = rand::rng().random_range(1..self.ports.len());
+        let next_index = (old_index + offset) % self.ports.len();
+        self.ports[next_index]
+    }
+}
+
+type PortHopSocketFactory =
+    Arc<dyn Fn(bool) -> io::Result<Arc<dyn AsyncUdpSocket>> + Send + Sync + 'static>;
+
+struct PortHopping {
+    config: PortHoppingConfig,
+    hopper: Arc<PortHopper>,
+    socket_factory: PortHopSocketFactory,
+}
+
+/// An [`AsyncUdpSocket`] wrapper used for Hysteria2 UDP port hopping.
+///
+/// Quinn continues to see the canonical peer port passed to `connect`; this
+/// wrapper changes only the wire destination. Incoming packets have their
+/// source port normalized back to the canonical port, which prevents Quinn's
+/// client-side remote-migration guard from discarding replies after a hop.
+pub struct PortHoppingSocket {
+    inner: Arc<dyn AsyncUdpSocket>,
+    target_port: AtomicU16,
+    canonical_port: u16,
+}
+
+impl PortHoppingSocket {
+    pub fn new(inner: Arc<dyn AsyncUdpSocket>, target_port: u16, canonical_port: u16) -> Self {
+        Self {
+            inner,
+            target_port: AtomicU16::new(target_port),
+            canonical_port,
+        }
+    }
+
+    pub fn target_port(&self) -> u16 {
+        self.target_port.load(Ordering::Acquire)
+    }
+
+    pub fn set_target_port(&self, target_port: u16) {
+        self.target_port.store(target_port, Ordering::Release);
+    }
+}
+
+impl std::fmt::Debug for PortHoppingSocket {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PortHoppingSocket")
+            .field("inner", &self.inner)
+            .field("target_port", &self.target_port())
+            .field("canonical_port", &self.canonical_port)
+            .finish()
+    }
+}
+
+impl AsyncUdpSocket for PortHoppingSocket {
+    fn create_io_poller(self: Arc<Self>) -> Pin<Box<dyn UdpPoller>> {
+        Arc::clone(&self.inner).create_io_poller()
+    }
+
+    fn try_send(&self, transmit: &quinn::udp::Transmit) -> io::Result<()> {
+        let mut destination = transmit.destination;
+        destination.set_port(self.target_port());
+        self.inner.try_send(&quinn::udp::Transmit {
+            destination,
+            ecn: transmit.ecn,
+            contents: transmit.contents,
+            segment_size: transmit.segment_size,
+            src_ip: transmit.src_ip,
+        })
+    }
+
+    fn poll_recv(
+        &self,
+        cx: &mut Context<'_>,
+        bufs: &mut [IoSliceMut<'_>],
+        meta: &mut [quinn::udp::RecvMeta],
+    ) -> Poll<io::Result<usize>> {
+        match self.inner.poll_recv(cx, bufs, meta) {
+            Poll::Ready(Ok(count)) => {
+                for item in meta.iter_mut().take(count) {
+                    item.addr.set_port(self.canonical_port);
+                }
+                Poll::Ready(Ok(count))
+            }
+            other => other,
+        }
+    }
+
+    fn local_addr(&self) -> io::Result<SocketAddr> {
+        self.inner.local_addr()
+    }
+
+    fn max_transmit_segments(&self) -> usize {
+        self.inner.max_transmit_segments()
+    }
+
+    fn max_receive_segments(&self) -> usize {
+        self.inner.max_receive_segments()
+    }
+
+    fn may_fragment(&self) -> bool {
+        self.inner.may_fragment()
+    }
+}
+
 struct State<C> {
     /// Lazily created endpoint, tagged with its address family. Recreated when
     /// the family of the resolved server address changes.
     endpoint: Option<(bool, Endpoint)>,
+    /// Port-rewriting wrapper owned by the cached endpoint.
+    port_hop_socket: Option<Arc<PortHoppingSocket>>,
     conn: Option<(Connection, Arc<C>)>,
+    /// Stops the port-hop task associated with the cached connection.
+    port_hop_stop: Option<oneshot::Sender<()>>,
 }
 
 /// Per-server QUIC connection holder.
@@ -310,6 +512,8 @@ pub struct QuicClient<C> {
     /// run QUIC over a salamander-obfuscated socket; when unset the plain
     /// marked socket from [`client_endpoint`] is used.
     endpoint_factory: Option<Arc<dyn Fn(bool) -> io::Result<Endpoint> + Send + Sync>>,
+    /// Optional Hysteria2 UDP port-hopping transport.
+    port_hopping: Option<PortHopping>,
     state: Mutex<State<C>>,
 }
 
@@ -326,9 +530,12 @@ impl<C> QuicClient<C> {
             server_name: server_name.into(),
             config,
             endpoint_factory: None,
+            port_hopping: None,
             state: Mutex::new(State {
                 endpoint: None,
+                port_hop_socket: None,
                 conn: None,
+                port_hop_stop: None,
             }),
         }
     }
@@ -342,6 +549,31 @@ impl<C> QuicClient<C> {
     ) -> Self {
         self.endpoint_factory = Some(Arc::new(factory));
         self
+    }
+
+    /// Enable Hysteria2 UDP port hopping for this client.
+    ///
+    /// The factory builds the marked, optionally obfuscated UDP socket once.
+    /// Hopping only updates the surrounding [`PortHoppingSocket`]'s target
+    /// port; the endpoint and underlying socket remain unchanged.
+    pub fn with_port_hopping(
+        mut self,
+        config: PortHoppingConfig,
+        socket_factory: impl Fn(bool) -> io::Result<Arc<dyn AsyncUdpSocket>> + Send + Sync + 'static,
+    ) -> Self {
+        self.endpoint_factory = None;
+        self.port_hopping = Some(PortHopping {
+            hopper: Arc::new(PortHopper::new(&config)),
+            config,
+            socket_factory: Arc::new(socket_factory),
+        });
+        self
+    }
+
+    fn stop_port_hop_task(state: &mut State<C>) {
+        if let Some(stop) = state.port_hop_stop.take() {
+            let _ = stop.send(());
+        }
     }
 
     /// Return the shared connection (plus its protocol state), dialing and
@@ -365,6 +597,7 @@ impl<C> QuicClient<C> {
             return Ok((conn.clone(), Arc::clone(ctx)));
         }
         state.conn = None;
+        Self::stop_port_hop_task(&mut state);
 
         let host = format!("{}:{}", self.server_host, self.server_port);
         let addrs: Vec<SocketAddr> = crate::bootstrap::resolve(&self.server_host)
@@ -384,12 +617,28 @@ impl<C> QuicClient<C> {
             let endpoint = match &state.endpoint {
                 Some((family, ep)) if *family == ipv6 => ep.clone(),
                 _ => {
-                    let ep = match &self.endpoint_factory {
-                        Some(factory) => factory(ipv6),
-                        None => client_endpoint(ipv6),
-                    }
-                    .with_context(|| format!("create QUIC endpoint (ipv6={ipv6})"))?;
+                    let (ep, port_hop_socket) = if let Some(hopping) = &self.port_hopping {
+                        let target_port = hopping.hopper.initial_port();
+                        let inner = (hopping.socket_factory)(ipv6).with_context(|| {
+                            format!(
+                                "create Hysteria2 port-hop socket (ipv6={ipv6}, target_port={target_port})"
+                            )
+                        })?;
+                        let socket =
+                            Arc::new(PortHoppingSocket::new(inner, target_port, self.server_port));
+                        (client_endpoint_with_socket(socket.clone()), Some(socket))
+                    } else {
+                        (
+                            match &self.endpoint_factory {
+                                Some(factory) => factory(ipv6),
+                                None => client_endpoint(ipv6),
+                            },
+                            None,
+                        )
+                    };
+                    let ep = ep.with_context(|| format!("create QUIC endpoint (ipv6={ipv6})"))?;
                     state.endpoint = Some((ipv6, ep.clone()));
+                    state.port_hop_socket = port_hop_socket;
                     ep
                 }
             };
@@ -438,6 +687,16 @@ impl<C> QuicClient<C> {
         })?;
         let ctx = Arc::new(ctx);
         state.conn = Some((conn.clone(), Arc::clone(&ctx)));
+        if let Some(hopping) = &self.port_hopping {
+            let socket = state
+                .port_hop_socket
+                .as_ref()
+                .cloned()
+                .expect("port-hop socket is present after a successful connection");
+            let (stop, stop_rx) = oneshot::channel();
+            spawn_port_hop_task(socket, conn.clone(), hopping, stop_rx);
+            state.port_hop_stop = Some(stop);
+        }
         Ok((conn, ctx))
     }
 
@@ -450,7 +709,155 @@ impl<C> QuicClient<C> {
             && cached.stable_id() == conn.stable_id()
         {
             state.conn = None;
+            Self::stop_port_hop_task(&mut state);
         }
+    }
+}
+
+/// Drive a Hysteria2 QUIC port-hopping transport until its connection is
+/// closed or the owning [`QuicClient`] invalidates it.
+fn spawn_port_hop_task(
+    socket: Arc<PortHoppingSocket>,
+    conn: Connection,
+    hopping: &PortHopping,
+    stop_rx: oneshot::Receiver<()>,
+) {
+    let config = hopping.config.clone();
+    let hopper = Arc::clone(&hopping.hopper);
+    tokio::spawn(async move {
+        let mut stop_rx = stop_rx;
+        loop {
+            tokio::select! {
+                _ = tokio::time::sleep(config.next_interval()) => {}
+                _ = &mut stop_rx => return,
+                _ = conn.closed() => return,
+            }
+
+            let old_port = socket.target_port();
+            let target_port = hopper.next_port(old_port);
+            socket.set_target_port(target_port);
+            debug!(
+                old_port,
+                target_port, "Hysteria2 QUIC connection switched to a new target port"
+            );
+        }
+    });
+}
+
+#[cfg(test)]
+mod port_hopping_tests {
+    use std::future::poll_fn;
+    use std::net::{IpAddr, Ipv4Addr};
+
+    use super::*;
+
+    #[test]
+    fn port_hopper_always_selects_a_different_member() {
+        let config = PortHoppingConfig::fixed(vec![8443, 443, 10000], Duration::from_secs(5))
+            .expect("valid hop configuration");
+        let hopper = PortHopper::new(&config);
+        let mut current = hopper.initial_port();
+        for _ in 0..20 {
+            let new = hopper.next_port(current);
+            assert_ne!(current, new);
+            assert!(matches!(new, 443 | 8443 | 10000));
+            current = new;
+        }
+    }
+
+    #[tokio::test]
+    async fn port_hopping_socket_updates_target_without_rebinding() {
+        let first_peer = tokio::net::UdpSocket::bind((Ipv4Addr::LOCALHOST, 0))
+            .await
+            .expect("bind first peer");
+        let second_peer = tokio::net::UdpSocket::bind((Ipv4Addr::LOCALHOST, 0))
+            .await
+            .expect("bind second peer");
+        let raw = std::net::UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).expect("bind client");
+        raw.set_nonblocking(true).expect("make client nonblocking");
+        let runtime = quinn::default_runtime().expect("Tokio QUIC runtime");
+        let inner = runtime.wrap_udp_socket(raw).expect("wrap client socket");
+
+        let canonical_port = 443;
+        let socket = Arc::new(PortHoppingSocket::new(
+            inner,
+            first_peer.local_addr().expect("first peer address").port(),
+            canonical_port,
+        ));
+        let transmit = quinn::udp::Transmit {
+            destination: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), canonical_port),
+            ecn: None,
+            contents: b"outbound",
+            segment_size: None,
+            src_ip: None,
+        };
+        let mut poller = Arc::clone(&socket).create_io_poller();
+        loop {
+            match socket.try_send(&transmit) {
+                Ok(()) => break,
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                    poll_fn(|cx| poller.as_mut().poll_writable(cx))
+                        .await
+                        .expect("wait for client socket write readiness");
+                }
+                Err(e) => panic!("send rewritten packet: {e}"),
+            }
+        }
+
+        let mut outbound = [0u8; 64];
+        let (n, client_addr) = first_peer
+            .recv_from(&mut outbound)
+            .await
+            .expect("receive rewritten packet");
+        assert_eq!(&outbound[..n], b"outbound");
+        assert_eq!(client_addr, socket.local_addr().expect("client address"));
+
+        socket.set_target_port(
+            second_peer
+                .local_addr()
+                .expect("second peer address")
+                .port(),
+        );
+        let hopped = quinn::udp::Transmit {
+            contents: b"hopped",
+            ..transmit
+        };
+        loop {
+            match socket.try_send(&hopped) {
+                Ok(()) => break,
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                    poll_fn(|cx| poller.as_mut().poll_writable(cx))
+                        .await
+                        .expect("wait for client socket write readiness");
+                }
+                Err(e) => panic!("send packet after target-port update: {e}"),
+            }
+        }
+        let (n, hopped_client_addr) = second_peer
+            .recv_from(&mut outbound)
+            .await
+            .expect("receive packet after target-port update");
+        assert_eq!(&outbound[..n], b"hopped");
+        assert_eq!(hopped_client_addr, client_addr);
+        assert_eq!(socket.local_addr().expect("client address"), client_addr);
+
+        second_peer
+            .send_to(b"inbound", client_addr)
+            .await
+            .expect("send reply");
+        let mut inbound = [0u8; 64];
+        let mut bufs = [IoSliceMut::new(&mut inbound)];
+        let mut meta = [quinn::udp::RecvMeta::default()];
+        let count = poll_fn(|cx| socket.poll_recv(cx, &mut bufs, &mut meta))
+            .await
+            .expect("receive normalized packet");
+        let len = meta[0].len;
+        let addr = meta[0].addr;
+        drop(bufs);
+        assert_eq!(count, 1);
+        assert_eq!(&inbound[..len], b"inbound");
+        assert_eq!(addr.ip(), IpAddr::V4(Ipv4Addr::LOCALHOST));
+        assert_eq!(addr.port(), canonical_port);
     }
 }
 

--- a/crates/honk-outbound/src/quic_boring.rs
+++ b/crates/honk-outbound/src/quic_boring.rs
@@ -899,8 +899,7 @@ mod tests {
     async fn pin_sha256_accepts_matching_cert_and_rejects_others() {
         let (config, cert_der) =
             crate::quic::testutil::server_config_with_cert(&[b"h3"], true).unwrap();
-        let endpoint =
-            quinn::Endpoint::server(config, "127.0.0.1:0".parse().unwrap()).unwrap();
+        let endpoint = quinn::Endpoint::server(config, "127.0.0.1:0".parse().unwrap()).unwrap();
         let addr = endpoint.local_addr().unwrap();
         tokio::spawn(async move {
             while let Some(incoming) = endpoint.accept().await {
@@ -1084,15 +1083,14 @@ mod tests {
             crypto::ClientConfig::start_session(Arc::new(rustls_crypto), 1, "localhost", &params)
                 .unwrap();
 
-        let my_cfg =
-            Arc::new(
-                BoringQuicClientConfig::new(BoringQuicOptions {
-                    alpn_wire: b"\x02h3".to_vec(),
-                    skip_cert_verify: true,
-                    ..Default::default()
-                })
-                .unwrap(),
-            );
+        let my_cfg = Arc::new(
+            BoringQuicClientConfig::new(BoringQuicOptions {
+                alpn_wire: b"\x02h3".to_vec(),
+                skip_cert_verify: true,
+                ..Default::default()
+            })
+            .unwrap(),
+        );
         let my_session =
             crypto::ClientConfig::start_session(my_cfg, 1, "localhost", &params).unwrap();
 

--- a/crates/honk-outbound/src/tls.rs
+++ b/crates/honk-outbound/src/tls.rs
@@ -333,7 +333,10 @@ fn base_builder(skip_cert_verify: bool) -> anyhow::Result<boring::ssl::SslConnec
 
 /// Parse a `pinSHA256` value (hex, optionally colon-separated) into 32 bytes.
 pub fn parse_pin_sha256(s: &str) -> Option<[u8; 32]> {
-    let hex: String = s.chars().filter(|c| *c != ':' && !c.is_whitespace()).collect();
+    let hex: String = s
+        .chars()
+        .filter(|c| *c != ':' && !c.is_whitespace())
+        .collect();
     if hex.len() != 64 {
         return None;
     }
@@ -378,10 +381,7 @@ pub fn build_connector(node: &Node) -> anyhow::Result<TlsConnector> {
     let chrome = chrome_mode();
     let ech_config_list = load_ech_config_list(node)?;
 
-    let pin = node
-        .tls_pin_sha256
-        .as_deref()
-        .and_then(parse_pin_sha256);
+    let pin = node.tls_pin_sha256.as_deref().and_then(parse_pin_sha256);
     let mut builder = base_builder(node.skip_cert_verify || pin.is_some())?;
     if let Some(pin) = pin {
         builder.set_custom_verify_callback(SslVerifyMode::PEER, pin_sha256_custom_verify(pin));

--- a/doc/components.en.md
+++ b/doc/components.en.md
@@ -117,6 +117,7 @@ The fields below are what a parsed node carries. In dae syntax they are **derive
 | `ws_path` / `ws_host` | string? | null | WebSocket (share-link `path=`/`host=`) |
 | `grpc_service` | string? | null | gRPC service name (`serviceName=`) |
 | `hy2_auth` / `hy2_obfs` | string? | null | Hysteria2 auth / salamander obfs password |
+| `hy2_port_ranges` | `PortRange[]` | `[]` | Port-hop union parsed from `host:port,port-start-end` |
 | `hy2_up_mbps` / `hy2_down_mbps` | u32? | null | Hysteria2 brutal bandwidth (`upmbps`/`downmbps`) |
 | `hy2_port_hopping` / `hy2_hop_interval` | string? / u64? | null | Hysteria2 port hopping (`mport`/`mhop`) |
 | `hy2_init_stream_recv_window` / `hy2_init_conn_recv_window` | u64? | null | Hysteria2 QUIC receive windows |
@@ -148,7 +149,7 @@ The fields below are what a parsed node carries. In dae syntax they are **derive
 | `vless` | | Yes | No | Header UDP exists in tests only |
 | `socks5` | | Yes | Yes | UDP ASSOCIATE |
 | `http` | | Yes* | — | Mapped through direct-style dial |
-| `hysteria2` | | Yes | Yes | Real QUIC/H3; salamander; brutal (with bandwidth) or BBR; port hopping |
+| `hysteria2` | `hy2`, `hysteria` | Yes | Yes | Real QUIC/H3; salamander; brutal (with bandwidth) or BBR; port hopping |
 | `tuic` | | Yes | Yes | TUIC v5 / quinn |
 | `juicity` | | Yes | Yes | quinn bi-stream UDP |
 | `anytls` | | Yes | Yes | Session pool + UoT v2 |
@@ -174,6 +175,24 @@ node {
 ```
 
 `mux = true` (h2mux) exists in the node schema but cannot be expressed in dae syntax today.
+
+**Hysteria2 port hopping**
+
+Hysteria2 share links accept the upstream multi-port authority syntax. Use an
+individual port, a range, or a comma-separated union:
+
+```dae
+node {
+    hy2_hop: 'hy2://secret@example.com:443,8443,40000-50000/?sni=example.com&obfs=salamander&obfs-password=obfs#hy2_hop'
+}
+```
+
+For two or more distinct ports, honk chooses an initial port at random, then
+every 30 seconds updates the existing UDP socket's wire target port. The local
+socket and QUIC endpoint remain unchanged. Replies are normalized internally so
+the QUIC connection remains continuous. All listed ports must reach the same
+Hysteria2 server and credentials; a single port keeps the ordinary non-hopping
+behavior.
 
 ### TLS fingerprint and ECH
 

--- a/doc/components.zh.md
+++ b/doc/components.zh.md
@@ -87,6 +87,7 @@ dae 语法中节点**只能以分享链接书写**：`tag: 'scheme://...'` 或�
 | `ws_path` / `ws_host` | string? | null | WebSocket；链接 `path` / `host` 参数 |
 | `grpc_service` | string? | null | gRPC service 名；链接 `serviceName` 参数 |
 | `hy2_auth` / `hy2_obfs` | string? | null | Hysteria2 认证 / salamander 混淆密码 |
+| `hy2_port_ranges` | `PortRange[]` | `[]` | 从 `host:端口,端口-端口` 解析出的端口跳跃集合 |
 | `hy2_up_mbps` / `hy2_down_mbps` | u32? | null | Hysteria2 brutal 带宽（`upmbps`/`downmbps`） |
 | `hy2_port_hopping` / `hy2_hop_interval` | string? / u64? | null | Hysteria2 端口跳跃（`mport`/`mhop`） |
 | `hy2_init_stream_recv_window` / `hy2_init_conn_recv_window` | u64? | null | Hysteria2 QUIC 接收窗口 |
@@ -118,7 +119,7 @@ dae 语法中节点**只能以分享链接书写**：`tag: 'scheme://...'` 或�
 | `vless` | | 是 | 否 | 头里的 UDP 仅测试存在 |
 | `socks5` | | 是 | 是 | UDP ASSOCIATE |
 | `http` | | 是* | — | 走类似 direct 的拨号 |
-| `hysteria2` | | 是 | 是 | 真实 QUIC/H3；salamander；brutal（配带宽时）或 BBR；端口跳跃 |
+| `hysteria2` | `hy2`, `hysteria` | 是 | 是 | 真实 QUIC/H3；salamander；brutal（配带宽时）或 BBR；端口跳跃 |
 | `tuic` | | 是 | 是 | TUIC v5 / quinn |
 | `juicity` | | 是 | 是 | quinn 双向流 UDP |
 | `anytls` | | 是 | 是 | 会话池 + UoT v2 |
@@ -181,6 +182,18 @@ node {
     hy2: 'hysteria2://secret@example.com:443?sni=example.com&insecure=1&obfs=salamander&obfs-password=obfspw&upmbps=50&downmbps=200&mport=20000-30000&mhop=30#hy2'
 }
 ```
+
+**Hysteria2 端口跳跃**
+
+Hy2 分享链接支持上游的多端口 authority 语法：单端口、端口范围，或逗号分隔的并集均可。
+
+```dae
+node {
+    hy2_hop: 'hy2://secret@example.com:443,8443,40000-50000/?sni=example.com&obfs=salamander&obfs-password=obfs#hy2_hop'
+}
+```
+
+当集合中至少有两个不同端口时，honk 会随机选择初始端口，之后每 30 秒只更新现有 UDP socket 的实际目标端口；本地 socket 和 QUIC endpoint 均保持不变。入站回复会在内部归一化，连接不会因服务端端口变化而中断。列出的全部端口必须指向同一台 Hysteria2 服务端并使用相同凭据；只有一个端口时保持普通的非跳跃行为。
 
 ### 分享链接 scheme
 

--- a/doc/configuration.en.md
+++ b/doc/configuration.en.md
@@ -177,9 +177,11 @@ node {
 }
 ```
 
-Supported schemes (parser): `ss://`, `ssr://`, `socks5://`, `trojan://`, `trojan-go://`, `vmess://`, `vless://`, `hysteria2://`, `tuic://`, `juicity://`, `anytls://`, `http://`, `https://`.
+Supported schemes (parser): `ss://`, `ssr://`, `socks5://`, `trojan://`, `trojan-go://`, `vmess://`, `vless://`, `hysteria2://` / `hy2://`, `tuic://`, `juicity://`, `anytls://`, `http://`, `https://`.
 
 Node parameters (credentials, `sni`, transport/ws/grpc options, `mux`, protocol-specific Hy2/TUIC/Juicity/AnyTLS options) are carried by the share link's userinfo/host/query components — the same fields the `Node` model exposes (`name`, `protocol`, `address`/`host`, `port`, `password`/`username`, `encryption`, `tls`, `sni`, `transport`, `ws_path`, `ws_host`, `grpc_service`, `mux`, ...). An explicit `tag:` prefix overrides the name embedded in the link.
+
+For Hysteria2, the authority may carry a port-hop union such as `:443,8443,40000-50000`; honk preserves the union and enables QUIC port hopping when it contains at least two ports. See [components.en.md](./components.en.md#protocol-specific-tips) for its 30-second hop behavior.
 
 See [components.en.md](./components.en.md) for the full field table and protocol notes (including UDP support matrix).
 

--- a/doc/configuration.zh.md
+++ b/doc/configuration.zh.md
@@ -154,9 +154,11 @@ experimental {
 
 节点在 `node { }` 中以**分享链接**声明，格式为 `tag: 'scheme://...'`（tag 即节点名）。
 
-解析支持的 scheme：`ss://`、`ssr://`、`socks5://`、`trojan://`、`trojan-go://`、`vmess://`、`vless://`、`hysteria2://`、`tuic://`、`juicity://`、`anytls://`、`http://`、`https://`。
+解析支持的 scheme：`ss://`、`ssr://`、`socks5://`、`trojan://`、`trojan-go://`、`vmess://`、`vless://`、`hysteria2://` / `hy2://`、`tuic://`、`juicity://`、`anytls://`、`http://`、`https://`。
 
 分享链接中的参数会映射到 `Node` 字段：`name`、`protocol`、`address`/`host`、`port`、`password`/`username`、`encryption`、`tls`、`sni`、`transport`、`ws_path`、`ws_host`、`grpc_service`、`mux`，以及 Hy2/TUIC/Juicity/AnyTLS 专用字段。
+
+Hysteria2 的 authority 可携带端口跳跃并集，例如 `:443,8443,40000-50000`；honk 会保留该集合，并在其中至少有两个端口时启用 QUIC 端口跳跃。30 秒的切换行为见 [components.zh.md](./components.zh.md#协议提示)。
 
 完整字段表与协议注意点（含 UDP 支持矩阵）见 [components.zh.md](./components.zh.md)。
 


### PR DESCRIPTION
## Summary

- Parse Hysteria2 multi-port share-link authorities such as `hy2://…:443,8443,40000-50000`.
- Keep the QUIC connection alive while switching to a marked UDP socket on a new HY2 port every 30 seconds.
- Add parser and transport coverage, plus English and Chinese documentation.

## Why

`url::Url` rejects Hysteria2's multi-port authority syntax, and a QUIC client needs peer-port normalization while migrating sockets. Without both pieces, HY2 port-hopping links cannot be used reliably.

## Validation

- `cargo test -q -p honk-config share_link --lib`
- `cargo test -q -p honk-outbound hysteria2 --lib`
- `cargo test -q -p honk-outbound port_hopping --lib`
- `cargo check -q -p honk-core --features ebpf`
- End-to-end HY2 test: `curl https://ip.sb` succeeded before and after two live port migrations.
