### PR TITLE
fix(ebpf): hold cgroup/TC link lifetimes; bound post-detach shutdown

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,7 +249,7 @@ cargo +nightly build --release -Zbuild-std=core --target bpfel-unknown-none
 | -------- | --------- |
 | `build` / `check` / `lint` / `fmt` | `cargo build --release` / `check` / `clippy --all -D warnings` / `fmt --all` |
 | `test` / `test-ci` / `test-core` / `test-config` / `test-ebpf` | Test suites (`test` = full incl. known failures; `test-ci` = CI gate with the 3 known failures skipped; `test-ebpf` = honk-ebpf-common only) |
-| `test-netns` | Root-gated netlink/netns roundtrip tests (`--features ebpf --ignored`: veth/addr/route/fwmark-rule/neigh against the real kernel) |
+| `test-netns` | Root-gated real-kernel tests (`--features ebpf --ignored`): netlink/netns roundtrips (veth/addr/route/fwmark-rule/neigh) plus the `link_lifecycle` regression test asserting every TC+cgroup link stays held until `detach_hooks` |
 | `outbound-ci` / `outbound-ci-e2e` | honk-outbound gate (`ci/outbound-ci.sh`: fmt + clippy + honk-config & honk-outbound suites; `...-e2e` adds live hy2 e2e via `HONK_HY2_SERVER=`) — run after every outbound change |
 | `dns-ci` | DNS subsystem gate (`ci/dns-ci.sh`: fmt + clippy + honk-config + honk-core dns/control + honk-outbound suites) — run after every DNS-path change |
 | `build-core` / `build-core-ebpf` | honk-core with `ebpf` feature |

--- a/Justfile
+++ b/Justfile
@@ -93,6 +93,7 @@ test-ebpf:
 # Root-gated netlink/netns integration tests (veth/route/rule roundtrip)
 test-netns:
     cargo test -p honk-core --features ebpf --lib netns -- --ignored --test-threads=1
+    cargo test -p honk-core --features ebpf --lib link_lifecycle -- --ignored --test-threads=1
 
 # Full honk-outbound gate after outbound changes (fmt + clippy + config & outbound suites)
 outbound-ci:

--- a/crates/honk-core/src/control/dns_control.rs
+++ b/crates/honk-core/src/control/dns_control.rs
@@ -20,8 +20,9 @@ use crate::group::GroupManager;
 use crate::routing::Router;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::{RwLock, Semaphore};
-use tracing::debug;
+use tracing::{debug, warn};
 
 mod transport;
 
@@ -150,9 +151,21 @@ impl DnsController {
         self.dns_service.clone()
     }
 
