### PR TITLE
fix(ebpf): isolate wildcard socket address reads

### DIFF
--- a/crates/honk-ebpf/src/sk.rs
+++ b/crates/honk-ebpf/src/sk.rs
@@ -95,22 +95,32 @@ fn probe_result(sk: *mut bpf_sock) -> Option<SkProbe> {
     if sk.is_null() {
         return None;
     }
-    let socket = unsafe { &*sk };
-    let is_wildcard = if socket.family == AF_INET {
-        socket.src_ip4 == 0
-    } else if socket.family == AF_INET6 {
-        socket.src_ip6[0] == 0
-            && socket.src_ip6[1] == 0
-            && socket.src_ip6[2] == 0
-            && socket.src_ip6[3] == 0
+    let family = unsafe { (*sk).family };
+    let is_wildcard = if family == AF_INET {
+        socket_is_v4_wildcard(sk)
+    } else if family == AF_INET6 {
+        socket_is_v6_wildcard(sk)
     } else {
         true
     };
     let probe = SkProbe {
-        state: socket.state,
+        state: unsafe { (*sk).state },
         is_dae_socket: bpf_sock_is_dae_socket(sk as *const _),
         is_wildcard,
     };
     unsafe { bpf_sk_release(sk as *mut c_void) };
     Some(probe)
+}
+
+// Family-specific subprograms keep LLVM from folding these field reads into
+// pointer arithmetic on `bpf_sock`, which the verifier rejects at opt-level 2.
+#[inline(never)]
+fn socket_is_v4_wildcard(sk: *const bpf_sock) -> bool {
+    unsafe { (*sk).src_ip4 == 0 }
+}
+
+#[inline(never)]
+fn socket_is_v6_wildcard(sk: *const bpf_sock) -> bool {
+    let address = unsafe { (*sk).src_ip6 };
+    address[0] == 0 && address[1] == 0 && address[2] == 0 && address[3] == 0
 }


### PR DESCRIPTION
## Summary

- keep IPv4 and IPv6 wildcard-address reads in separate non-inlined eBPF subprograms
- prevent LLVM opt-level 2 from folding family selection into verifier-forbidden pointer arithmetic on `bpf_sock`
- preserve the standalone DNS wildcard-listener locality check introduced in beta.42

## Production evidence

The published beta.42 musl binary failed to load `lan_ingress_l3` on the VyOS 6.18.0 kernel with `R0 pointer arithmetic on sock prohibited`. A musl build containing this fix is running on `vyos@10.10.10.1`; the embedded object loaded and attached to `wg0`, `pppoe0`, and `bond0`. Manual deployment binary SHA-256: `3c431dd62d955fd1039076cead97a918ac11537f1ea1fa298600ab671f1b8299`.

## Verification

- `just build-ebpf`
- `just build-musl`
- `just test-netns` — 2 netns tests and 1 link-lifecycle test passed
- real-kernel load and datapath attachment on VyOS kernel 6.18.0
