### PR TITLE
feat(dns): resolve queries from system hosts file

### DIFF
--- a/config.dae
+++ b/config.dae
@@ -41,6 +41,7 @@ dns {
     # 保持注释可避免与现有 dnsmasq/AdGuardHome 抢占；透明 :53 仍生效
     # bind: 'tcp+udp://:1053'
     ipversion_prefer: 4
+    # use_host: true  # SIGHUP 后重新加载 /etc/hosts
     upstream {
         homedns: 'udp+tcp://10.10.10.1:53'
     }

--- a/crates/honk-config/src/dns.rs
+++ b/crates/honk-config/src/dns.rs
@@ -167,6 +167,9 @@ pub struct DnsConfig {
     /// Standalone DNS listener endpoint. Empty disables the listener.
     #[serde(default)]
     pub bind: String,
+    /// Resolve A/AAAA queries from `/etc/hosts` before DNS routing and upstreams.
+    #[serde(default)]
+    pub use_host: bool,
     #[serde(default)]
     pub upstream: Vec<DnsUpstream>,
     #[serde(default)]
@@ -577,6 +580,7 @@ impl Default for DnsConfig {
     fn default() -> Self {
         Self {
             bind: String::new(),
+            use_host: false,
             upstream: vec![DnsUpstream {
                 name: "default".to_string(),
                 address: "223.5.5.5:53".to_string(),
@@ -686,6 +690,17 @@ mod tests {
         assert!(endpoint.udp_enabled());
         assert_eq!(endpoint.host(), "localhost");
         assert_eq!(endpoint.port(), 53);
+    }
+
+    #[test]
+    fn use_host_is_serde_defaulted_and_explicitly_configurable() {
+        assert!(!DnsConfig::default().use_host);
+        assert!(!serde_json::from_str::<DnsConfig>("{}").unwrap().use_host);
+        assert!(
+            serde_json::from_str::<DnsConfig>(r#"{"use_host":true}"#)
+                .unwrap()
+                .use_host
+        );
     }
 
     /// Regression: a `[dns]` section without `cache` must still get the

--- a/crates/honk-config/src/parser/mod.rs
+++ b/crates/honk-config/src/parser/mod.rs
@@ -874,6 +874,9 @@ fn parse_dns_section(section: &Section) -> Result<DnsConfig, crate::ConfigError>
         cfg.bind_endpoint()
             .map_err(|error| crate::ConfigError::Parse(error.to_string()))?;
     }
+    if let Some(v) = kv.get("use_host") {
+        cfg.use_host = parse_bool(v);
+    }
 
     if let Some(v) = kv.get("ipversion_prefer") {
         cfg.strategy = parse_ip_prefer(v);

--- a/crates/honk-config/src/parser/tests.rs
+++ b/crates/honk-config/src/parser/tests.rs
@@ -1229,6 +1229,29 @@ fn test_parse_dns_zero_max_cache_size_is_preserved_for_runtime_clamp() {
 }
 
 #[test]
+fn use_host_defaults_off_and_parses_dae_boolean_forms() {
+    assert!(!parse_dae_config("dns {}").unwrap().dns.use_host);
+    assert!(
+        parse_dae_config("dns {\n    use_host: true\n}")
+            .unwrap()
+            .dns
+            .use_host
+    );
+    assert!(
+        parse_dae_config("dns {\n    use_host: on\n}")
+            .unwrap()
+            .dns
+            .use_host
+    );
+    assert!(
+        !parse_dae_config("dns {\n    use_host: false\n}")
+            .unwrap()
+            .dns
+            .use_host
+    );
+}
+
+#[test]
 fn udp_warm_node_count_defaults_to_strictly_disabled() {
     assert_eq!(crate::Config::default().global.udp_warm_node_count, 0);
     assert_eq!(

--- a/crates/honk-core/src/control/reload.rs
+++ b/crates/honk-core/src/control/reload.rs
@@ -470,7 +470,8 @@ impl ControlPlane {
             .with_strategy(config.dns.strategy.clone())
             .with_cache_enabled(config.dns.cache.enabled)
             .with_cache_ttl(config.dns.cache.ttl.min(u64::from(u32::MAX)) as u32)
-            .with_policy_from_config(&config.dns)?,
+            .with_policy_from_config(&config.dns)?
+            .with_hosts_from_config(&config.dns)?,
         );
         Ok((forwarder, dns_upstream_pool))
     }

--- a/crates/honk-core/src/dns/engine.rs
+++ b/crates/honk-core/src/dns/engine.rs
@@ -60,6 +60,12 @@ pub(crate) struct PreparedQuery {
     plan: RequestPlan,
 }
 
+pub(crate) struct ParsedQuery {
+    query: QueryContext,
+    domain: Arc<str>,
+    qtype: u16,
+}
+
 pub(crate) struct AnalyzedResponse {
     pub wire: Vec<u8>,
     pub class: ResponseClass,
@@ -97,31 +103,21 @@ impl DnsEngine {
         })
     }
 
+    #[cfg(test)]
     pub(crate) fn prepare(
         &self,
         raw_query: &[u8],
         original_dst: Option<SocketAddr>,
         ingress: IngressProfile,
     ) -> Result<PreparedQuery, EngineError> {
-        self.prepare_with_mode(raw_query, original_dst, ingress, false)
+        let parsed = Self::parse_query(raw_query, ingress)?;
+        self.prepare_parsed(parsed, original_dst, false)
     }
 
-    pub(crate) fn prepare_compatibility(
-        &self,
+    pub(crate) fn parse_query(
         raw_query: &[u8],
-        original_dst: Option<SocketAddr>,
         ingress: IngressProfile,
-    ) -> Result<PreparedQuery, EngineError> {
-        self.prepare_with_mode(raw_query, original_dst, ingress, true)
-    }
-
-    fn prepare_with_mode(
-        &self,
-        raw_query: &[u8],
-        original_dst: Option<SocketAddr>,
-        ingress: IngressProfile,
-        compatibility: bool,
-    ) -> Result<PreparedQuery, EngineError> {
+    ) -> Result<ParsedQuery, EngineError> {
         let query = QueryContext::parse_with_profile(raw_query, ingress)?;
         if query.questions().len() > 1 {
             return Err(EngineError::MultipleQuestions);
@@ -133,6 +129,24 @@ impl DnsEngine {
             .ok_or(EngineError::MalformedCanonicalName)?
             .into();
         let qtype = query.qtype().ok_or(EngineError::MissingQuestion)?.get();
+        Ok(ParsedQuery {
+            query,
+            domain,
+            qtype,
+        })
+    }
+
+    pub(crate) fn prepare_parsed(
+        &self,
+        parsed: ParsedQuery,
+        original_dst: Option<SocketAddr>,
+        compatibility: bool,
+    ) -> Result<PreparedQuery, EngineError> {
+        let ParsedQuery {
+            query,
+            domain,
+            qtype,
+        } = parsed;
         let context = RequestContext {
             domain: &domain,
             qtype,
@@ -219,6 +233,24 @@ impl DnsEngine {
 
     pub(crate) const fn policy_id(&self) -> Option<&PolicyId> {
         self.policy_id.as_ref()
+    }
+}
+
+impl ParsedQuery {
+    pub(crate) const fn query(&self) -> &QueryContext {
+        &self.query
+    }
+
+    pub(crate) fn domain(&self) -> &str {
+        &self.domain
+    }
+
+    pub(crate) fn domain_arc(&self) -> Arc<str> {
+        Arc::clone(&self.domain)
+    }
+
+    pub(crate) const fn qtype(&self) -> u16 {
+        self.qtype
     }
 }
 

--- a/crates/honk-core/src/dns/engine/pipeline.rs
+++ b/crates/honk-core/src/dns/engine/pipeline.rs
@@ -172,13 +172,18 @@ pub(crate) async fn resolve_with_owner(
     } = execution;
     debug!("DNS forwarder: resolving {} bytes", raw_query.len());
     let engine = forwarder.engine().await?;
-    let prepared = match mode {
-        ResolveMode::Strict => engine.prepare(raw_query, original_dst, ingress)?,
-        ResolveMode::Compatibility => {
-            engine.prepare_compatibility(raw_query, original_dst, ingress)?
-        }
-    };
-    let qtype = prepared.qtype();
+    let parsed = DnsEngine::parse_query(raw_query, ingress)?;
+    let qtype = parsed.qtype();
+    if !is_filtered_qtype(qtype, &forwarder.strategy)
+        && let Some(outcome) = forwarder.resolve_hosts(engine, &parsed, raw_query, mode)?
+    {
+        return Ok(outcome);
+    }
+    let prepared = engine.prepare_parsed(
+        parsed,
+        original_dst,
+        matches!(mode, ResolveMode::Compatibility),
+    )?;
     let reuse_eligible = prepared.is_cacheable() && prepared.is_coalescable();
 
     if is_filtered_qtype(qtype, &forwarder.strategy) {

--- a/crates/honk-core/src/dns/forwarder.rs
+++ b/crates/honk-core/src/dns/forwarder.rs
@@ -6,6 +6,7 @@
 //! and returns the result.  It also supports background prefetch to
 //! warm the cache for frequently-accessed domains.
 
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -93,6 +94,7 @@ pub struct DnsForwarder {
     engine: Arc<OnceCell<DnsEngine>>,
     pub(crate) routing: Arc<DnsRouter>,
     pub(crate) strategy: DnsStrategy,
+    hosts: Option<Arc<hosts::HostsFile>>,
     /// When false, skip positive/negative cache lookups and inserts
     /// (`dns.optimistic_cache` / `cache.enabled`).
     pub(crate) cache_enabled: bool,
@@ -121,6 +123,7 @@ impl DnsForwarder {
             engine: Arc::new(OnceCell::new()),
             routing,
             strategy: DnsStrategy::default(),
+            hosts: None,
             cache_enabled: true,
             // 0 = keep answer min TTL until `with_cache_ttl` is applied from config.
             cache_ttl: 0,
@@ -174,6 +177,28 @@ impl DnsForwarder {
         Ok(self.with_policy_id(policy_id))
     }
 
+    pub(crate) fn with_hosts_from_config(self, config: &DnsConfig) -> anyhow::Result<Self> {
+        self.with_hosts_file(config.use_host, hosts::SYSTEM_HOSTS_PATH)
+    }
+
+    fn with_hosts_file(mut self, enabled: bool, path: impl AsRef<Path>) -> anyhow::Result<Self> {
+        if !enabled {
+            self.hosts = None;
+            return Ok(self);
+        }
+        let path = path.as_ref();
+        let hosts = hosts::HostsFile::load(path)
+            .with_context(|| format!("failed to load DNS hosts file {}", path.display()))?;
+        tracing::info!(
+            path = %path.display(),
+            hostnames = hosts.len(),
+            addresses = hosts.address_count(),
+            "Loaded DNS hosts snapshot"
+        );
+        self.hosts = Some(Arc::new(hosts));
+        Ok(self)
+    }
+
     /// Return a clone of the underlying cache Arc.
     pub fn cache(&self) -> Arc<Mutex<DnsCache>> {
         self.cache.clone()
@@ -203,6 +228,7 @@ impl DnsForwarder {
             engine: Arc::clone(&self.engine),
             routing: Arc::clone(&self.routing),
             strategy: self.strategy.clone(),
+            hosts: self.hosts.clone(),
             cache_enabled: self.cache_enabled,
             cache_ttl: self.cache_ttl,
             policy_id: self.policy_id.clone(),
@@ -218,6 +244,7 @@ impl DnsForwarder {
 }
 
 mod exchange;
+mod hosts;
 mod message {
     use crate::dns::query::{NameParseState, parse_name};
     use std::net::{IpAddr, SocketAddr};
@@ -314,6 +341,8 @@ mod message {
 mod prefetch;
 mod resolution;
 mod response {
+    use std::net::IpAddr;
+
     use super::message::extract_answer_ips;
     use crate::dns::query::QueryContext;
     use crate::dns::response::dns_error_flags;
@@ -355,16 +384,55 @@ mod response {
 
     /// Build a NODATA response while preserving the exact question bytes.
     pub(crate) fn make_empty_response(raw_query: &[u8], query: &QueryContext) -> Vec<u8> {
+        make_address_response(raw_query, query, &[], 0)
+    }
+
+    pub(super) fn make_address_response(
+        raw_query: &[u8],
+        query: &QueryContext,
+        addresses: &[IpAddr],
+        ttl: u32,
+    ) -> Vec<u8> {
         let question_end = query
             .question_offsets()
             .map(|offsets| offsets.end())
             .unwrap_or(12)
             .min(raw_query.len());
-        let mut response = raw_query[..question_end].to_vec();
+        let mut response = Vec::with_capacity(
+            question_end
+                .saturating_add(addresses.len().saturating_mul(28))
+                .saturating_add(11),
+        );
+        response.extend_from_slice(&raw_query[..question_end]);
         response.resize(response.len().max(12), 0);
         response[2..4].copy_from_slice(&dns_error_flags(raw_query, 0).to_be_bytes());
         response[4..6].copy_from_slice(&1u16.to_be_bytes());
         response[6..12].fill(0);
+
+        let qtype = query.qtype().map(|value| value.get()).unwrap_or_default();
+        let question_offset = query
+            .question_offsets()
+            .and_then(|offsets| u16::try_from(offsets.start()).ok())
+            .filter(|offset| *offset <= 0x3fff)
+            .unwrap_or(12);
+        let name_pointer = (0xc000 | question_offset).to_be_bytes();
+        let mut answer_count = 0u16;
+        for address in addresses {
+            if answer_count == u16::MAX {
+                break;
+            }
+            match (qtype, address) {
+                (1, IpAddr::V4(address)) => {
+                    append_address_record(&mut response, name_pointer, 1, ttl, &address.octets());
+                }
+                (28, IpAddr::V6(address)) => {
+                    append_address_record(&mut response, name_pointer, 28, ttl, &address.octets());
+                }
+                _ => continue,
+            }
+            answer_count += 1;
+        }
+        response[6..8].copy_from_slice(&answer_count.to_be_bytes());
 
         if let Some(edns) = query.edns().filter(|edns| edns.version() == 0) {
             response[10..12].copy_from_slice(&1u16.to_be_bytes());
@@ -375,6 +443,22 @@ mod response {
             response.extend_from_slice(&0u16.to_be_bytes());
         }
         response
+    }
+
+    fn append_address_record(
+        response: &mut Vec<u8>,
+        name_pointer: [u8; 2],
+        record_type: u16,
+        ttl: u32,
+        address: &[u8],
+    ) {
+        response.extend_from_slice(&name_pointer);
+        response.extend_from_slice(&record_type.to_be_bytes());
+        response.extend_from_slice(&1u16.to_be_bytes());
+        response.extend_from_slice(&ttl.to_be_bytes());
+        let rdlength = if record_type == 1 { 4u16 } else { 16u16 };
+        response.extend_from_slice(&rdlength.to_be_bytes());
+        response.extend_from_slice(address);
     }
 }
 mod strategy {

--- a/crates/honk-core/src/dns/forwarder/exchange.rs
+++ b/crates/honk-core/src/dns/forwarder/exchange.rs
@@ -6,10 +6,10 @@ use bytes::Bytes;
 use tracing::{debug, trace};
 
 use crate::dns::cache::{CacheKey, DnsCacheService, PublicationEpoch};
-use crate::dns::engine::{DnsEngine, PreparedQuery};
+use crate::dns::engine::{DnsEngine, ParsedQuery, PreparedQuery};
 use crate::dns::outcome::{DnsOutcome, EffectiveExpiry, OutcomeParts, OutcomeStatus, Provenance};
 use crate::dns::planner::RequestScope;
-use crate::dns::query::IngressProfile;
+use crate::dns::query::{IngressProfile, QueryContext};
 use crate::dns::response::ResponseTemplate;
 use honk_ebpf_common::DAE_BYPASS_MARK;
 
@@ -49,15 +49,70 @@ impl DnsForwarder {
         requery_history: Vec<String>,
         mode: ResolveMode,
     ) -> Result<DnsOutcome, DnsForwardError> {
+        self.outcome_from_query(
+            engine,
+            prepared.query(),
+            prepared.domain_arc(),
+            reusable,
+            analyzed_answer_ips,
+            status,
+            provenance,
+            expiry,
+            logical_upstream,
+            final_upstream,
+            requery_history,
+            mode,
+        )
+    }
+
+    pub(crate) fn local_outcome_from_wire(
+        &self,
+        engine: &DnsEngine,
+        parsed: &ParsedQuery,
+        reusable: impl Into<Bytes>,
+        mode: ResolveMode,
+    ) -> Result<DnsOutcome, DnsForwardError> {
+        self.outcome_from_query(
+            engine,
+            parsed.query(),
+            parsed.domain_arc(),
+            reusable,
+            None,
+            OutcomeStatus::Accepted,
+            Provenance::Fresh,
+            EffectiveExpiry::do_not_cache(),
+            None,
+            None,
+            Vec::new(),
+            mode,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn outcome_from_query(
+        &self,
+        engine: &DnsEngine,
+        query: &QueryContext,
+        domain: Arc<str>,
+        reusable: impl Into<Bytes>,
+        analyzed_answer_ips: Option<(usize, Vec<IpAddr>)>,
+        status: OutcomeStatus,
+        provenance: Provenance,
+        expiry: EffectiveExpiry,
+        logical_upstream: Option<String>,
+        final_upstream: Option<String>,
+        requery_history: Vec<String>,
+        mode: ResolveMode,
+    ) -> Result<DnsOutcome, DnsForwardError> {
         let reusable = reusable.into();
-        let template = match ResponseTemplate::validate_owned(prepared.query(), reusable.clone()) {
+        let template = match ResponseTemplate::validate_owned(query, reusable.clone()) {
             Ok(template) => Some(template),
             Err(_) if matches!(mode, ResolveMode::Compatibility) => None,
             Err(error) => return Err(error.into()),
         };
         let rendered = match &template {
-            Some(template) => template.render(prepared.query())?,
-            None => patch_txid(reusable.to_vec(), prepared.query().txid().get()),
+            Some(template) => template.render(query)?,
+            None => patch_txid(reusable.to_vec(), query.txid().get()),
         };
         let response_class = crate::dns::engine::classify_response(&reusable);
         let answer_ips = if status == OutcomeStatus::Accepted
@@ -74,7 +129,7 @@ impl DnsForwarder {
             status,
             response_class,
             provenance,
-            domain: prepared.domain_arc(),
+            domain,
             answer_ips,
             expiry,
             logical_upstream,

--- a/crates/honk-core/src/dns/forwarder/hosts.rs
+++ b/crates/honk-core/src/dns/forwarder/hosts.rs
@@ -1,0 +1,297 @@
+//! Immutable `/etc/hosts` snapshots for one DNS runtime generation.
+//!
+//! Loading happens while a generation is built, so SIGHUP publishes hosts,
+//! policy, transports, and routing together. Query handling performs no file I/O.
+
+use std::collections::HashMap;
+use std::fs;
+use std::io;
+use std::net::IpAddr;
+use std::path::Path;
+
+use crate::dns::engine::{DnsEngine, ParsedQuery};
+use crate::dns::outcome::DnsOutcome;
+
+use super::response::make_address_response;
+use super::{DnsForwardError, DnsForwarder, ResolveMode};
+
+pub(super) const SYSTEM_HOSTS_PATH: &str = "/etc/hosts";
+const HOSTS_TTL_SECS: u32 = 60;
+
+#[derive(Debug, Default)]
+pub(super) struct HostsFile {
+    entries: HashMap<String, Vec<IpAddr>>,
+}
+
+impl HostsFile {
+    pub(super) fn load(path: &Path) -> io::Result<Self> {
+        fs::read_to_string(path).map(|contents| Self::parse(&contents))
+    }
+
+    fn parse(contents: &str) -> Self {
+        let mut entries: HashMap<String, Vec<IpAddr>> = HashMap::new();
+        for line in contents.lines() {
+            let fields = line
+                .split_once('#')
+                .map_or(line, |(record, _)| record)
+                .split_whitespace();
+            let mut fields = fields;
+            let Some(address) = fields.next().and_then(|value| value.parse::<IpAddr>().ok()) else {
+                continue;
+            };
+            for hostname in fields {
+                let hostname = normalize_hostname(hostname);
+                if hostname.is_empty() {
+                    continue;
+                }
+                let addresses = entries.entry(hostname).or_default();
+                if !addresses.contains(&address) {
+                    addresses.push(address);
+                }
+            }
+        }
+        Self { entries }
+    }
+
+    pub(super) fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub(super) fn address_count(&self) -> usize {
+        self.entries.values().map(Vec::len).sum()
+    }
+
+    fn response(&self, raw_query: &[u8], parsed: &ParsedQuery) -> Option<Vec<u8>> {
+        if parsed.query().qclass()?.get() != 1 || !matches!(parsed.qtype(), 1 | 28) {
+            return None;
+        }
+        let addresses = self.entries.get(parsed.domain())?;
+        Some(make_address_response(
+            raw_query,
+            parsed.query(),
+            addresses,
+            HOSTS_TTL_SECS,
+        ))
+    }
+}
+
+fn normalize_hostname(hostname: &str) -> String {
+    let mut hostname = hostname.trim_end_matches('.').to_owned();
+    hostname.make_ascii_lowercase();
+    hostname
+}
+
+impl DnsForwarder {
+    pub(crate) fn resolve_hosts(
+        &self,
+        engine: &DnsEngine,
+        parsed: &ParsedQuery,
+        raw_query: &[u8],
+        mode: ResolveMode,
+    ) -> Result<Option<DnsOutcome>, DnsForwardError> {
+        let Some(response) = self
+            .hosts
+            .as_deref()
+            .and_then(|hosts| hosts.response(raw_query, parsed))
+        else {
+            return Ok(None);
+        };
+        self.local_outcome_from_wire(engine, parsed, response, mode)
+            .map(Some)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use async_trait::async_trait;
+    use honk_config::dns::{
+        DnsCond, DnsConfig, DnsDomainMatcher, DnsRequestAction, DnsRequestRule,
+    };
+    use tempfile::{NamedTempFile, tempdir};
+    use tokio::sync::Mutex;
+
+    use crate::dns::cache::DnsCache;
+    use crate::dns::forwarder::{DnsUpstreamPool, build_dns_query};
+    use crate::dns::outcome::{OutcomeStatus, Provenance, ResponseClass};
+    use crate::dns::query::QueryContext;
+    use crate::dns::routing::DnsRouter;
+
+    use super::super::response::make_empty_response;
+    use super::*;
+
+    #[derive(Default)]
+    struct CountingUpstream {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl DnsUpstreamPool for CountingUpstream {
+        async fn query(&self, _upstream_name: &str, raw_query: &[u8]) -> anyhow::Result<Vec<u8>> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let query = QueryContext::parse(raw_query)?;
+            Ok(make_empty_response(raw_query, &query))
+        }
+    }
+
+    fn hosts_file(contents: &str) -> NamedTempFile {
+        let file = NamedTempFile::new().expect("temporary hosts file");
+        std::fs::write(file.path(), contents).expect("write hosts file");
+        file
+    }
+
+    fn test_forwarder(
+        path: &Path,
+        config: &DnsConfig,
+        upstream: Arc<CountingUpstream>,
+    ) -> DnsForwarder {
+        let router = Arc::new(DnsRouter::new_from_dns_config(config).expect("DNS router"));
+        let upstream: Arc<dyn DnsUpstreamPool> = upstream;
+        DnsForwarder::new(upstream, Arc::new(Mutex::new(DnsCache::new(100))), router)
+            .with_policy_from_config(config)
+            .expect("DNS policy")
+            .with_hosts_file(config.use_host, path)
+            .expect("hosts snapshot")
+    }
+
+    #[test]
+    fn parser_normalizes_aliases_and_deduplicates_addresses() {
+        let hosts = HostsFile::parse(
+            "127.0.0.1 LOCALHOST localhost. alias # inline comment\n\
+             ::1 localhost\n\
+             invalid ignored\n\
+             192.0.2.1 alias alias\n",
+        );
+
+        assert_eq!(hosts.len(), 2);
+        assert_eq!(hosts.address_count(), 4);
+        assert_eq!(
+            hosts.entries.get("localhost"),
+            Some(&vec![
+                IpAddr::V4(Ipv4Addr::LOCALHOST),
+                IpAddr::V6(Ipv6Addr::LOCALHOST),
+            ])
+        );
+        assert_eq!(
+            hosts.entries.get("alias"),
+            Some(&vec![
+                IpAddr::V4(Ipv4Addr::LOCALHOST),
+                IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
+            ])
+        );
+    }
+
+    #[tokio::test]
+    async fn hosts_answers_a_and_aaaa_before_request_reject() {
+        let file = hosts_file("192.0.2.10 service.test\n2001:db8::10 service.test\n");
+        let upstream = Arc::new(CountingUpstream::default());
+        let mut config = DnsConfig {
+            use_host: true,
+            ..Default::default()
+        };
+        config.routing.request.rules = vec![DnsRequestRule {
+            conditions: vec![DnsCond::Qname {
+                not: false,
+                matchers: vec![DnsDomainMatcher::Full("service.test".into())],
+            }],
+            action: DnsRequestAction::Reject,
+        }];
+        let forwarder = test_forwarder(file.path(), &config, Arc::clone(&upstream));
+
+        let mut a_query = build_dns_query("SERVICE.TEST", 1);
+        a_query[0..2].copy_from_slice(&0x1234u16.to_be_bytes());
+        let a = forwarder
+            .resolve_outcome(&a_query)
+            .await
+            .expect("A outcome");
+        let aaaa = forwarder
+            .resolve_outcome(&build_dns_query("service.test", 28))
+            .await
+            .expect("AAAA outcome");
+
+        assert_eq!(a.status(), OutcomeStatus::Accepted);
+        assert_eq!(a.provenance(), Provenance::Fresh);
+        assert_eq!(a.response_class(), ResponseClass::Positive);
+        assert!(!a.expiry().is_cacheable());
+        assert_eq!(&a.rendered()[0..2], &0x1234u16.to_be_bytes());
+        assert_eq!(a.answer_ips(), &[IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10))]);
+        assert_eq!(
+            aaaa.answer_ips(),
+            &[IpAddr::V6("2001:db8::10".parse().unwrap())]
+        );
+        assert_eq!(upstream.calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn known_name_family_miss_is_nodata_but_other_queries_use_upstream() {
+        let file = hosts_file("192.0.2.20 ipv4-only.test\n");
+        let upstream = Arc::new(CountingUpstream::default());
+        let config = DnsConfig {
+            use_host: true,
+            ..Default::default()
+        };
+        let forwarder = test_forwarder(file.path(), &config, Arc::clone(&upstream));
+
+        let family_miss = forwarder
+            .resolve_outcome(&build_dns_query("ipv4-only.test", 28))
+            .await
+            .expect("AAAA outcome");
+        assert_eq!(family_miss.status(), OutcomeStatus::Accepted);
+        assert_eq!(family_miss.response_class(), ResponseClass::Nodata);
+        assert_eq!(upstream.calls.load(Ordering::SeqCst), 0);
+
+        forwarder
+            .resolve_outcome(&build_dns_query("ipv4-only.test", 16))
+            .await
+            .expect("TXT outcome");
+        forwarder
+            .resolve_outcome(&build_dns_query("unknown.test", 1))
+            .await
+            .expect("unknown A outcome");
+        assert_eq!(upstream.calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn rebuilt_forwarder_loads_a_new_snapshot_without_mutating_the_old_one() {
+        let file = hosts_file("192.0.2.30 reload.test\n");
+        let upstream = Arc::new(CountingUpstream::default());
+        let config = DnsConfig {
+            use_host: true,
+            ..Default::default()
+        };
+        let old = test_forwarder(file.path(), &config, Arc::clone(&upstream));
+
+        std::fs::write(file.path(), "192.0.2.31 reload.test\n").expect("replace hosts file");
+        let new = test_forwarder(file.path(), &config, Arc::clone(&upstream));
+
+        let query = build_dns_query("reload.test", 1);
+        let old_outcome = old.resolve_outcome(&query).await.expect("old snapshot");
+        let new_outcome = new.resolve_outcome(&query).await.expect("new snapshot");
+        assert_eq!(
+            old_outcome.answer_ips(),
+            &[IpAddr::V4(Ipv4Addr::new(192, 0, 2, 30))]
+        );
+        assert_eq!(
+            new_outcome.answer_ips(),
+            &[IpAddr::V4(Ipv4Addr::new(192, 0, 2, 31))]
+        );
+        assert_eq!(upstream.calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn enabled_hosts_load_failure_is_fatal_but_disabled_hosts_skips_io() {
+        let directory = tempdir().expect("temporary directory");
+        let missing = directory.path().join("missing-hosts");
+        let config = DnsConfig::default();
+        let router = Arc::new(DnsRouter::new_from_dns_config(&config).expect("DNS router"));
+        let upstream: Arc<dyn DnsUpstreamPool> = Arc::new(CountingUpstream::default());
+        let forwarder =
+            DnsForwarder::new(upstream, Arc::new(Mutex::new(DnsCache::new(100))), router);
+
+        assert!(forwarder.clone().with_hosts_file(false, &missing).is_ok());
+        assert!(forwarder.with_hosts_file(true, &missing).is_err());
+    }
+}

--- a/crates/honk-core/src/dns/policy/tests.rs
+++ b/crates/honk-core/src/dns/policy/tests.rs
@@ -132,6 +132,19 @@ fn listener_bind_does_not_change_resolution_policy_identity() {
 }
 
 #[test]
+fn hosts_lookup_does_not_change_upstream_cache_identity() {
+    let base = representative_config();
+    let mut with_hosts = base.clone();
+    with_hosts.use_host = true;
+
+    // Hosts answers bypass the cache before routing; non-host upstream policy is unchanged.
+    assert_eq!(
+        PolicyId::from_config(&base).expect("base policy"),
+        PolicyId::from_config(&with_hosts).expect("hosts policy"),
+    );
+}
+
+#[test]
 fn request_and_response_rule_order_change_identity() {
     // Given
     let mut base = representative_config();

--- a/crates/honk-core/src/dns/resolver.rs
+++ b/crates/honk-core/src/dns/resolver.rs
@@ -38,7 +38,8 @@ impl DnsResolver {
                 forwarder
                     .as_ref()
                     .clone()
-                    .with_strategy(config.strategy.clone()),
+                    .with_strategy(config.strategy.clone())
+                    .with_hosts_from_config(config)?,
             )),
         })
     }
@@ -75,7 +76,8 @@ fn build_forwarder_from_config(config: &DnsConfig) -> anyhow::Result<Arc<DnsForw
             .with_strategy(config.strategy.clone())
             .with_cache_enabled(config.cache.enabled)
             .with_cache_ttl(config.cache.ttl.min(u64::from(u32::MAX)) as u32)
-            .with_policy_from_config(config)?,
+            .with_policy_from_config(config)?
+            .with_hosts_from_config(config)?,
     ))
 }
 

--- a/crates/honk-core/src/lib.rs
+++ b/crates/honk-core/src/lib.rs
@@ -848,7 +848,8 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
         .with_strategy(config.dns.strategy.clone())
         .with_cache_enabled(config.dns.cache.enabled)
         .with_cache_ttl(config.dns.cache.ttl.min(u64::from(u32::MAX)) as u32)
-        .with_policy_from_config(&config.dns)?,
+        .with_policy_from_config(&config.dns)?
+        .with_hosts_from_config(&config.dns)?,
     );
     info!("DNS forwarder ready");
 

--- a/doc/components.en.md
+++ b/doc/components.en.md
@@ -399,6 +399,7 @@ Multiple functions on one rule are AND'd with `&&`.
 dns {
     # bind: 'tcp+udp://:1053'   # leave commented to keep standalone DNS off
     ipversion_prefer: 4
+    use_host: true
     optimistic_cache: true
     optimistic_cache_ttl: 600
     max_cache_size: 10000
@@ -420,12 +421,35 @@ dns {
 | dae key | Internal field | Default | Meaning |
 | ------- | -------------- | --------- | --------- |
 | `bind` | `bind` | `""` | Optional standalone UDP/TCP listener in the host network namespace; empty disables only this listener |
+| `use_host` | `use_host` | `false` | Resolve IN-class A/AAAA queries from `/etc/hosts` before DNS routing, cache, and upstreams |
 | `upstream { ... }` | `upstream` | one `default` @ 223.5.5.5 UDP | Servers |
 | `routing { ... }` | `routing` | fallback default | Request routing |
 | `ipversion_prefer` | `strategy` | `both` when omitted; `preferipv4`/`preferipv6` when set to `4`/`6` | Address-family preference (`4`/`6`) |
 | `optimistic_cache` | `cache.enabled` | `true` | Cache on/off |
 | `optimistic_cache_ttl` | `cache.ttl` | `600` | Fixed positive-cache TTL (overrides answer min TTL; `0` keeps answer TTL) |
 | `max_cache_size` | `cache.max_size` | `10000` | Max entries; also scales the retained query/response wire-byte budget at 4 KiB/entry (minimum 65,535 bytes/shard, global maximum 64 MiB); `0` is accepted, warned, and clamped to `1` |
+
+### Hosts file
+
+With `use_host: true`, generation construction reads `/etc/hosts` once. Each
+valid address line contributes its canonical name and aliases; matching is
+exact and ASCII case-insensitive, trailing dots are normalized, duplicate
+addresses are removed, and both IPv4 and IPv6 are supported. Invalid-address
+lines and comments are ignored.
+
+Hard `ipv4_only`/`ipv6_only` strategy filtering remains first. Otherwise a
+known IN-class A/AAAA name takes precedence over request rules (including
+`reject`), cache entries, and upstreams. If the name exists but has no address
+in the requested family, honk returns NOERROR/NODATA instead of leaking the
+query upstream. Non-address qtypes and non-IN classes keep the normal routing
+path. Host answers participate in the normal DNS routing projection, advertise
+a 60-second TTL, and bypass honk's response cache.
+
+The loaded table is immutable for the lifetime of its DNS runtime generation;
+the query path never reads the file. Send SIGHUP after editing `/etc/hosts`.
+The replacement generation loads the new snapshot atomically while in-flight
+leases may finish on the old one. If the file cannot be read, startup fails or
+the reload aborts before publication, retaining the active generation.
 
 ### Standalone listener
 

--- a/doc/components.zh.md
+++ b/doc/components.zh.md
@@ -360,6 +360,7 @@ domain/geosite matcher 视为"不是 x"，不会被其否决。
 dns {
     # bind: 'tcp+udp://:1053'   # 保持注释即可只用透明 DNS
     ipversion_prefer: 4
+    use_host: true
     upstream {
         homedns: 'udp+tcp://10.10.10.1:53'
     }
@@ -376,10 +377,28 @@ dns {
 | 字段 | 类型 | 默认值 | 含义 |
 | ------ | ------ | -------- | ------ |
 | `bind` | string | `""` | host netns 中可选的独立 UDP/TCP 监听；空值只关闭此监听 |
+| `use_host` | bool | `false` | 先于 DNS 路由、缓存和上游，用 `/etc/hosts` 应答 IN class A/AAAA 查询 |
 | `upstream` | list | 一个 `default` @ 223.5.5.5 UDP | 服务器；dae：`upstream { name: 'uri' }` |
 | `routing` | object | fallback 默认 | 请求路由；dae：`routing { request { ... } }` |
 | `strategy` | enum | 未指定时为 `both`；设置 `ipversion_prefer: 4\|6` 时分别为 `preferipv4`/`preferipv6` | 地址族策略 |
 | `cache` | object | 启用 | 缓存；dae：`optimistic_cache` / `optimistic_cache_ttl` / `max_cache_size` |
+
+### hosts 文件
+
+`use_host: true` 时，每次构建 DNS generation 都会读取一次 `/etc/hosts`。每个有效
+地址行的规范名和别名都会生效；匹配为精确、ASCII 大小写不敏感，末尾点会归一化，
+重复地址会去重，同时支持 IPv4 与 IPv6。无效地址行和注释会被忽略。
+
+`ipv4_only`/`ipv6_only` 的硬地址族过滤仍最先执行。除此之外，已知名称的 IN class
+A/AAAA 查询优先于 request 规则（包括 `reject`）、缓存条目和上游。名称存在但缺少所
+请求地址族时返回 NOERROR/NODATA，不会把查询泄漏给上游；非地址 qtype 与非 IN class
+仍走原路由管线。hosts 应答参与正常的 DNS 路由投影，wire TTL 为 60 秒，且绕过 honk
+应答缓存。
+
+加载后的表在该 DNS runtime generation 生命周期内不可变，查询路径不会读文件。
+修改 `/etc/hosts` 后需发送 SIGHUP；替换 generation 会原子加载新快照，已取得 lease
+的在途请求仍可在旧快照上结束。文件不可读会令启动失败，或在发布前中止 reload 并
+保留当前 generation。
 
 ### 独立监听
 

--- a/doc/configuration.en.md
+++ b/doc/configuration.en.md
@@ -372,6 +372,7 @@ dns {
     # Standalone listener is disabled unless bind is set.
     # bind: 'tcp+udp://:1053'
     ipversion_prefer: 4
+    use_host: true
 
     upstream {
         alidns: 'udp://223.5.5.5:53'
@@ -409,6 +410,15 @@ dns {
     max_cache_size: 10000
 }
 ```
+
+`use_host` defaults to `false`. When enabled, honk loads `/etc/hosts` while
+building each DNS runtime generation. Matching IN-class A/AAAA queries are
+answered before request routing, cache lookup, or upstream exchange; a known
+name without the requested address family returns NOERROR/NODATA. Other query
+types continue through the normal pipeline. The snapshot is immutable on the
+query path and is refreshed by SIGHUP; an unreadable file fails startup or the
+new reload generation. Synthesized records advertise a 60-second TTL and are
+not inserted into honk's DNS cache.
 
 Upstream URIs take a scheme prefix: `udp://`, `tcp://`, `tcp+udp://`, `tls://`, `https://`, `quic://`, `h3://`; a bare `host:port` defaults to UDP.
 

--- a/doc/configuration.zh.md
+++ b/doc/configuration.zh.md
@@ -334,6 +334,7 @@ dns {
     # 未设置 bind 时不启动独立监听。
     # bind: 'tcp+udp://:1053'
     ipversion_prefer: 4
+    use_host: true
     optimistic_cache: true        # 缓存开关
     # 正缓存固定 TTL（覆盖应答 min TTL，并改写 wire RR TTL）。0 = 沿用上游应答 TTL。
     optimistic_cache_ttl: 600
@@ -365,6 +366,13 @@ dns {
     }
 }
 ```
+
+`use_host` 默认为 `false`。启用后，honk 会在构建每个 DNS runtime generation 时
+加载 `/etc/hosts`。IN class 的 A/AAAA 查询命中后，会先于 request routing、缓存查询
+和上游交换直接应答；名称存在但缺少所请求的地址族时返回 NOERROR/NODATA，其他查询
+类型继续走原有管线。查询热路径只读不可变快照，SIGHUP 会重新加载；文件不可读会令
+启动失败，或令新的 reload generation 构建失败并保留旧 generation。合成记录的 TTL
+为 60 秒，且不写入 honk DNS 缓存。
 
 上游 URI 协议前缀：`udp://`、`tcp://`、`tcp+udp://`、`tls://`、`https://`、`h3://`、`quic://`；无前缀按 UDP 处理。
 

--- a/example.dae
+++ b/example.dae
@@ -73,6 +73,7 @@ dns {
     # 默认只用透明 :53；需要普通 host-netns UDP socket 时再启用
     # bind: '127.0.0.1:1053'
     ipversion_prefer: 4
+    # use_host: true  # 优先使用 /etc/hosts；修改后需 SIGHUP
     upstream {
         alidns: 'udp://223.5.5.5:53'
         googledns: 'udp+tcp://8.8.8.8:53'


### PR DESCRIPTION
## Summary
- add `dns.use_host` (default `false`) to dae and structured configuration
- load an immutable `/etc/hosts` snapshot per DNS runtime generation and refresh it on SIGHUP
- answer matching IN-class A/AAAA queries before request routing, cache, and upstream exchange
- document precedence, NODATA behavior, 60-second wire TTL, reload lifecycle, and failure handling in English and Chinese

## Behavior
- exact ASCII case-insensitive hostname and alias matching with trailing-dot normalization
- IPv4/IPv6 support and duplicate-address removal
- known names without the requested family return NOERROR/NODATA
- non-address qtypes and non-IN classes continue through the normal DNS pipeline
- hosts answers bypass the honk DNS cache and continue through routing projection

## Verification
- `just dns-ci` (`dns-ci: ALL GREEN`)
- `cargo build -p honk-core`
- production-binary smoke test with `--mock-ebpf`: `localhost` A returned `127.0.0.1`, AAAA returned `::1`, both TTL 60 and RCODE 0