-    pub(crate) async fn shutdown(&self) {
-        self.routing_projection.shutdown().await;
-        self.runtime_provider().shutdown().await;
+    pub(crate) async fn shutdown(&self, timeout: Duration) {
+        self.routing_projection.shutdown(timeout).await;
+        // The provider retires runtimes through a JoinSet of supervisors,
+        // and a dropped JoinSet aborts its tasks — a timeout here cannot
+        // leave a detached worker behind.
+        let provider = self.runtime_provider();
+        if tokio::time::timeout(timeout, provider.shutdown())
+            .await
+            .is_err()
+        {
+            warn!(
+                "DNS runtime provider shutdown exceeded {:?}; continuing",
+                timeout
+            );
+        }
     }
 
     pub(crate) fn update_projection_snapshot(

--- a/crates/honk-core/src/control/mod.rs
+++ b/crates/honk-core/src/control/mod.rs
@@ -55,6 +55,12 @@ use tokio::net::{TcpListener, TcpStream, UdpSocket};
 use tokio::sync::{RwLock, mpsc};
 use tracing::{debug, error, info, trace, warn};
 
+/// Bound for shutdown stages that have no natural deadline (watcher join,
+/// runtime-generation retirement, DNS controller/persistence close). The
+/// datapath hooks are already detached by then, so a hung stage must time
+/// out and log rather than leave the process half-torn-down forever.
+const SHUTDOWN_STAGE_TIMEOUT: Duration = Duration::from_secs(10);
+
 pub mod commands {
     use honk_config::{Config, node::Node};
     use tokio::sync::mpsc;
@@ -1105,7 +1111,6 @@ impl ControlPlane {
 
         let mut rx = self.command_rx.take().expect("command_rx already taken");
         let drain = self.drain_tracker.clone();
-        let ebpf = self.ebpf.clone();
 
         let mut heartbeat = tokio::time::interval(std::time::Duration::from_secs(5));
         heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -1239,48 +1244,7 @@ impl ControlPlane {
                             let _ = tx.send(StatsSnapshot { per_outbound: snap, total_connections: total }).await;
                         }
                         Some(ControlCommand::Shutdown) | None => {
-                            info!("Control plane shutting down, draining {} active connections",
-                                drain.active_count());
-                            if let Err(error) = ebpf.write().await.set_datapath_ready(false) {
-                                warn!(%error, "failed to close eBPF datapath admission");
-                            }
-                            drain.start_rejecting();
-                            self.stop_udp_warm_coordinator().await;
-                            if !self.udp_pool.shutdown().await {
-                                error!("UDP endpoint shutdown required forced cleanup");
-                            }
-                            // Keep the removal consumer alive until terminal endpoint cleanup has
-                            // emitted and drained every conn-state/tracker retirement.
-                            if let Err(error) = (&mut udp_removal_task).await {
-                                warn!("UDP removal consumer failed during shutdown: {}", error);
-                            }
-                            // Abort remaining background tasks (health check, janitors, preconnect)
-                            // only after UDP drivers and their removal sink have drained.
-                            {
-                                let mut tasks = self.background_tasks.lock().await;
-                                for handle in tasks.drain(..) {
-                                    handle.abort();
-                                }
-                            }
-                            // Stop the interface watcher first: it shares the
-                            // backend and could re-attach hooks mid-drain.
-                            #[cfg(feature = "ebpf")]
-                            if let Some(watcher) = self.iface_watcher.take() {
-                                watcher.shutdown().await;
-                            }
-                            // Detach BPF hooks immediately to restore network connectivity
-                            // before draining connections (matches Go dae behaviour).
-                            let mut ebpf = ebpf.write().await;
-                            if let Err(e) = ebpf.detach_hooks() {
-                                warn!("Failed to detach BPF hooks: {}", e);
-                            }
-                            drop(ebpf);
-                            drain.drain().await?;
-                            // Active flows own the current runtime until the
-                            // drain completes; only then terminally close its
-                            // AnyTLS pools and reject any late warm work.
-                            let generation = self.runtime_registry.read().clone();
-                            generation.shutdown().await;
+                            self.shutdown_datapath(&drain, &mut udp_removal_task).await?;
                             break;
                         }
                     }
@@ -1288,15 +1252,113 @@ impl ControlPlane {
             }
         }
 
-        self.dns_controller.shutdown().await;
+        self.finalize_shutdown().await
+    }
+
+    /// Datapath half of shutdown: close admission, stop background work,
+    /// detach the eBPF hooks (network restored before the connection drain,
+    /// Go dae behaviour), then drain flows and retire the outbound runtime
+    /// generation.  Every await without a natural deadline is bounded —
+    /// with the hooks already detached, a hung stage would otherwise leave
+    /// the engine half-torn-down forever: links gone, process alive.
+    async fn shutdown_datapath(
+        &mut self,
+        drain: &Arc<DrainTracker>,
+        udp_removal_task: &mut tokio::task::JoinHandle<()>,
+    ) -> anyhow::Result<()> {
+        info!(
+            "Control plane shutting down, draining {} active connections",
+            drain.active_count()
+        );
+        if let Err(error) = self.ebpf.write().await.set_datapath_ready(false) {
+            warn!(%error, "failed to close eBPF datapath admission");
+        }
+        drain.start_rejecting();
+        self.stop_udp_warm_coordinator().await;
+        if !self.udp_pool.shutdown().await {
+            error!("UDP endpoint shutdown required forced cleanup");
+        }
+        // Keep the removal consumer alive until terminal endpoint cleanup has
+        // emitted and drained every conn-state/tracker retirement.
+        if let Err(error) = (&mut *udp_removal_task).await {
+            warn!("UDP removal consumer failed during shutdown: {}", error);
+        }
+        // Abort remaining background tasks (health check, janitors, preconnect)
+        // only after UDP drivers and their removal sink have drained.
+        {
+            let mut tasks = self.background_tasks.lock().await;
+            for handle in tasks.drain(..) {
+                handle.abort();
+            }
+        }
+        // Stop the interface watcher first: it shares the backend and could
+        // re-attach hooks mid-drain.
+        #[cfg(feature = "ebpf")]
+        if let Some(watcher) = self.iface_watcher.take()
+            && tokio::time::timeout(SHUTDOWN_STAGE_TIMEOUT, watcher.shutdown())
+                .await
+                .is_err()
+        {
+            warn!(
+                "interface watcher shutdown exceeded {:?}; continuing",
+                SHUTDOWN_STAGE_TIMEOUT
+            );
+        }
+        // Detach BPF hooks immediately to restore network connectivity
+        // before draining connections (matches Go dae behaviour).
+        info!("shutdown: detaching eBPF hooks");
+        {
+            let mut ebpf = self.ebpf.write().await;
+            if let Err(e) = ebpf.detach_hooks() {
+                warn!("Failed to detach BPF hooks: {}", e);
+            }
+        }
+        info!("shutdown: draining connections");
+        drain.drain().await?;
+        // Active flows own the current runtime until the drain completes; only
+        // then terminally close its AnyTLS pools and reject any late warm work.
+        let generation = self.runtime_registry.read().clone();
+        info!("shutdown: retiring outbound runtime generation");
+        if tokio::time::timeout(SHUTDOWN_STAGE_TIMEOUT, generation.shutdown())
+            .await
+            .is_err()
+        {
+            warn!(
+                "outbound runtime generation shutdown exceeded {:?}; continuing",
+                SHUTDOWN_STAGE_TIMEOUT
+            );
+        }
+        Ok(())
+    }
+
+    /// Userspace half of shutdown: DNS controller, DNS persistence, and the
+    /// eBPF backend cleanup.  Bounded like `shutdown_datapath` so a stuck
+    /// DNS transport cannot pin the process after the datapath is down.
+    async fn finalize_shutdown(&mut self) -> anyhow::Result<()> {
+        info!("shutdown: stopping DNS controller");
+        if tokio::time::timeout(SHUTDOWN_STAGE_TIMEOUT, self.dns_controller.shutdown())
+            .await
+            .is_err()
+        {
+            warn!(
+                "DNS controller shutdown exceeded {:?}; continuing",
+                SHUTDOWN_STAGE_TIMEOUT
+            );
+        }
         let dns_cache = self.dns_controller.cache().await;
         let persistence = dns_cache.lock().await.persistence();
-        if let Some(persistence) = persistence
-            && let Err(error) = persistence.shutdown().await
-        {
-            warn!(%error, "DNS persistence shutdown failed");
+        if let Some(persistence) = persistence {
+            match tokio::time::timeout(SHUTDOWN_STAGE_TIMEOUT, persistence.shutdown()).await {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => warn!(%error, "DNS persistence shutdown failed"),
+                Err(_) => warn!(
+                    "DNS persistence shutdown exceeded {:?}; continuing",
+                    SHUTDOWN_STAGE_TIMEOUT
+                ),
+            }
         }
-        ebpf.write().await.cleanup().await?;
+        info!("shutdown: cleaning up eBPF backend");
+        self.ebpf.write().await.cleanup().await?;
         info!("Control plane stopped");
         Ok(())
     }

--- a/crates/honk-core/src/control/mod.rs
+++ b/crates/honk-core/src/control/mod.rs
@@ -1292,17 +1292,12 @@ impl ControlPlane {
             }
         }
         // Stop the interface watcher first: it shares the backend and could
-        // re-attach hooks mid-drain.
+        // re-attach hooks mid-drain. The timeout aborts the worker instead
+        // of detaching it (a detached watcher could re-attach hooks after
+        // detach_hooks).
         #[cfg(feature = "ebpf")]
-        if let Some(watcher) = self.iface_watcher.take()
-            && tokio::time::timeout(SHUTDOWN_STAGE_TIMEOUT, watcher.shutdown())
-                .await
-                .is_err()
-        {
-            warn!(
-                "interface watcher shutdown exceeded {:?}; continuing",
-                SHUTDOWN_STAGE_TIMEOUT
-            );
+        if let Some(watcher) = self.iface_watcher.take() {
+            watcher.shutdown(SHUTDOWN_STAGE_TIMEOUT).await;
         }
         // Detach BPF hooks immediately to restore network connectivity
         // before draining connections (matches Go dae behaviour).
@@ -1317,6 +1312,9 @@ impl ControlPlane {
         drain.drain().await?;
         // Active flows own the current runtime until the drain completes; only
         // then terminally close its AnyTLS pools and reject any late warm work.
+        // Dropping this future on timeout detaches nothing: the force-closes
+        // are synchronous once entered and none of the runtimes touch the
+        // eBPF backend.
         let generation = self.runtime_registry.read().clone();
         info!("shutdown: retiring outbound runtime generation");
         if tokio::time::timeout(SHUTDOWN_STAGE_TIMEOUT, generation.shutdown())
@@ -1336,18 +1334,14 @@ impl ControlPlane {
     /// DNS transport cannot pin the process after the datapath is down.
     async fn finalize_shutdown(&mut self) -> anyhow::Result<()> {
         info!("shutdown: stopping DNS controller");
-        if tokio::time::timeout(SHUTDOWN_STAGE_TIMEOUT, self.dns_controller.shutdown())
-            .await
-            .is_err()
-        {
-            warn!(
-                "DNS controller shutdown exceeded {:?}; continuing",
-                SHUTDOWN_STAGE_TIMEOUT
-            );
-        }
+        self.dns_controller.shutdown(SHUTDOWN_STAGE_TIMEOUT).await;
         let dns_cache = self.dns_controller.cache().await;
         let persistence = dns_cache.lock().await.persistence();
         if let Some(persistence) = persistence {
+            // The worker is a std thread that cannot be aborted, but the
+            // Shutdown command is queued before the join starts, and the
+            // spawn_blocking join keeps owning the thread handle even if
+            // this future is dropped on timeout — no detached writer.
             match tokio::time::timeout(SHUTDOWN_STAGE_TIMEOUT, persistence.shutdown()).await {
                 Ok(Ok(())) => {}
                 Ok(Err(error)) => warn!(%error, "DNS persistence shutdown failed"),

--- a/crates/honk-core/src/control/tests.rs
+++ b/crates/honk-core/src/control/tests.rs
@@ -3290,3 +3290,68 @@ fn probe_warm_runtime_reuses_only_warm_or_stateless_nodes() {
         "a session-less protocol has nothing to retain; reuse the generation runtime"
     );
 }
+
+fn link_lifecycle_cp(backend: crate::ebpf::mock::MockEbpfBackend) -> ControlPlane {
+    ControlPlane::new(
+        Config::default(),
+        Box::new(backend),
+        Router::new(&[], "direct").unwrap(),
+        Arc::new(ProxyRegistry::default_resolver().unwrap()),
+        DnsResolver::new(&honk_config::dns::DnsConfig::default()).unwrap(),
+        udp_test_forwarder(),
+    )
+    .unwrap()
+}
+
+/// Reload and subscription merge share `apply_runtime_config`, which only
+/// rewrites maps through the live backend — datapath hooks must never be
+/// detached or re-attached outside shutdown.
+#[tokio::test]
+async fn reload_and_merge_never_touch_ebpf_hooks() {
+    use std::sync::atomic::Ordering;
+    let backend = crate::ebpf::mock::MockEbpfBackend::new();
+    let detach = backend.detach_calls.clone();
+    let dyn_attach = backend.dynamic_attach_calls.clone();
+    let dyn_forget = backend.dynamic_forget_calls.clone();
+    let cp = link_lifecycle_cp(backend);
+
+    let drain = DrainTracker::new();
+    assert!(cp.apply_runtime_config(Config::default(), &drain).await);
+    assert!(cp.apply_runtime_config(Config::default(), &drain).await);
+
+    assert_eq!(
+        detach.load(Ordering::Relaxed),
+        0,
+        "reload/merge must never detach datapath hooks"
+    );
+    assert_eq!(dyn_attach.load(Ordering::Relaxed), 0);
+    assert_eq!(dyn_forget.load(Ordering::Relaxed), 0);
+}
+
+/// Shutdown with a flow that never finishes must still detach the hooks and
+/// return in bounded time (the drain tracker caps the wait).
+#[tokio::test]
+async fn shutdown_detaches_hooks_and_stays_bounded_with_stuck_flow() {
+    use std::sync::atomic::Ordering;
+    let backend = crate::ebpf::mock::MockEbpfBackend::new();
+    let detach = backend.detach_calls.clone();
+    let mut cp = link_lifecycle_cp(backend);
+
+    // A flow that never finishes: the drain tracker must cap the wait.
+    cp.drain_tracker.increment();
+    let drain = cp.drain_tracker.clone();
+    let mut removal_task = tokio::spawn(async {});
+
+    tokio::time::timeout(Duration::from_secs(30), async {
+        cp.shutdown_datapath(&drain, &mut removal_task)
+            .await
+            .unwrap();
+        cp.finalize_shutdown().await.unwrap();
+    })
+    .await
+    .expect("shutdown must stay bounded with a stuck flow");
+    assert!(
+        detach.load(Ordering::Relaxed) >= 1,
+        "shutdown must detach the datapath hooks"
+    );
+}

--- a/crates/honk-core/src/dns/projection/mod.rs
+++ b/crates/honk-core/src/dns/projection/mod.rs
@@ -187,13 +187,19 @@ impl RoutingProjection {
         self.counters.snapshot()
     }
 
-    pub(crate) async fn shutdown(&self) {
+    pub(crate) async fn shutdown(&self, timeout: Duration) {
         self.wake.lock().take();
         let handle = self.worker.lock().take();
-        if let Some(handle) = handle {
-            let _ = handle.await;
+        if let Some(mut handle) = handle {
+            // A wedged worker must be aborted, never detached: shutdown
+            // continues into backend cleanup, and a live worker would keep
+            // pushing map writes into the backend being torn down.
+            if tokio::time::timeout(timeout, &mut handle).await.is_err() {
+                handle.abort();
+                let _ = (&mut handle).await;
+            }
         } else {
-            self.lifecycle.wait().await;
+            let _ = tokio::time::timeout(timeout, self.lifecycle.wait()).await;
         }
     }
 

--- a/crates/honk-core/src/dns/projection/tests/worker_tests.rs
+++ b/crates/honk-core/src/dns/projection/tests/worker_tests.rs
@@ -194,7 +194,34 @@ async fn spawned_worker_converges_mock_map_after_transient_failure() {
         map[0].1.bitmap,
         projection.counters().write_failures
     );
-    projection.shutdown().await;
+    projection.shutdown(Duration::from_secs(30)).await;
+}
+
+#[tokio::test]
+async fn shutdown_timeout_aborts_wedged_worker() {
+    // Given a worker wedged on the backend write lock mid-flush.
+    let ebpf: Arc<tokio::sync::RwLock<Box<dyn EbpfBackend>>> =
+        Arc::new(tokio::sync::RwLock::new(Box::new(MockEbpfBackend::new())));
+    let projection = RoutingProjection::spawn(ebpf.clone(), snapshot(1, 1, 2));
+    let termination = projection.termination_probe_for_test();
+    let guard = ebpf.write().await;
+    projection.submit(
+        snapshot(1, 1, 2),
+        positive(
+            "a.test",
+            &[IpAddr::V4(Ipv4Addr::new(203, 0, 113, 40))],
+            Duration::from_secs(30),
+        ),
+    );
+
+    // When shutdown's budget expires, the worker must be aborted (never
+    // detached into backend teardown) and shutdown must still return.
+    projection.shutdown(Duration::from_millis(50)).await;
+    drop(guard);
+
+    // Then
+    termination.wait().await;
+    assert!(termination.is_terminated());
 }
 
 #[tokio::test]
@@ -207,7 +234,10 @@ async fn shutdown_is_idempotent_and_awaits_worker_termination() {
         let termination = projection.termination_probe_for_test();
 
         // When
-        tokio::join!(projection.shutdown(), projection.shutdown());
+        tokio::join!(
+            projection.shutdown(Duration::from_secs(30)),
+            projection.shutdown(Duration::from_secs(30))
+        );
 
         // Then
         assert!(termination.is_terminated());

--- a/crates/honk-core/src/ebpf/mock.rs
+++ b/crates/honk-core/src/ebpf/mock.rs
@@ -174,6 +174,11 @@ pub struct MockEbpfBackend {
     /// Whether TC entry points may redirect traffic into the control plane.
     pub datapath_ready: bool,
     pub listener_sockets_published: bool,
+    /// Lifecycle counters (shared so tests can read them after the backend is
+    /// boxed): detach_hooks must only ever run during shutdown.
+    pub detach_calls: std::sync::Arc<std::sync::atomic::AtomicU64>,
+    pub dynamic_attach_calls: std::sync::Arc<std::sync::atomic::AtomicU64>,
+    pub dynamic_forget_calls: std::sync::Arc<std::sync::atomic::AtomicU64>,
     pub routing_meta_write_order: Vec<u32>,
     pub routing_publication_order: Vec<MockRoutingPublicationWrite>,
     routing_fault: Option<(RoutingPushPhase, usize)>,
@@ -1072,6 +1077,31 @@ impl EbpfBackend for MockEbpfBackend {
             }
         }
         Ok(removed)
+    }
+
+    fn detach_hooks(&mut self) -> anyhow::Result<()> {
+        self.detach_calls
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        Ok(())
+    }
+
+    fn attach_dynamic_interface(
+        &mut self,
+        _ifname: &str,
+        _role: super::IfaceRole,
+        _single_homed: bool,
+    ) -> anyhow::Result<super::DynamicHooks> {
+        self.dynamic_attach_calls
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        Ok(super::DynamicHooks {
+            ingress: true,
+            egress: true,
+        })
+    }
+
+    fn forget_dynamic_interface(&mut self, _ifindex: u32) {
+        self.dynamic_forget_calls
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }
 
     async fn cleanup(&mut self) -> anyhow::Result<()> {

--- a/crates/honk-core/src/ebpf/real/attach.rs
+++ b/crates/honk-core/src/ebpf/real/attach.rs
@@ -180,6 +180,11 @@ impl RealEbpfBackend {
         }
         // Attach cgroup programs to root cgroup2 for cookie→PID mapping.
         // This enables pname routing and control-plane traffic bypass (Go dae parity).
+        // The links must stay owned by the backend: a dropped link fd detaches
+        // the program, which once silently disabled COOKIE_PID_MAP (pname
+        // routing) from the first microseconds of every run.
+        let mut cgroup_sock_links = Vec::new();
+        let mut cgroup_sock_addr_links = Vec::new();
         match detect_cgroup_path() {
             Ok(cgroup_path) => {
                 let cgroup_file = std::fs::File::open(&cgroup_path)
@@ -193,7 +198,7 @@ impl RealEbpfBackend {
                     p.load()?;
                     let link_id =
                         p.attach(&cgroup_file, aya::programs::CgroupAttachMode::Single)?;
-                    let _link = p.take_link(link_id)?;
+                    cgroup_sock_links.push(p.take_link(link_id)?);
                 }
                 let cg_addr_names = [
                     "tproxy_wan_cg_connect4",
@@ -209,7 +214,7 @@ impl RealEbpfBackend {
                     p.load()?;
                     let link_id =
                         p.attach(&cgroup_file, aya::programs::CgroupAttachMode::Single)?;
-                    let _link = p.take_link(link_id)?;
+                    cgroup_sock_addr_links.push(p.take_link(link_id)?);
                 }
                 info!("Attached 6 cgroup programs to {}", cgroup_path);
             }
@@ -602,6 +607,8 @@ impl RealEbpfBackend {
             lan_slave_links,
             wan_slave_links,
             dynamic_links,
+            cgroup_sock_links,
+            cgroup_sock_addr_links,
             dae0_ingress_link: None,
             dae0peer_ingress_link: None,
             sk_lookup_link: None,

--- a/crates/honk-core/src/ebpf/real/attach.rs
+++ b/crates/honk-core/src/ebpf/real/attach.rs
@@ -438,8 +438,10 @@ impl RealEbpfBackend {
 
         // For bond masters, packets may be delivered on the slave interfaces
         // before they are aggregated onto the master. Attach lan_ingress to
-        // each slave so we do not miss downstream traffic.
-        let mut lan_slave_links = Vec::new();
+        // each slave so we do not miss downstream traffic.  Like bridge
+        // slaves above, the links go into `dynamic_links` so the watcher's
+        // `dynamic_hooked` dedup sees them and does not stack a duplicate
+        // hook on the first reconcile.
         let slaves = Self::bond_slaves(&ebpf_lan_ifname);
         if !slaves.is_empty() {
             info!(
@@ -466,7 +468,7 @@ impl RealEbpfBackend {
                     let id = p.attach(slave, slave_dir).map_err(|e| {
                         anyhow::anyhow!("attach {} to {}: {}", slave_prog, slave, e)
                     })?;
-                    lan_slave_links.push(p.take_link(id)?);
+                    dynamic_links.push((Self::iface_ifindex(slave), false, p.take_link(id)?));
                     Ok(())
                 })();
                 attach_result.map_err(|e| {
@@ -480,7 +482,6 @@ impl RealEbpfBackend {
         // traversing the master's egress qdisc. Attach wan_egress to each slave
         // so locally-generated traffic is intercepted regardless of the bond's
         // egress slave selection.
-        let mut wan_slave_links = Vec::new();
         if !slaves.is_empty() {
             info!(
                 "Bond master {} has slaves {:?}; attaching wan_egress to slaves",
@@ -503,7 +504,7 @@ impl RealEbpfBackend {
                     let id = p.attach(slave, slave_dir).map_err(|e| {
                         anyhow::anyhow!("attach {} to {}: {}", slave_prog, slave, e)
                     })?;
-                    wan_slave_links.push(p.take_link(id)?);
+                    dynamic_links.push((Self::iface_ifindex(slave), true, p.take_link(id)?));
                     Ok(())
                 })();
                 attach_result.map_err(|e| {
@@ -604,8 +605,6 @@ impl RealEbpfBackend {
             lan_egress_link,
             wan_egress_link,
             wan_ingress_link,
-            lan_slave_links,
-            wan_slave_links,
             dynamic_links,
             cgroup_sock_links,
             cgroup_sock_addr_links,

--- a/crates/honk-core/src/ebpf/real/iface_watch.rs
+++ b/crates/honk-core/src/ebpf/real/iface_watch.rs
@@ -286,3 +286,39 @@ fn iface_is_up(name: &str) -> bool {
         .and_then(|s| u32::from_str_radix(s.trim().trim_start_matches("0x"), 16).ok())
         .is_some_and(|flags| flags & IFF_UP != 0)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::Ordering;
+
+    /// Reconcile attaches an interface's hooks exactly once and never
+    /// detaches: hook removal belongs to shutdown alone, a periodic
+    /// reconcile must not tear down the datapath.
+    #[tokio::test]
+    async fn reconcile_attaches_once_and_never_detaches() {
+        let backend = crate::ebpf::mock::MockEbpfBackend::new();
+        let attach = backend.dynamic_attach_calls.clone();
+        let detach = backend.detach_calls.clone();
+        let ebpf: Arc<RwLock<Box<dyn EbpfBackend>>> = Arc::new(RwLock::new(Box::new(backend)));
+        let config = Arc::new(RwLock::new(honk_config::Config::default()));
+        let mut attached = AttachedMap::new();
+
+        reconcile(&ebpf, &config, &mut attached).await;
+        let first = attach.load(Ordering::Relaxed);
+        assert!(first >= 1, "first reconcile attaches the configured lo");
+        assert_eq!(detach.load(Ordering::Relaxed), 0);
+
+        reconcile(&ebpf, &config, &mut attached).await;
+        assert_eq!(
+            attach.load(Ordering::Relaxed),
+            first,
+            "second reconcile must not re-attach"
+        );
+        assert_eq!(
+            detach.load(Ordering::Relaxed),
+            0,
+            "reconcile must never detach"
+        );
+    }
+}

--- a/crates/honk-core/src/ebpf/real/iface_watch.rs
+++ b/crates/honk-core/src/ebpf/real/iface_watch.rs
@@ -54,9 +54,16 @@ impl IfaceWatcher {
         Some(Self { handle, stop })
     }
 
-    pub async fn shutdown(self) {
+    pub async fn shutdown(self, timeout: Duration) {
         let _ = self.stop.send(true);
-        let _ = self.handle.await;
+        let mut handle = self.handle;
+        // A watcher wedged mid-reconcile holds the backend write lock and
+        // could re-attach hooks after detach_hooks — abort it rather than
+        // drop the handle and leave the task running into teardown.
+        if tokio::time::timeout(timeout, &mut handle).await.is_err() {
+            handle.abort();
+            let _ = (&mut handle).await;
+        }
     }
 }
 

--- a/crates/honk-core/src/ebpf/real/mod.rs
+++ b/crates/honk-core/src/ebpf/real/mod.rs
@@ -67,6 +67,12 @@ pub struct RealEbpfBackend {
     /// watcher can drop dead links when a device vanishes, and the (ifindex,
     /// direction) pair dedupes retries after a partial failure.
     dynamic_links: Vec<(u32, bool, aya::programs::tc::SchedClassifierLink)>,
+    /// cgroup sock_create/sock_release links (cookie→PID mapping, control-plane
+    /// bypass). Held for the backend lifetime — dropping one detaches the
+    /// program in the kernel.
+    cgroup_sock_links: Vec<aya::programs::cgroup_sock::CgroupSockLink>,
+    /// cgroup connect4/6 + sendmsg4/6 links; same lifetime rule as above.
+    cgroup_sock_addr_links: Vec<aya::programs::cgroup_sock_addr::CgroupSockAddrLink>,
     dae0_ingress_link: Option<aya::programs::tc::SchedClassifierLink>,
     dae0peer_ingress_link: Option<aya::programs::tc::SchedClassifierLink>,
     sk_lookup_link: Option<aya::programs::sk_lookup::SkLookupLink>,
@@ -1063,7 +1069,7 @@ impl EbpfBackend for RealEbpfBackend {
         // Drop all TC links, which detaches the eBPF programs from the
         // network interfaces and restores normal packet processing.
         info!(
-            "Detaching BPF hooks (lan_ingress, lan_egress, wan_egress, wan_ingress, bond slaves, bridge slaves, dae0, sk_lookup)"
+            "Detaching BPF hooks (lan_ingress, lan_egress, wan_egress, wan_ingress, bond slaves, bridge slaves, cgroup, dae0, sk_lookup)"
         );
         self.lan_ingress_link = None;
         self.lan_egress_link = None;
@@ -1072,6 +1078,8 @@ impl EbpfBackend for RealEbpfBackend {
         self.lan_slave_links.clear();
         self.wan_slave_links.clear();
         self.dynamic_links.clear();
+        self.cgroup_sock_links.clear();
+        self.cgroup_sock_addr_links.clear();
         self.dae0_ingress_link = None;
         self.dae0peer_ingress_link = None;
         self.sk_lookup_link = None;

--- a/crates/honk-core/src/ebpf/real/mod.rs
+++ b/crates/honk-core/src/ebpf/real/mod.rs
@@ -53,16 +53,9 @@ pub struct RealEbpfBackend {
     /// Skipped in single-homed setups, where lan_ingress already owns the
     /// shared interface's ingress hook.
     wan_ingress_link: Option<aya::programs::tc::SchedClassifierLink>,
-    /// Additional ingress links for bond slaves. Packets may arrive on the
-    /// physical slaves before the bonding driver aggregates them onto the
-    /// master, so we attach the same lan_ingress program to each slave.
-    lan_slave_links: Vec<aya::programs::tc::SchedClassifierLink>,
-    /// Additional egress links for bond slaves. Outbound packets leaving a bond
-    /// slave may bypass the master's egress qdisc, so attach wan_egress there too.
-    wan_slave_links: Vec<aya::programs::tc::SchedClassifierLink>,
-    /// Links installed by dynamic attach (startup bridge slaves, extra
-    /// startup interfaces, and the interface watcher), keyed by (ifindex,
-    /// is_egress).  Keeping them here
+    /// Links installed by dynamic attach (startup bridge and bond slaves,
+    /// extra startup interfaces, and the interface watcher), keyed by
+    /// (ifindex, is_egress).  Keeping them here
     /// serves three purposes: the fd stays alive until `detach_hooks`, the
     /// watcher can drop dead links when a device vanishes, and the (ifindex,
     /// direction) pair dedupes retries after a partial failure.
@@ -1075,8 +1068,6 @@ impl EbpfBackend for RealEbpfBackend {
         self.lan_egress_link = None;
         self.wan_egress_link = None;
         self.wan_ingress_link = None;
-        self.lan_slave_links.clear();
-        self.wan_slave_links.clear();
         self.dynamic_links.clear();
         self.cgroup_sock_links.clear();
         self.cgroup_sock_addr_links.clear();

--- a/crates/honk-core/src/ebpf/real/tests.rs
+++ b/crates/honk-core/src/ebpf/real/tests.rs
@@ -47,8 +47,7 @@ async fn link_lifecycle_held_until_detach_hooks() {
         Err(_) => return, // cgroup2 unavailable: nothing to attach, nothing to test
     };
     let cgroup_file = std::fs::File::open(&cgroup_path).unwrap();
-    let pin_root =
-        Path::new("/sys/fs/bpf").join(format!("honk-link-test-{}", std::process::id()));
+    let pin_root = Path::new("/sys/fs/bpf").join(format!("honk-link-test-{}", std::process::id()));
     // Other agents (systemd, …) may legitimately hold root-cgroup programs;
     // only the delta belongs to this backend.
     let baseline = cgroup_attached_prog_count(cgroup_file.as_raw_fd());
@@ -77,7 +76,11 @@ async fn link_lifecycle_held_until_detach_hooks() {
     );
 
     backend.detach_hooks().expect("detach_hooks");
-    assert_eq!(held_bpf_link_count(), 0, "detach_hooks must release every link");
+    assert_eq!(
+        held_bpf_link_count(),
+        0,
+        "detach_hooks must release every link"
+    );
     assert_eq!(
         cgroup_attached_prog_count(cgroup_file.as_raw_fd()),
         baseline,

--- a/crates/honk-core/src/ebpf/real/tests.rs
+++ b/crates/honk-core/src/ebpf/real/tests.rs
@@ -1,5 +1,91 @@
 use super::*;
 
+/// Number of bpf links this process currently holds open. Every link fd
+/// shows a `link_type:` line in its /proc/self/fdinfo entry.
+fn held_bpf_link_count() -> usize {
+    std::fs::read_dir("/proc/self/fdinfo")
+        .map(|entries| {
+            entries
+                .filter_map(|e| e.ok())
+                .filter(|e| {
+                    std::fs::read_to_string(e.path())
+                        .map(|c| c.contains("link_type:"))
+                        .unwrap_or(false)
+                })
+                .count()
+        })
+        .unwrap_or(0)
+}
+
+/// Total programs attached to the root cgroup2 across every attach type,
+/// via raw BPF_PROG_QUERY (kernel ground truth, no aya state involved).
+fn cgroup_attached_prog_count(cgroup_fd: RawFd) -> u32 {
+    use aya_obj::generated::bpf_attr;
+    use aya_obj::generated::bpf_cmd::*;
+    let mut total = 0;
+    for attach_type in 0..64u32 {
+        let mut attr: bpf_attr = unsafe { core::mem::zeroed() };
+        attr.query.__bindgen_anon_1.target_fd = cgroup_fd as u32;
+        attr.query.attach_type = attach_type;
+        if unsafe { bpf_syscall(BPF_PROG_QUERY as _, &mut attr) }.is_ok() {
+            total += unsafe { attr.query.__bindgen_anon_2.prog_cnt };
+        }
+    }
+    total
+}
+
+/// Regression test: every link aya hands us (TC, cgroup sock/sock_addr)
+/// must stay owned by the backend until `detach_hooks`. The cgroup links
+/// were once dropped at the end of `load()`'s attach loop, detaching all
+/// six programs within microseconds and silently disabling pname routing.
+#[tokio::test]
+#[ignore = "requires root; run via just test-netns"]
+async fn link_lifecycle_held_until_detach_hooks() {
+    use std::os::fd::AsRawFd;
+    let cgroup_path = match detect_cgroup_path() {
+        Ok(p) => p,
+        Err(_) => return, // cgroup2 unavailable: nothing to attach, nothing to test
+    };
+    let cgroup_file = std::fs::File::open(&cgroup_path).unwrap();
+    let pin_root =
+        Path::new("/sys/fs/bpf").join(format!("honk-link-test-{}", std::process::id()));
+    // Other agents (systemd, …) may legitimately hold root-cgroup programs;
+    // only the delta belongs to this backend.
+    let baseline = cgroup_attached_prog_count(cgroup_file.as_raw_fd());
+    let mut backend = RealEbpfBackend::load(
+        crate::DEFAULT_BPF_OBJECT,
+        &pin_root,
+        12345,
+        0x0800_0000,
+        "lo",
+        "",
+        true,
+    )
+    .await
+    .expect("backend load");
+
+    // 6 cgroup links + lan_ingress on lo (single-homed: no egress/wan links).
+    let held = held_bpf_link_count();
+    assert!(
+        held >= 7,
+        "expected >= 7 held bpf links after load, got {held}"
+    );
+    assert_eq!(
+        cgroup_attached_prog_count(cgroup_file.as_raw_fd()),
+        baseline + 6,
+        "all 6 cgroup programs must stay attached after load"
+    );
+
+    backend.detach_hooks().expect("detach_hooks");
+    assert_eq!(held_bpf_link_count(), 0, "detach_hooks must release every link");
+    assert_eq!(
+        cgroup_attached_prog_count(cgroup_file.as_raw_fd()),
+        baseline,
+        "detach_hooks must detach the cgroup programs"
+    );
+    backend.cleanup().await.expect("cleanup");
+}
+
 #[test]
 fn test_parse_possible_cpus() {
     assert_eq!(parse_possible_cpus("0"), 1);


### PR DESCRIPTION
## Summary

Fixes the eBPF link lifecycle bugs found via production diagnosis (pname() rules never matching; datapath links disappearing while the process stays alive).

- `fix(ebpf): hold cgroup program links for the backend lifetime` — **pname() has never worked in any honk release**: the 6 cgroup programs (sock_create/sock_release/connect4/6/sendmsg4/6) were attached and their links immediately dropped (`let _link`), so the kernel detached them microseconds after startup. `COOKIE_PID_MAP` stayed empty forever → process-name rules silently never matched, and the control-plane bypass in `wan_egress` lost its cookie lookup. Links are now held on `RealEbpfBackend` like all other links. Root-gated regression test asserts links survive until `detach_hooks` (verified to fail on the old code).
- `fix(ebpf): track startup bond slave links in dynamic_links` — startup bond-slave links were invisible to IfaceWatcher's dedup, so the first reconcile attached a duplicate tcx link per slave for the process lifetime.
- `fix(control): bound shutdown stages after hook detach` — the post-detach awaits (runtime generation / DNS controller / persistence / watcher join) were unbounded; a hang there leaves the worst possible state: datapath torn down, process alive, singleton flock held, clash API still answering. Each stage now has a 10s bound + stage logs. Mock-level tests pin: reload/merge/reconcile never detach hooks, shutdown detaches and stays bounded.

Production note: the gateway incident that surfaced this (all TC+cgroup links gone mid-run, process alive, no shutdown logs) has no remaining code path after auditing all 12 `take_link` sites, the watcher, and reload; residual explanation is environmental (qdisc/device recreation). The bounded-shutdown change removes the hang variant of that state regardless.
