### PR TITLE
fix(nfqueue): preserve superseding UDP tuple state

### DIFF
--- a/crates/honk-core/src/control/mod.rs
+++ b/crates/honk-core/src/control/mod.rs
@@ -392,7 +392,8 @@ pub(crate) fn spawn_udp_removal_worker(
                     );
                     match backend.remove_udp_flow(&key, removal.decision_token) {
                         Ok(crate::ebpf::UdpDecisionCommitResult::Applied)
-                        | Ok(crate::ebpf::UdpDecisionCommitResult::Missing) => true,
+                        | Ok(crate::ebpf::UdpDecisionCommitResult::Missing)
+                        | Ok(crate::ebpf::UdpDecisionCommitResult::Superseded) => true,
                         Ok(result) => {
                             warn!(
                                 ?result,

--- a/crates/honk-core/src/control/nfqueue.rs
+++ b/crates/honk-core/src/control/nfqueue.rs
@@ -1102,7 +1102,9 @@ impl PendingUdpVerdicts {
                 .abort_pending_udp_flow(&identity.tuples(), identity.decision_token)
                 .map_err(|error| self.fatal_error("abort pending flow", error.to_string()))?;
             let mismatch = match result {
-                UdpDecisionCommitResult::Applied | UdpDecisionCommitResult::Missing => None,
+                UdpDecisionCommitResult::Applied
+                | UdpDecisionCommitResult::Missing
+                | UdpDecisionCommitResult::Superseded => None,
                 UdpDecisionCommitResult::TokenMismatch => {
                     self.stats.record_udp_nfqueue_token_mismatch();
                     Some(UdpDecisionCommitResult::TokenMismatch)
@@ -1138,9 +1140,11 @@ impl PendingUdpVerdicts {
                 Err(fatal.into())
             }
             None => Ok(()),
-            Some(UdpDecisionCommitResult::Applied | UdpDecisionCommitResult::Missing) => {
-                unreachable!("applied and missing aborts are not mismatches")
-            }
+            Some(
+                UdpDecisionCommitResult::Applied
+                | UdpDecisionCommitResult::Missing
+                | UdpDecisionCommitResult::Superseded,
+            ) => unreachable!("successful abort results are not mismatches"),
         }
     }
 

--- a/crates/honk-core/src/control/tests.rs
+++ b/crates/honk-core/src/control/tests.rs
@@ -3807,7 +3807,7 @@ async fn udp_removal_worker_retires_legacy_token_zero_conn_state() {
 }
 
 #[tokio::test]
-async fn udp_removal_worker_escalates_token_mismatch() {
+async fn udp_removal_worker_acknowledges_superseding_token() {
     use honk_ebpf_common::conn::{ConnState, UdpDecisionState};
 
     let client: SocketAddr = "10.0.0.1:53000".parse().unwrap();
@@ -3820,6 +3820,74 @@ async fn udp_removal_worker_escalates_token_mismatch() {
             state: UdpDecisionState::Pending as u8,
             decision_token: 42,
             ..ConnState::default()
+        },
+    )
+    .unwrap();
+    let backend: Arc<RwLock<Box<dyn EbpfBackend>>> = Arc::new(RwLock::new(Box::new(mock)));
+    let pool = Arc::new(UdpEndpointPool::new());
+    let (fatal_tx, mut fatal_rx) = tokio::sync::mpsc::unbounded_channel();
+    let removal_task = spawn_udp_removal_worker(
+        Arc::clone(&pool),
+        Arc::clone(&backend),
+        Arc::new(ConnectionTracker::new()),
+        fatal_tx,
+    );
+    let lease = match pool.reserve_owned_or_enqueue(
+        client,
+        dst,
+        Bytes::from_static(b"held datagram"),
+        41,
+        None,
+        Arc::new(tokio::sync::Semaphore::new(1))
+            .try_acquire_owned()
+            .unwrap(),
+        &StatsManager::new(),
+    ) {
+        udp_endpoint::EndpointReservation::Initializing(lease) => lease,
+        _ => panic!("expected an initializing lease"),
+    };
+
+    drop(lease);
+    assert!(pool.wait_for_retirements().await);
+    assert!(pool.is_empty());
+    assert_eq!(
+        backend
+            .read()
+            .await
+            .udp_conn_state_lookup(&key)
+            .unwrap()
+            .unwrap()
+            .decision_token,
+        42
+    );
+    assert!(fatal_rx.try_recv().is_err());
+
+    assert!(pool.shutdown().await);
+    removal_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn udp_removal_worker_escalates_auxiliary_token_mismatch() {
+    use honk_ebpf_common::conn::{ConnState, UdpDecisionState};
+    use honk_ebpf_common::{RedirectEntry, RedirectTuple};
+
+    let client: SocketAddr = "10.0.0.1:53000".parse().unwrap();
+    let dst: SocketAddr = "203.0.113.1:443".parse().unwrap();
+    let key = connection::build_tuples_key(dst.ip(), dst.port(), client.ip(), client.port(), 17);
+    let mut mock = crate::ebpf::mock::MockEbpfBackend::new();
+    mock.seed_staged_udp_flow(
+        &key,
+        ConnState {
+            state: UdpDecisionState::Pending as u8,
+            decision_token: 41,
+            ..ConnState::default()
+        },
+    );
+    mock.redirect_track_store(
+        &RedirectTuple::from_tuples(&key),
+        &RedirectEntry {
+            decision_token: 42,
+            ..RedirectEntry::default()
         },
     )
     .unwrap();
@@ -3850,7 +3918,7 @@ async fn udp_removal_worker_escalates_token_mismatch() {
     drop(lease);
     let fatal = tokio::time::timeout(Duration::from_secs(1), fatal_rx.recv())
         .await
-        .expect("removal mismatch must reach supervision")
+        .expect("auxiliary mismatch must reach supervision")
         .expect("removal fatal channel must remain open");
     assert!(fatal.to_string().contains("identity mismatch"));
 

--- a/crates/honk-core/src/ebpf/mock.rs
+++ b/crates/honk-core/src/ebpf/mock.rs
@@ -247,7 +247,11 @@ impl MockEbpfBackend {
             return Ok(UdpDecisionCommitResult::Missing);
         };
         if state.decision_token != token {
-            return Ok(UdpDecisionCommitResult::TokenMismatch);
+            return Ok(if pending_only {
+                UdpDecisionCommitResult::TokenMismatch
+            } else {
+                UdpDecisionCommitResult::Superseded
+            });
         }
         let state_allowed = if pending_only {
             state.state == UdpDecisionState::Preparing as u8
@@ -967,7 +971,7 @@ impl EbpfBackend for MockEbpfBackend {
             return Ok(UdpDecisionCommitResult::Missing);
         };
         if !udp_state_is_legacy_userspace_owned(&state) {
-            return Ok(UdpDecisionCommitResult::StateMismatch);
+            return Ok(UdpDecisionCommitResult::Superseded);
         }
         if self.udp_conn_states.remove(&key_bytes).is_some() {
             super::USERSPACE_CONN_STATE_DELETES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -1781,7 +1785,7 @@ mod tests {
                 .unwrap();
             assert_eq!(
                 backend.remove_udp_flow(&key, 0).unwrap(),
-                UdpDecisionCommitResult::StateMismatch
+                UdpDecisionCommitResult::Superseded
             );
             assert!(backend.udp_conn_state_lookup(&key).unwrap().is_some());
         }

--- a/crates/honk-core/src/ebpf/mod.rs
+++ b/crates/honk-core/src/ebpf/mod.rs
@@ -96,6 +96,8 @@ pub enum UdpDecisionTransition {
 pub enum UdpDecisionCommitResult {
     Applied,
     Missing,
+    /// A newer kernel incarnation owns the tuple; nothing was removed.
+    Superseded,
     TokenMismatch,
     StateMismatch,
 }
@@ -533,7 +535,8 @@ pub trait EbpfBackend: Send + Sync {
 
     /// Retire a userspace-owned flow. Nonzero tokens remove only the matching
     /// staged/proxy incarnation and auxiliaries; zero removes only a legacy
-    /// published, non-offloaded forward state. Kernel handoffs are retained.
+    /// published, non-offloaded forward state. Kernel handoffs and superseding
+    /// tuple incarnations are retained.
     fn remove_udp_flow(
         &mut self,
         key: &TuplesKey,

--- a/crates/honk-core/src/ebpf/real/mod.rs
+++ b/crates/honk-core/src/ebpf/real/mod.rs
@@ -460,7 +460,11 @@ impl RealEbpfBackend {
                 return Ok(UdpDecisionCommitResult::Missing);
             };
             if state.decision_token != token {
-                return Ok(UdpDecisionCommitResult::TokenMismatch);
+                return Ok(if pending_only {
+                    UdpDecisionCommitResult::TokenMismatch
+                } else {
+                    UdpDecisionCommitResult::Superseded
+                });
             }
             let state_allowed = if pending_only {
                 state.state == UdpDecisionState::Preparing as u8
@@ -963,7 +967,7 @@ impl EbpfBackend for RealEbpfBackend {
                 return Ok(UdpDecisionCommitResult::Missing);
             };
             if !udp_state_is_legacy_userspace_owned(&state) {
-                return Ok(UdpDecisionCommitResult::StateMismatch);
+                return Ok(UdpDecisionCommitResult::Superseded);
             }
             if !backend.hash_remove_present::<_, ConnState>("CONN_STATE_MAP", key)? {
                 return Ok(UdpDecisionCommitResult::Missing);

--- a/crates/honk-core/src/ebpf/real/tests.rs
+++ b/crates/honk-core/src/ebpf/real/tests.rs
@@ -81,7 +81,7 @@ async fn link_lifecycle_holds_links_and_rebinds_primary_wan() {
         backend
             .remove_udp_flow(&staged_key, 41)
             .expect("stale retirement result"),
-        UdpDecisionCommitResult::TokenMismatch
+        UdpDecisionCommitResult::Superseded
     );
     assert_eq!(
         backend


### PR DESCRIPTION
## Problem
A 120-second UDP tuple reuse can replace an expired conn-state before the old endpoint retirement worker runs. The conditional removal correctly preserved the new state, but reported it as an identity mismatch and terminated honk-core.

## Fix
Classify newer token and terminal legacy states as superseded, acknowledge the old endpoint tombstone, and retain fatal handling for inconsistent auxiliary-map tokens.

## Verification
- Focused supersession and auxiliary-mismatch regressions
- Workspace clippy with warnings denied
- Workspace release test gate: 1,449 passed
- eBPF-feature regression build
- Root-gated real backend lifecycle test