### PR TITLE
perf(control): remove redundant hot-path work

### DIFF
--- a/crates/honk-core/benches/dns.rs
+++ b/crates/honk-core/benches/dns.rs
@@ -18,6 +18,7 @@ criterion_group!(
     legacy::bench_udp_pool_exchange,
     legacy_framing::bench_length_prefix_roundtrip,
     architecture::bench_typed_key_build,
+    architecture::bench_dns_udp_validation_profile,
     architecture::bench_warmed_forwarder_hits,
     architecture::bench_projection_replacement,
     architecture::bench_policy_evaluation,

--- a/crates/honk-core/benches/dns/architecture.rs
+++ b/crates/honk-core/benches/dns/architecture.rs
@@ -11,7 +11,7 @@ use honk_config::dns::{
 use honk_core::dns::DnsResolver;
 use honk_core::dns::bench_support::{
     CacheKeyBenchmarkInput, ProjectionBenchmark, RuntimeBenchmark, observability_snapshot_checksum,
-    record_observability_event,
+    record_observability_event, validate_udp_query_profile,
 };
 use honk_core::dns::cache::DnsCache;
 use honk_core::dns::forwarder::build_dns_query;
@@ -97,6 +97,13 @@ pub(super) fn bench_warmed_forwarder_hits(c: &mut Criterion) {
         });
     });
     group.finish();
+}
+
+pub(super) fn bench_dns_udp_validation_profile(c: &mut Criterion) {
+    let query = build_dns_query("www.example.com", 1);
+    c.bench_function("dns_udp_validation_profile", |b| {
+        b.iter(|| black_box(validate_udp_query_profile(black_box(&query))));
+    });
 }
 
 pub(super) fn bench_projection_replacement(c: &mut Criterion) {

--- a/crates/honk-core/benches/udp.rs
+++ b/crates/honk-core/benches/udp.rs
@@ -13,6 +13,19 @@ const STEADY_ENQUEUE_ITERATIONS: usize = 1_000_000;
 const RESERVE_ROLLBACK_ITERATIONS: usize = 10_000;
 const HISTOGRAM_ITERATIONS: usize = 1_000_000;
 const QUEUE_SATURATION_OPERATIONS: u64 = 64;
+const FIRST_REPLY_METRIC_ITERATIONS: usize = 1_000_000;
+
+fn bench_first_reply_metric_hot(c: &mut Criterion) {
+    let mut group = c.benchmark_group("udp_first_reply_metric_hot");
+    group.sample_size(10);
+    group.throughput(Throughput::Elements(FIRST_REPLY_METRIC_ITERATIONS as u64));
+    group.bench_function("one_million", |b| {
+        b.iter(|| {
+            bench_support::first_reply_metric_hot_batch(black_box(FIRST_REPLY_METRIC_ITERATIONS))
+        });
+    });
+    group.finish();
+}
 
 fn bench_steady_enqueue(c: &mut Criterion) {
     let mut group = c.benchmark_group("udp_steady_enqueue_128b");
@@ -77,5 +90,6 @@ criterion_group!(
     bench_reserve_rollback,
     bench_histogram_record_snapshot,
     bench_queue_saturation,
+    bench_first_reply_metric_hot,
 );
 criterion_main!(benches);

--- a/crates/honk-core/src/control/connection.rs
+++ b/crates/honk-core/src/control/connection.rs
@@ -587,19 +587,20 @@ impl ControlPlaneHandle {
             return Ok(());
         }
 
-        let dial_mode = {
+        let (dial_mode, connect_timeout, dns_resolve_timeout, overall_dial_timeout) = {
             let config = self.config.read().await;
-            config
-                .global
-                .dial_mode
-                .parse::<DialMode>()
-                .ok()
-                .unwrap_or(DialMode::DomainPlusPlus)
-        };
-
-        let connect_timeout = {
-            let config = self.config.read().await;
-            std::time::Duration::from_millis(config.global.connect_timeout_ms)
+            let connect_timeout_ms = config.global.connect_timeout_ms;
+            (
+                config
+                    .global
+                    .dial_mode
+                    .parse::<DialMode>()
+                    .ok()
+                    .unwrap_or(DialMode::DomainPlusPlus),
+                Duration::from_millis(connect_timeout_ms),
+                Duration::from_millis(config.global.dns_resolve_timeout_ms),
+                Duration::from_millis((connect_timeout_ms.max(1000) * 4).max(10000)),
+            )
         };
 
         // Skip sniffing if eBPF routing already decided with must flag
@@ -678,6 +679,20 @@ impl ControlPlaneHandle {
         // prefer all 'direct' need handoff, even if in complex chain select 'direct' outbound
         let reroute_by_sniffed_domain =
             Self::should_reroute_sniffed_domain(dial_mode, domain.as_deref(), handoff.as_ref());
+        let (userspace_outbound, userspace_must, matched_rule) = {
+            let router = self.router.read().await;
+            match router.route_full(&conn_info) {
+                Some(matched) => (
+                    matched.outbound_name.to_owned(),
+                    matched.must,
+                    Some((
+                        matched.rule_type.to_owned(),
+                        matched.rule_payload.to_owned(),
+                    )),
+                ),
+                None => (router.default_outbound().to_owned(), false, None),
+            }
+        };
         let (outbound_name, must) = if let Some(ho) = &handoff {
             debug!(
                 "eBPF handoff: outbound={}, mark=0x{:x}, dscp={}",
@@ -685,26 +700,12 @@ impl ControlPlaneHandle {
             );
             if ho.outbound == OutboundIndex::ControlPlaneRouting as u8 || reroute_by_sniffed_domain
             {
-                let router = self.router.read().await;
-                let (name, must) = router.route_with_must(&conn_info);
-                (name.to_string(), must)
+                (userspace_outbound, userspace_must)
             } else {
                 (self.outbound_index_to_name(ho.outbound).await, ho.must != 0)
             }
         } else {
-            let router = self.router.read().await;
-            let (name, must) = router.route_with_must(&conn_info);
-            (name.to_string(), must)
-        };
-
-        // Matched-rule identity for the /connections display. The userspace
-        // Router mirrors the eBPF-compiled rules, so this names eBPF-decided
-        // flows as well (display-only; the handoff decision above stands).
-        let matched_rule = {
-            let router = self.router.read().await;
-            router
-                .route_full(&conn_info)
-                .map(|m| (m.rule_type.to_string(), m.rule_payload.to_string()))
+            (userspace_outbound, userspace_must)
         };
 
         // Clash mode override (Direct/Global); no-op when the clash API is
@@ -842,10 +843,9 @@ impl ControlPlaneHandle {
                 // Resolve both IPv4 and IPv6, preferring the version that
                 // matches original_dst. Apply configurable timeout.
                 let is_v6 = original_dst.is_ipv6();
-                let dns_timeout = std::time::Duration::from_millis(
-                    self.config.read().await.global.dns_resolve_timeout_ms,
-                );
-                match tokio::time::timeout(dns_timeout, self.dns_resolver.resolve(domain)).await {
+                match tokio::time::timeout(dns_resolve_timeout, self.dns_resolver.resolve(domain))
+                    .await
+                {
                     Ok(Ok(resolved)) => {
                         // Prefer AAAA records for v6 original_dst, A records for v4.
                         let preferred_ip = if is_v6 {
@@ -897,13 +897,14 @@ impl ControlPlaneHandle {
                 target_domain.clone(),
                 &outbound_name,
                 connect_timeout,
+                overall_dial_timeout,
                 Arc::clone(&runtime_generation),
                 ipver,
                 cold_urltest,
             )
             .await;
-        let (mut proxy_stream, node): (crate::proxy::ProxyStream, Node) = match raced {
-            Some((stream, idx)) => (stream, candidates[idx].clone()),
+        let (mut proxy_stream, node) = match raced {
+            Some(pair) => pair,
             None => {
                 // Exactly one retry when the just-reported failure may have
                 // moved the plan (URLTest strike demotion). Same-plan
@@ -927,12 +928,12 @@ impl ControlPlaneHandle {
                                 target_domain.clone(),
                                 &outbound_name,
                                 connect_timeout,
+                                overall_dial_timeout,
                                 Arc::clone(&runtime_generation),
                                 ipver,
                                 false,
                             )
-                            .await
-                            .map(|(stream, idx)| (stream, nodes[idx].clone()));
+                            .await;
                     }
                 }
                 match retried {
@@ -1350,7 +1351,7 @@ impl ControlPlaneHandle {
         if !lease.dns_checked() {
             match self
                 .dns_controller
-                .handle_udp_dns(&data, client_addr, original_dst)
+                .handle_udp_dns(&data, client_addr, original_dst, None)
                 .await
             {
                 Ok(true) => {
@@ -1862,9 +1863,9 @@ impl ControlPlaneHandle {
     /// cancelled, and fresh connections for losers are deposited into the
     /// pool (≤2 per race, off the critical path). Failures are reported via
     /// traffic-based thresholds to avoid killing a node from a single
-    /// transient failure. Returns the winning stream and its index into
-    /// `candidates`; `None` means every candidate failed (already logged) —
-    /// close-accounting stays with the caller.
+    /// transient failure. Returns the winning stream and its already-owned
+    /// node; `None` means every candidate failed (already logged) — close
+    /// accounting stays with the caller.
     #[allow(clippy::too_many_arguments)]
     async fn race_candidates(
         &self,
@@ -1873,16 +1874,12 @@ impl ControlPlaneHandle {
         target_domain: Option<String>,
         outbound_name: &str,
         connect_timeout: Duration,
+        overall_dial_timeout: Duration,
         runtime_generation: Arc<honk_outbound::runtime::OutboundRuntimeRegistry>,
         ipver: IpVersion,
         cold_urltest: bool,
-    ) -> Option<(crate::proxy::ProxyStream, usize)> {
-        let dial_deadline = {
-            let config = self.config.read().await;
-            let per_node_ms = config.global.connect_timeout_ms.max(1000);
-            let overall_ms = (per_node_ms * 4).max(10000);
-            tokio::time::Instant::now() + std::time::Duration::from_millis(overall_ms)
-        };
+    ) -> Option<(crate::proxy::ProxyStream, Node)> {
+        let dial_deadline = tokio::time::Instant::now() + overall_dial_timeout;
         let ctx = self.clone();
         let target = resolved_target;
         let outbound = outbound_name.to_string();
@@ -1922,14 +1919,14 @@ impl ControlPlaneHandle {
                     ))
                 });
                 let elapsed = start.elapsed();
-                (result, idx, elapsed)
+                (result, idx, elapsed, node)
             });
         }
 
         let mut last_err: Option<(String, String)> = None;
         let mut first_err: Option<(String, String)> = None;
         let mut timeout_count: usize = 0;
-        let mut winner: Option<(crate::proxy::ProxyStream, usize)> = None;
+        let mut winner: Option<(crate::proxy::ProxyStream, usize, Node)> = None;
         let mut remaining = set.len();
 
         loop {
@@ -1939,8 +1936,7 @@ impl ControlPlaneHandle {
             remaining -= 1;
             match tokio::time::timeout_at(dial_deadline, set.join_next()).await {
                 Ok(Some(task_result)) => match task_result {
-                    Ok((Ok((stream, fresh)), idx, elapsed)) => {
-                        let node = &candidates[idx];
+                    Ok((Ok((stream, fresh)), idx, elapsed, node)) => {
                         ctx.alive_set
                             .report_available_traffic(node.id, ProbeDomain::Tcp, ipver);
                         // Real-traffic degradation fast path: a fresh
@@ -1957,12 +1953,11 @@ impl ControlPlaneHandle {
                         {
                             ctx.alive_set.notify_check_tcp(node.id);
                         }
-                        winner = Some((stream, idx));
+                        winner = Some((stream, idx, node));
                         set.abort_all();
                         break;
                     }
-                    Ok((Err(e), idx, _elapsed)) => {
-                        let node = &candidates[idx];
+                    Ok((Err(e), _idx, _elapsed, node)) => {
                         debug!("Parallel dial to {} failed: {}", node.name, e);
                         ctx.stats.record_error(&outbound);
                         ctx.alive_set
@@ -2007,7 +2002,7 @@ impl ControlPlaneHandle {
         // included, paid off the critical path); others get a bare TCP.
         if outbound_name != "direct"
             && outbound_name != "block"
-            && let Some((_, winning_idx)) = &winner
+            && let Some((_, winning_idx, _)) = &winner
         {
             let mut deposit_count = 0u32;
             for (idx, node) in candidates.iter().enumerate() {
@@ -2091,7 +2086,7 @@ impl ControlPlaneHandle {
         }
 
         match winner {
-            Some((s, idx)) => Some((s, idx)),
+            Some((stream, _, node)) => Some((stream, node)),
             None => {
                 if let Some((last_msg, last_name)) = last_err {
                     let (first_msg, first_name) =

--- a/crates/honk-core/src/control/dns_control.rs
+++ b/crates/honk-core/src/control/dns_control.rs
@@ -190,7 +190,7 @@ impl DnsController {
         {
             Ok((outcome, runtime)) => {
                 self.submit_projection(runtime.runtime(), &outcome);
-                outcome.rendered().to_vec()
+                outcome.into_rendered()
             }
             Err(error)
                 if error

--- a/crates/honk-core/src/control/dns_control/tests/udp.rs
+++ b/crates/honk-core/src/control/dns_control/tests/udp.rs
@@ -29,7 +29,7 @@ async fn udp_overload_is_refused_while_permit_owner_is_in_flight() {
         let client_addr = first_client.local_addr().expect("first client address");
         tokio::spawn(async move {
             controller
-                .handle_udp_dns(&first_query, client_addr, original_dst)
+                .handle_udp_dns(&first_query, client_addr, original_dst, None)
                 .await
         })
     };
@@ -42,6 +42,7 @@ async fn udp_overload_is_refused_while_permit_owner_is_in_flight() {
                 &second_query,
                 second_client.local_addr().expect("second client address"),
                 original_dst,
+                None,
             )
             .await
             .expect("second handler")

--- a/crates/honk-core/src/control/dns_control/transport.rs
+++ b/crates/honk-core/src/control/dns_control/transport.rs
@@ -1,5 +1,7 @@
 use super::DnsController;
-use crate::dns::query::{IngressProfile, is_exact_dns_query, udp_ingress_profile};
+use crate::dns::query::{
+    IngressProfile, ValidatedDnsQuery, is_exact_dns_query, validate_exact_dns_query,
+};
 use crate::dns::response::build_dns_refused;
 use crate::dns::transport::{read_length_prefixed_into, write_length_prefixed};
 use std::net::SocketAddr;
@@ -11,16 +13,19 @@ pub(super) const TCP_DNS_IO_TIMEOUT: Duration = Duration::from_secs(30);
 
 impl DnsController {
     /// Handle a UDP DNS query from TPROXY.
-    pub async fn handle_udp_dns(
+    pub(crate) async fn handle_udp_dns(
         &self,
         data: &[u8],
         client_addr: SocketAddr,
         original_dst: SocketAddr,
+        validated: Option<ValidatedDnsQuery>,
     ) -> anyhow::Result<bool> {
-        if original_dst.port() != 53 || !is_exact_dns_query(data) {
+        if original_dst.port() != 53 {
             return Ok(false);
         }
-
+        let Some(validated) = validated.or_else(|| validate_exact_dns_query(data)) else {
+            return Ok(false);
+        };
         // Keep the permit through the reply write so the limit bounds the
         // complete request lifecycle rather than only upstream resolution.
         let _permit = match self.try_acquire_query() {
@@ -40,7 +45,7 @@ impl DnsController {
 
         debug!(%client_addr, "DNS controller (UDP): forwarding query");
         let response = self
-            .answer_query(data, Some(original_dst), udp_ingress_profile(data))
+            .answer_query(data, Some(original_dst), validated.ingress())
             .await;
         let _ =
             super::super::send_udp_reply_from_orig_dst(&response, client_addr, original_dst).await;

--- a/crates/honk-core/src/control/dns_listener.rs
+++ b/crates/honk-core/src/control/dns_listener.rs
@@ -7,7 +7,7 @@
 use super::{ConnectionGuard, try_admit_udp_slow_path};
 use crate::control::dns_control::DnsController;
 use crate::control::drain::DrainTracker;
-use crate::dns::query::{IngressProfile, udp_ingress_profile};
+use crate::dns::query::validate_exact_dns_query;
 use crate::stats::StatsManager;
 use honk_config::dns::DnsBindEndpoint;
 use std::io;
@@ -19,7 +19,6 @@ use tokio::task::JoinSet;
 use tracing::{debug, warn};
 
 const MAX_UDP_DNS_MESSAGE: usize = u16::MAX as usize;
-const MAX_STANDALONE_UDP_RESPONSE: u16 = 1232;
 const EPHEMERAL_BIND_ATTEMPTS: usize = 32;
 const fn standalone_tcp_capacity(total_connection_capacity: usize) -> usize {
     if total_connection_capacity == 0 {
@@ -27,15 +26,6 @@ const fn standalone_tcp_capacity(total_connection_capacity: usize) -> usize {
     } else {
         let quarter = total_connection_capacity / 4;
         if quarter == 0 { 1 } else { quarter }
-    }
-}
-
-fn standalone_udp_ingress_profile(query: &[u8]) -> IngressProfile {
-    let IngressProfile::Udp { advertised_size } = udp_ingress_profile(query) else {
-        unreachable!("UDP ingress parser always returns a UDP profile")
-    };
-    IngressProfile::Udp {
-        advertised_size: advertised_size.clamp(512, MAX_STANDALONE_UDP_RESPONSE),
     }
 }
 
@@ -354,6 +344,13 @@ async fn run_udp_supervisor(
 ) {
     let mut buffer = [0u8; MAX_UDP_DNS_MESSAGE];
     let mut children = JoinSet::new();
+    let local_addr = match socket.local_addr() {
+        Ok(local_addr) => local_addr,
+        Err(error) => {
+            warn!(error_kind = ?error.kind(), "standalone UDP DNS receive failed");
+            return;
+        }
+    };
 
     loop {
         tokio::select! {
@@ -366,7 +363,7 @@ async fn run_udp_supervisor(
             completed = children.join_next(), if !children.is_empty() => {
                 log_child_result(completed, "UDP query");
             }
-            received = super::sockets::recv_from_with_orig_dst(socket.as_ref(), &mut buffer) => {
+            received = super::sockets::recv_from_with_orig_dst(socket.as_ref(), local_addr, &mut buffer) => {
                 let (length, client_addr, meta) = match received {
                     Ok(received) => received,
                     Err(error) => {
@@ -404,18 +401,18 @@ async fn run_udp_supervisor(
                         continue;
                     }
                 };
-                if !crate::dns::query::is_exact_dns_query(query) {
+                let Some(validated) = validate_exact_dns_query(query) else {
                     let response = minimal_dns_error_response(query, 1);
                     if let Err(error) = send_bound_udp_response(socket.as_ref(), &response, response_source, client_addr).await {
                         debug!(error_kind = ?error.kind(), %client_addr, "standalone UDP DNS FORMERR send failed");
                     }
                     continue;
-                }
+                };
 
                 // All bounded admission is owned before the datagram copy and
                 // child allocation. Register the drain guard before spawn so a
                 // simultaneous shutdown cannot observe an untracked query.
-                let ingress = standalone_udp_ingress_profile(query);
+                let ingress = validated.ingress();
                 let query = query.to_vec();
                 let guard = ConnectionGuard::new(Arc::clone(&drain));
                 let child_socket = Arc::clone(&socket);
@@ -735,7 +732,7 @@ mod tests {
     }
 
     #[test]
-    fn standalone_listener_caps_are_bounded() {
+    fn standalone_listener_capacities_and_profiles_are_exact() {
         assert_eq!(standalone_tcp_capacity(0), 0);
         assert_eq!(standalone_tcp_capacity(1), 1);
         assert_eq!(standalone_tcp_capacity(8), 2);
@@ -744,19 +741,17 @@ mod tests {
         wire[10..12].copy_from_slice(&1u16.to_be_bytes());
         wire.extend_from_slice(&[0, 0, 41, 0xff, 0xff, 0, 0, 0, 0, 0, 0]);
         assert_eq!(
-            standalone_udp_ingress_profile(&wire),
-            IngressProfile::Udp {
-                advertised_size: MAX_STANDALONE_UDP_RESPONSE
+            validate_exact_dns_query(&wire).unwrap().ingress(),
+            crate::dns::query::IngressProfile::Udp {
+                advertised_size: u16::MAX
             }
         );
         let mut undersized = wire.clone();
         let opt_class = undersized.len() - 8;
         undersized[opt_class..opt_class + 2].copy_from_slice(&1u16.to_be_bytes());
         assert_eq!(
-            standalone_udp_ingress_profile(&undersized),
-            IngressProfile::Udp {
-                advertised_size: 512
-            }
+            validate_exact_dns_query(&undersized).unwrap().ingress(),
+            crate::dns::query::IngressProfile::Udp { advertised_size: 1 }
         );
 
         let mut opcode_query = query("opcode.example", 0x5252);

--- a/crates/honk-core/src/control/mod.rs
+++ b/crates/honk-core/src/control/mod.rs
@@ -24,6 +24,7 @@ use crate::control::packet_sniffer::PacketSnifferPool;
 use crate::control::routing_matcher::DOMAIN_BITMAPS;
 use crate::control::udp_endpoint::{EndpointReservation, UdpEndpointPool, UdpInitLease};
 use crate::dns::DnsResolver;
+use crate::dns::query::{ValidatedDnsQuery, validate_exact_dns_query};
 use crate::ebpf::EbpfBackend;
 use crate::ebpf::maps::cidr_to_lpm_key;
 use crate::group::{GroupManager, SharedGroupManager};
@@ -2367,6 +2368,7 @@ enum UdpSlowPathWork {
     DnsThenMaybeInitialize {
         permit: tokio::sync::OwnedSemaphorePermit,
         data: Bytes,
+        validated: ValidatedDnsQuery,
     },
     /// Fully handled in the receive loop (enqueued / rejected / dropped).
     Done,
@@ -2385,16 +2387,20 @@ fn begin_udp_slow_path(
     src_addr: SocketAddr,
     original_dst: SocketAddr,
     data: &[u8],
+    validated_dns: Option<ValidatedDnsQuery>,
 ) -> UdpSlowPathWork {
     let Some(permit) = try_admit_udp_slow_path(stats, concurrency_limit) else {
         return UdpSlowPathWork::Done;
     };
-    if original_dst.port() == 53 && crate::dns::query::is_exact_dns_query(data) {
+    if original_dst.port() == 53
+        && let Some(validated) = validated_dns
+    {
         // Permit is acquired before the heap copy required to leave the
         // receive buffer for a permit-bounded DNS task.
         return UdpSlowPathWork::DnsThenMaybeInitialize {
             permit,
             data: Bytes::copy_from_slice(data),
+            validated,
         };
     }
     match pool.reserve_or_enqueue(src_addr, original_dst, data, permit, stats) {
@@ -2423,6 +2429,7 @@ async fn complete_udp_dns_slow_path(
     context: UdpDnsSlowPathContext<'_>,
     permit: tokio::sync::OwnedSemaphorePermit,
     data: &[u8],
+    validated: ValidatedDnsQuery,
 ) -> Option<UdpInitLease> {
     let UdpDnsSlowPathContext {
         pool,
@@ -2432,7 +2439,7 @@ async fn complete_udp_dns_slow_path(
         original_dst,
     } = context;
     match dns_controller
-        .handle_udp_dns(data, src_addr, original_dst)
+        .handle_udp_dns(data, src_addr, original_dst, Some(validated))
         .await
     {
         Ok(true) => return None,
@@ -2484,16 +2491,28 @@ struct UdpLoopState {
 /// run in parallel across runtime workers.
 async fn udp_listener_loop(state: UdpLoopState, socket: Arc<UdpSocket>, family: &'static str) {
     let mut buf = vec![0u8; 64 * 1024];
+    let local_addr = match socket.local_addr() {
+        Ok(local_addr) => local_addr,
+        Err(error) => {
+            error!("{} UDP recv error: {}", family, error);
+            return;
+        }
+    };
     loop {
-        match recv_from_with_orig_dst(&socket, &mut buf).await {
+        match recv_from_with_orig_dst(&socket, local_addr, &mut buf).await {
             Ok((n, src_addr, recv_meta)) => {
-                let Some(original_dst) = udp_original_dst(&recv_meta, &buf[..n]) else {
+                let Some(destination) = udp_original_dst(&recv_meta, &buf[..n]) else {
                     debug!(
                         "Dropping {} UDP from {} without original-destination provenance",
                         family, src_addr
                     );
                     continue;
                 };
+                let original_dst = destination.address;
+                let mut validated_dns = destination.validated_dns;
+                if original_dst.port() == 53 && validated_dns.is_none() {
+                    validated_dns = validate_exact_dns_query(&buf[..n]);
+                }
                 if !accepts_transparent_connection(&state.drain) {
                     state.stats.record_udp_slow_permit_closed();
                     continue;
@@ -2506,12 +2525,13 @@ async fn udp_listener_loop(state: UdpLoopState, socket: Arc<UdpSocket>, family: 
                     &buf[..n],
                     src_addr,
                     original_dst,
+                    validated_dns,
                 )
                 .await
                 {
                     continue;
                 }
-                dispatch_udp_slow_path(&state, src_addr, original_dst, &buf[..n]);
+                dispatch_udp_slow_path(&state, src_addr, original_dst, &buf[..n], validated_dns);
             }
             Err(e) => error!("{} UDP recv error: {}", family, e),
         }
@@ -2523,13 +2543,13 @@ fn dispatch_udp_slow_path(
     src_addr: SocketAddr,
     original_dst: SocketAddr,
     data: &[u8],
+    validated_dns: Option<ValidatedDnsQuery>,
 ) {
-    let concurrency_limit =
-        if original_dst.port() == 53 && crate::dns::query::is_exact_dns_query(data) {
-            &state.dns_concurrency_limit
-        } else {
-            &state.udp_concurrency_limit
-        };
+    let concurrency_limit = if original_dst.port() == 53 && validated_dns.is_some() {
+        &state.dns_concurrency_limit
+    } else {
+        &state.udp_concurrency_limit
+    };
     match begin_udp_slow_path(
         &state.udp_pool,
         &state.stats,
@@ -2537,6 +2557,7 @@ fn dispatch_udp_slow_path(
         src_addr,
         original_dst,
         data,
+        validated_dns,
     ) {
         UdpSlowPathWork::Done => {}
         UdpSlowPathWork::Initialize(lease) => {
@@ -2552,7 +2573,11 @@ fn dispatch_udp_slow_path(
                 }
             });
         }
-        UdpSlowPathWork::DnsThenMaybeInitialize { permit, data } => {
+        UdpSlowPathWork::DnsThenMaybeInitialize {
+            permit,
+            data,
+            validated,
+        } => {
             let handle = state.handle.clone();
             let guard = ConnectionGuard::new(Arc::clone(&state.drain));
             let pool = Arc::clone(&state.udp_pool);
@@ -2573,6 +2598,7 @@ fn dispatch_udp_slow_path(
                     },
                     permit,
                     &data,
+                    validated,
                 )
                 .await
                 else {
@@ -2600,9 +2626,17 @@ fn reserve_udp_slow_path(
     original_dst: SocketAddr,
     data: &[u8],
 ) -> Option<UdpInitLease> {
-    match begin_udp_slow_path(pool, stats, concurrency_limit, src_addr, original_dst, data) {
+    match begin_udp_slow_path(
+        pool,
+        stats,
+        concurrency_limit,
+        src_addr,
+        original_dst,
+        data,
+        None,
+    ) {
         UdpSlowPathWork::Initialize(lease) => Some(lease),
-        UdpSlowPathWork::DnsThenMaybeInitialize { permit, data } => {
+        UdpSlowPathWork::DnsThenMaybeInitialize { permit, data, .. } => {
             match pool.reserve_or_enqueue(src_addr, original_dst, &data, permit, stats) {
                 EndpointReservation::Initializing(lease) => Some(lease),
                 _ => None,

--- a/crates/honk-core/src/control/sockets.rs
+++ b/crates/honk-core/src/control/sockets.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::dns::query::is_exact_dns_query;
+use crate::dns::query::{ValidatedDnsQuery, validate_exact_dns_query};
 
 #[cfg(target_os = "linux")]
 const IPV6_ORIGDSTADDR_OPT: libc::c_int = 74;
@@ -606,9 +606,9 @@ pub(super) struct UdpRecvMeta {
 /// fallbacks by [`udp_original_dst`].
 pub(super) async fn recv_from_with_orig_dst(
     socket: &UdpSocket,
+    local_addr: SocketAddr,
     buf: &mut [u8],
 ) -> io::Result<(usize, SocketAddr, UdpRecvMeta)> {
-    let local_addr = socket.local_addr()?;
     socket
         .async_io(Interest::READABLE, || {
             recvmsg_origdst(socket.as_raw_fd(), buf, local_addr)
@@ -871,23 +871,41 @@ pub(super) fn packet_dst_ip_from_cmsg(
     packet_info_from_cmsg(cmsg_level, cmsg_type, data).map(|(ip, _)| ip)
 }
 
+#[derive(Clone, Copy, Debug)]
+pub(super) struct UdpOriginalDst {
+    pub(super) address: SocketAddr,
+    pub(super) validated_dns: Option<ValidatedDnsQuery>,
+}
+
 /// Select a real original destination without inventing one from UDP payload
 /// shape. An ORIGDST cmsg is authoritative; PKTINFO can only supply an IP for
 /// a validated DNS query on port 53; a specifically bound listener is the
 /// final fallback. Wildcard listeners with no valid metadata fail closed.
-pub(super) fn udp_original_dst(meta: &UdpRecvMeta, data: &[u8]) -> Option<SocketAddr> {
+pub(super) fn udp_original_dst(meta: &UdpRecvMeta, data: &[u8]) -> Option<UdpOriginalDst> {
     // A present ORIGDST cmsg is authoritative. An unspecified ORIGDST is
     // invalid provenance, so do not downgrade it to pktinfo/local fallback.
     if let Some(original_dst) = meta.original_dst_cmsg {
-        return (!original_dst.ip().is_unspecified()).then_some(original_dst);
+        return (!original_dst.ip().is_unspecified()).then_some(UdpOriginalDst {
+            address: original_dst,
+            validated_dns: None,
+        });
     }
-    if is_exact_dns_query(data)
+
+    let validated_dns = validate_exact_dns_query(data);
+    if let Some(validated_dns) = validated_dns
         && let Some(packet_dst_ip) = meta.packet_dst_ip
         && !packet_dst_ip.is_unspecified()
     {
-        return Some(SocketAddr::new(packet_dst_ip, 53));
+        return Some(UdpOriginalDst {
+            address: SocketAddr::new(packet_dst_ip, 53),
+            validated_dns: Some(validated_dns),
+        });
     }
-    (!meta.local_addr.ip().is_unspecified()).then_some(meta.local_addr)
+
+    (!meta.local_addr.ip().is_unspecified()).then_some(UdpOriginalDst {
+        address: meta.local_addr,
+        validated_dns,
+    })
 }
 
 fn sockaddr_to_std(addr: &libc::sockaddr_storage, len: libc::socklen_t) -> io::Result<SocketAddr> {
@@ -974,6 +992,7 @@ pub(super) async fn udp_fast_path(
     data: &[u8],
     client_addr: SocketAddr,
     original_dst: SocketAddr,
+    validated_dns: Option<ValidatedDnsQuery>,
 ) -> bool {
     // Same drop pre-checks as serve_udp_connection: honk-internal subnet and
     // broadcast/multicast traffic must never be proxied.
@@ -992,10 +1011,8 @@ pub(super) async fn udp_fast_path(
         return true;
     }
 
-    // Only traffic the controller can consume takes the DNS slow path. The
-    // shared strict predicate guards any PKTINFO-derived port 53; DNS-shaped
-    // traffic to every other authoritative port remains ordinary UDP.
-    if original_dst.port() == 53 && is_exact_dns_query(data) {
+    // A carried proof keeps strict validation out of the Ready hot path.
+    if original_dst.port() == 53 && validated_dns.is_some() {
         return false;
     }
 

--- a/crates/honk-core/src/control/tests.rs
+++ b/crates/honk-core/src/control/tests.rs
@@ -1,7 +1,7 @@
 use super::udp_dial::{UdpPrepare, UdpStaggerCallbacks, prepare_udp_plan};
 use super::*;
 use crate::control::udp_endpoint::UdpEndpoint;
-use crate::dns::query::is_exact_dns_query;
+use crate::dns::query::{IngressProfile, is_exact_dns_query, validate_exact_dns_query};
 
 #[cfg(feature = "ebpf")]
 #[test]
@@ -421,7 +421,7 @@ fn udp_original_dst_unspecified_origdst_is_authoritative_and_fails_closed() {
         local_addr: addr("192.0.2.20:5353"),
     };
 
-    assert_eq!(udp_original_dst(&meta, &dns_query_payload()), None);
+    assert!(udp_original_dst(&meta, &dns_query_payload()).is_none());
 }
 
 fn ipv4_origdst(ip: [u8; 4], port: u16) -> libc::sockaddr_in {
@@ -674,16 +674,23 @@ fn strict_dns_query_accepts_complete_query_and_edns_only() {
     edns.extend_from_slice(&[
         0x00, // root NAME
         0x00, 0x29, // TYPE OPT
-        0x10, 0x00, // UDP payload size
+        0x04, 0xd0, // UDP payload size (1232)
         0x00, 0x00, 0x00, 0x00, // extended RCODE/version/flags
         0x00, 0x00, // RDLENGTH
     ]);
     assert!(is_exact_dns_query(&edns));
+    assert_eq!(
+        validate_exact_dns_query(&edns).unwrap().ingress(),
+        IngressProfile::Udp {
+            advertised_size: 1232
+        }
+    );
 
     // A forged QDCOUNT cannot claim a second question that is not encoded.
     let mut forged_question_count = query.clone();
     forged_question_count[4..6].copy_from_slice(&2u16.to_be_bytes());
     assert!(!is_exact_dns_query(&forged_question_count));
+    assert!(validate_exact_dns_query(&forged_question_count).is_none());
 
     // Header record counts require a complete NAME + fixed RR + RDATA.
     let mut truncated_rr = query.clone();
@@ -713,6 +720,7 @@ fn strict_dns_query_accepts_complete_query_and_edns_only() {
     let mut trailing_junk = query;
     trailing_junk.push(0xde);
     assert!(!is_exact_dns_query(&trailing_junk));
+    assert!(validate_exact_dns_query(&trailing_junk).is_none());
 }
 
 fn dns_query_with_qname(qname: &[u8]) -> Vec<u8> {
@@ -801,14 +809,17 @@ async fn udp_dns_controller_declines_root_and_binary_questions() {
 
     let root = dns_query_with_qname(&[0x00]);
     assert!(
-        !controller.handle_udp_dns(&root, client, dst).await.unwrap(),
+        !controller
+            .handle_udp_dns(&root, client, dst, None)
+            .await
+            .unwrap(),
         "root qname must fall back to ordinary UDP"
     );
 
     let binary = dns_query_with_qname(&[0x01, 0xff, 0x00]);
     assert!(
         !controller
-            .handle_udp_dns(&binary, client, dst)
+            .handle_udp_dns(&binary, client, dst, None)
             .await
             .unwrap(),
         "binary qname must fall back to ordinary UDP"
@@ -821,6 +832,7 @@ async fn udp_dns_controller_declines_root_and_binary_questions() {
 fn udp_slow_path_only_forces_strict_dns_to_port_53() {
     let client = addr("10.0.0.1:12345");
     let data = dns_query_payload();
+    let validated = validate_exact_dns_query(&data).unwrap();
 
     let dns_pool = Arc::new(UdpEndpointPool::new());
     let dns_stats = Arc::new(StatsManager::new());
@@ -832,6 +844,7 @@ fn udp_slow_path_only_forces_strict_dns_to_port_53() {
         client,
         addr("203.0.113.53:53"),
         &data,
+        Some(validated),
     );
     assert!(matches!(
         dns_work,
@@ -848,6 +861,7 @@ fn udp_slow_path_only_forces_strict_dns_to_port_53() {
         client,
         addr("203.0.113.53:5353"),
         &data,
+        Some(validated),
     );
     assert!(matches!(ordinary_work, UdpSlowPathWork::Initialize(_)));
 }
@@ -861,10 +875,9 @@ fn udp_original_dst_cmsg_takes_precedence_over_other_metadata() {
         local_addr: addr("192.0.2.10:5353"),
     };
 
-    assert_eq!(
-        udp_original_dst(&meta, b"not a DNS query"),
-        Some(addr("203.0.113.10:4444"))
-    );
+    let destination = udp_original_dst(&meta, b"not a DNS query").unwrap();
+    assert_eq!(destination.address, addr("203.0.113.10:4444"));
+    assert!(destination.validated_dns.is_none());
 }
 
 #[test]
@@ -887,10 +900,9 @@ fn udp_original_dst_uses_ipv4_pktinfo_for_exact_dns_query() {
         packet_ifindex: None,
         local_addr: addr("0.0.0.0:15000"),
     };
-    assert_eq!(
-        udp_original_dst(&meta, &dns_query_payload()),
-        Some(addr("198.51.100.53:53"))
-    );
+    let destination = udp_original_dst(&meta, &dns_query_payload()).unwrap();
+    assert_eq!(destination.address, addr("198.51.100.53:53"));
+    assert!(destination.validated_dns.is_some());
 }
 
 #[test]
@@ -912,10 +924,9 @@ fn udp_original_dst_uses_ipv6_pktinfo_for_exact_dns_query() {
         packet_ifindex: None,
         local_addr: addr("[::]:15000"),
     };
-    assert_eq!(
-        udp_original_dst(&meta, &dns_query_payload()),
-        Some(addr("[2001:db8::53]:53"))
-    );
+    let destination = udp_original_dst(&meta, &dns_query_payload()).unwrap();
+    assert_eq!(destination.address, addr("[2001:db8::53]:53"));
+    assert!(destination.validated_dns.is_some());
 }
 
 #[test]
@@ -928,7 +939,12 @@ fn udp_original_dst_uses_non_wildcard_local_fallback() {
         local_addr,
     };
 
-    assert_eq!(udp_original_dst(&meta, b"opaque UDP"), Some(local_addr));
+    let destination = udp_original_dst(&meta, b"opaque UDP").unwrap();
+    assert_eq!(destination.address, local_addr);
+    assert!(destination.validated_dns.is_none());
+    let dns_destination = udp_original_dst(&meta, &dns_query_payload()).unwrap();
+    assert_eq!(dns_destination.address, local_addr);
+    assert!(dns_destination.validated_dns.is_some());
 }
 
 #[test]
@@ -940,7 +956,7 @@ fn udp_original_dst_fails_closed_for_wildcard_local_without_metadata() {
             packet_ifindex: None,
             local_addr,
         };
-        assert_eq!(udp_original_dst(&meta, b"opaque UDP"), None);
+        assert!(udp_original_dst(&meta, b"opaque UDP").is_none());
     }
 }
 
@@ -969,11 +985,10 @@ fn udp_original_dst_does_not_rewrite_non_exact_dns_payloads() {
         b"random non-53 UDP payload".as_slice(),
     ] {
         assert!(!is_exact_dns_query(payload));
-        assert_eq!(udp_original_dst(&packet_meta, payload), None);
-        assert_eq!(
-            udp_original_dst(&fallback_meta, payload),
-            Some(local_fallback)
-        );
+        assert!(udp_original_dst(&packet_meta, payload).is_none());
+        let destination = udp_original_dst(&fallback_meta, payload).unwrap();
+        assert_eq!(destination.address, local_fallback);
+        assert!(destination.validated_dns.is_none());
     }
 }
 
@@ -983,7 +998,7 @@ async fn udp_fast_path_miss_goes_slow() {
     let stats = StatsManager::new();
     let client = addr("10.0.0.1:12345");
     let dst = addr("203.0.113.1:443");
-    assert!(!udp_fast_path(&pool, &stats, b"hello", client, dst).await);
+    assert!(!udp_fast_path(&pool, &stats, b"hello", client, dst, None).await);
     let udp = stats.udp_snapshot();
     assert_eq!(udp.endpoint_misses, 1);
     assert_eq!(udp.endpoint_hits, 0);
@@ -1014,7 +1029,17 @@ async fn udp_fast_path_hit_enqueues_for_the_endpoint_driver() {
     let mut buf = [0u8; 64];
     // First packet was delivered through the driver start barrier.
     echo.recv_from(&mut buf).await.unwrap();
-    assert!(!udp_fast_path(&pool, &stats, b"wrong-client", addr("10.0.0.2:12345"), dst,).await);
+    assert!(
+        !udp_fast_path(
+            &pool,
+            &stats,
+            b"wrong-client",
+            addr("10.0.0.2:12345"),
+            dst,
+            None,
+        )
+        .await
+    );
     assert!(
         !udp_fast_path(
             &pool,
@@ -1022,6 +1047,7 @@ async fn udp_fast_path_hit_enqueues_for_the_endpoint_driver() {
             b"wrong-destination",
             client,
             addr("203.0.113.2:443"),
+            None,
         )
         .await
     );
@@ -1032,6 +1058,7 @@ async fn udp_fast_path_hit_enqueues_for_the_endpoint_driver() {
             b"wrong-client-port",
             addr("10.0.0.1:12346"),
             dst,
+            None,
         )
         .await
     );
@@ -1042,10 +1069,11 @@ async fn udp_fast_path_hit_enqueues_for_the_endpoint_driver() {
             b"wrong-destination-port",
             client,
             addr("203.0.113.1:444"),
+            None,
         )
         .await
     );
-    assert!(udp_fast_path(&pool, &stats, b"hello", client, dst).await);
+    assert!(udp_fast_path(&pool, &stats, b"hello", client, dst, None).await);
     let udp = stats.udp_snapshot();
     assert_eq!(udp.endpoint_hits, 1);
     assert_eq!(udp.endpoint_misses, 4);
@@ -1080,7 +1108,9 @@ async fn udp_fast_path_dns_goes_slow_even_with_endpoint() {
     )
     .await;
 
-    assert!(!udp_fast_path(&pool, &stats, &dns_query_payload(), client, dst).await);
+    let query = dns_query_payload();
+    let validated = validate_exact_dns_query(&query).unwrap();
+    assert!(!udp_fast_path(&pool, &stats, &query, client, dst, Some(validated)).await);
     let udp = stats.udp_snapshot();
     assert_eq!(udp.endpoint_hits, 0);
     assert_eq!(udp.endpoint_misses, 0);
@@ -1110,7 +1140,17 @@ async fn udp_fast_path_dns_shaped_non53_forwards() {
     let mut buf = [0u8; 64];
     echo.recv_from(&mut buf).await.unwrap();
     let query = dns_query_payload();
-    assert!(udp_fast_path(&pool, &stats, &query, client, dst).await);
+    assert!(
+        udp_fast_path(
+            &pool,
+            &stats,
+            &query,
+            client,
+            dst,
+            validate_exact_dns_query(&query),
+        )
+        .await
+    );
     assert_eq!(stats.udp_snapshot().endpoint_hits, 1);
 
     let (n, _) = tokio::time::timeout(Duration::from_secs(2), echo.recv_from(&mut buf))
@@ -1146,7 +1186,7 @@ async fn udp_fast_path_non_dns_port53_forwards() {
     let mut buf = [0u8; 64];
     echo.recv_from(&mut buf).await.unwrap();
     let garbage = [0u8; 20]; // QR=0 but qdcount=0 — not a DNS query
-    assert!(udp_fast_path(&pool, &stats, &garbage, client, dst).await);
+    assert!(udp_fast_path(&pool, &stats, &garbage, client, dst, None).await);
     assert_eq!(stats.udp_snapshot().endpoint_hits, 1);
 
     let (n, _) = tokio::time::timeout(Duration::from_secs(2), echo.recv_from(&mut buf))
@@ -1165,15 +1205,26 @@ async fn udp_fast_path_drops_internal_and_broadcast() {
     // honk-internal subnets (v4 + v6), either direction.  The v6 check
     // must match the real dae0 addresses (fd00:686f:6e6b::1/2, see the
     // DAENS_* constants in the crate root).
-    assert!(udp_fast_path(&pool, &stats, b"hello", client, addr("169.254.0.11:8080")).await);
-    assert!(udp_fast_path(&pool, &stats, b"hello", addr("169.254.0.1:1234"), dst).await);
     assert!(
         udp_fast_path(
             &pool,
             &stats,
             b"hello",
             client,
-            addr("[fd00:686f:6e6b::1]:8080")
+            addr("169.254.0.11:8080"),
+            None,
+        )
+        .await
+    );
+    assert!(udp_fast_path(&pool, &stats, b"hello", addr("169.254.0.1:1234"), dst, None).await);
+    assert!(
+        udp_fast_path(
+            &pool,
+            &stats,
+            b"hello",
+            client,
+            addr("[fd00:686f:6e6b::1]:8080"),
+            None,
         )
         .await
     );
@@ -1183,20 +1234,42 @@ async fn udp_fast_path_drops_internal_and_broadcast() {
             &stats,
             b"hello",
             addr("[fd00:686f:6e6b::2]:1234"),
-            dst
+            dst,
+            None,
         )
         .await
     );
     // Broadcast / multicast destinations.
-    assert!(udp_fast_path(&pool, &stats, b"hello", client, addr("255.255.255.255:67")).await);
-    assert!(udp_fast_path(&pool, &stats, b"hello", client, addr("192.168.1.255:67")).await);
     assert!(
         udp_fast_path(
             &pool,
             &stats,
             b"hello",
             client,
-            addr("239.255.255.250:1900")
+            addr("255.255.255.255:67"),
+            None,
+        )
+        .await
+    );
+    assert!(
+        udp_fast_path(
+            &pool,
+            &stats,
+            b"hello",
+            client,
+            addr("192.168.1.255:67"),
+            None,
+        )
+        .await
+    );
+    assert!(
+        udp_fast_path(
+            &pool,
+            &stats,
+            b"hello",
+            client,
+            addr("239.255.255.250:1900"),
+            None,
         )
         .await
     );
@@ -2751,7 +2824,9 @@ async fn udp_dns_dispatch_registers_connection_guard_before_task_poll() {
         drain: Arc::clone(&drain),
         handle: plane.spawn_handle(),
     };
-    super::dispatch_udp_slow_path(&state, client, dst, &dns_query_payload());
+    let query = dns_query_payload();
+    let validated = validate_exact_dns_query(&query);
+    super::dispatch_udp_slow_path(&state, client, dst, &query, validated);
     assert_eq!(
         drain.active_count(),
         1,
@@ -2805,12 +2880,17 @@ async fn udp_dns_with_ready_endpoint_uses_controller_not_queue() {
     let dns = production_dns_controller(upstream_calls.clone(), dns_response_payload());
     let slow = Arc::new(tokio::sync::Semaphore::new(1));
     let query = dns_query_payload();
+    let validated = validate_exact_dns_query(&query).unwrap();
 
     // Fast path must force DNS-shaped traffic slow even with Ready present.
-    assert!(!udp_fast_path(&pool, &stats, &query, client, dst).await);
+    assert!(!udp_fast_path(&pool, &stats, &query, client, dst, Some(validated)).await);
 
-    match super::begin_udp_slow_path(&pool, &stats, &slow, client, dst, &query) {
-        super::UdpSlowPathWork::DnsThenMaybeInitialize { permit, data } => {
+    match super::begin_udp_slow_path(&pool, &stats, &slow, client, dst, &query, Some(validated)) {
+        super::UdpSlowPathWork::DnsThenMaybeInitialize {
+            permit,
+            data,
+            validated,
+        } => {
             let lease = super::complete_udp_dns_slow_path(
                 super::UdpDnsSlowPathContext {
                     pool: &pool,
@@ -2821,6 +2901,7 @@ async fn udp_dns_with_ready_endpoint_uses_controller_not_queue() {
                 },
                 permit,
                 &data,
+                validated,
             )
             .await;
             assert!(
@@ -2868,10 +2949,15 @@ async fn udp_dns_with_initializing_endpoint_uses_controller_not_queue() {
     let dns = production_dns_controller(upstream_calls.clone(), dns_response_payload());
     let slow = Arc::new(tokio::sync::Semaphore::new(1));
     let query = dns_query_payload();
+    let validated = validate_exact_dns_query(&query).unwrap();
 
-    assert!(!udp_fast_path(&pool, &stats, &query, client, dst).await);
-    match super::begin_udp_slow_path(&pool, &stats, &slow, client, dst, &query) {
-        super::UdpSlowPathWork::DnsThenMaybeInitialize { permit, data } => {
+    assert!(!udp_fast_path(&pool, &stats, &query, client, dst, Some(validated)).await);
+    match super::begin_udp_slow_path(&pool, &stats, &slow, client, dst, &query, Some(validated)) {
+        super::UdpSlowPathWork::DnsThenMaybeInitialize {
+            permit,
+            data,
+            validated,
+        } => {
             let maybe_lease = super::complete_udp_dns_slow_path(
                 super::UdpDnsSlowPathContext {
                     pool: &pool,
@@ -2882,6 +2968,7 @@ async fn udp_dns_with_initializing_endpoint_uses_controller_not_queue() {
                 },
                 permit,
                 &data,
+                validated,
             )
             .await;
             assert!(maybe_lease.is_none());
@@ -2917,12 +3004,12 @@ async fn udp_initializing_follower_requires_slow_permit_via_shared_helper() {
     };
 
     // Fast path must miss for Initializing — no direct enqueue, no copy.
-    assert!(!udp_fast_path(&pool, &stats, b"follower", client, dst).await);
+    assert!(!udp_fast_path(&pool, &stats, b"follower", client, dst, None).await);
     assert_eq!(stats.udp_snapshot().endpoint_misses, 1);
     assert_eq!(stats.udp_snapshot().queue_accepted, 0);
 
     let zero = Arc::new(tokio::sync::Semaphore::new(0));
-    match super::begin_udp_slow_path(&pool, &stats, &zero, client, dst, b"follower") {
+    match super::begin_udp_slow_path(&pool, &stats, &zero, client, dst, b"follower", None) {
         super::UdpSlowPathWork::Done => {}
         _ => panic!("zero slow permit must not reserve or enqueue"),
     }
@@ -2931,7 +3018,7 @@ async fn udp_initializing_follower_requires_slow_permit_via_shared_helper() {
     assert_eq!(udp.queue_accepted, 0);
 
     let open = Arc::new(tokio::sync::Semaphore::new(1));
-    match super::begin_udp_slow_path(&pool, &stats, &open, client, dst, b"follower") {
+    match super::begin_udp_slow_path(&pool, &stats, &open, client, dst, b"follower", None) {
         super::UdpSlowPathWork::Done => {}
         super::UdpSlowPathWork::Initialize(_) => {
             panic!("Initializing follower must enqueue, not create a second lease")

--- a/crates/honk-core/src/control/udp_endpoint.rs
+++ b/crates/honk-core/src/control/udp_endpoint.rs
@@ -39,6 +39,7 @@ const FLOW_QUEUE_CAPACITY: usize = 64;
 /// All retained payload bytes across UDP flows are bounded exactly by permits.
 const GLOBAL_PAYLOAD_CAPACITY: usize = 8 * 1024 * 1024;
 const TRANSPORT_SEND_TIMEOUT: Duration = Duration::from_secs(5);
+const TRAFFIC_ALIVE_REPORT_INTERVAL: Duration = Duration::from_millis(200);
 const DRIVER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(6);
 const DRIVER_ABORT_TIMEOUT: Duration = Duration::from_secs(1);
 /// Includes the eagerly-created original-destination socket. Reaching the
@@ -60,6 +61,8 @@ pub struct UdpEndpoint {
     has_reply: AtomicBool,
     /// Guard for the exactly-once first-reply metric.
     first_reply_recorded: AtomicBool,
+    /// Bounds traffic-state lock acquisition to five times per second per endpoint.
+    next_alive_report_at: AtomicI64,
     /// Creation time used for reply latency accounting.
     created_at: Instant,
     /// Reference count for active operations.
@@ -97,6 +100,7 @@ impl UdpEndpoint {
             expires_at: AtomicI64::new(now + nanos_from_dur(DEFAULT_NAT_TIMEOUT)),
             has_reply: AtomicBool::new(false),
             first_reply_recorded: AtomicBool::new(false),
+            next_alive_report_at: AtomicI64::new(0),
             created_at: Instant::now(),
             ref_count: AtomicI64::new(1),
             dead: AtomicBool::new(false),
@@ -157,7 +161,22 @@ impl UdpEndpoint {
     }
 
     fn take_first_reply_metric(&self) -> Option<Duration> {
+        if self.first_reply_recorded.load(Ordering::Acquire) {
+            return None;
+        }
         (!self.first_reply_recorded.swap(true, Ordering::AcqRel)).then(|| self.created_at.elapsed())
+    }
+
+    fn take_alive_report_slot(&self) -> bool {
+        let now = monotonic_nanos();
+        if now < self.next_alive_report_at.load(Ordering::Relaxed) {
+            return false;
+        }
+        self.next_alive_report_at.store(
+            now + nanos_from_dur(TRAFFIC_ALIVE_REPORT_INTERVAL),
+            Ordering::Relaxed,
+        );
+        true
     }
 
     pub fn has_reply(&self) -> bool {
@@ -2188,11 +2207,13 @@ async fn receive_loop(
         }
         endpoint.tracker_download(n as u64);
         outbound_tracker.add_bytes(0, n as u64);
-        alive_set.report_available_traffic(
-            endpoint.node_id,
-            honk_outbound::alive::ProbeDomain::DataUdp,
-            ipver,
-        );
+        if endpoint.take_alive_report_slot() {
+            alive_set.report_available_traffic(
+                endpoint.node_id,
+                honk_outbound::alive::ProbeDomain::DataUdp,
+                ipver,
+            );
+        }
     }
 }
 
@@ -2218,6 +2239,22 @@ mod tests {
     }
 
     use super::*;
+
+    #[tokio::test]
+    async fn first_reply_metric_and_alive_reporting_are_throttled() {
+        let socket = Arc::new(UdpSocket::bind("127.0.0.1:0").await.unwrap());
+        let relay = "127.0.0.1:53".parse().unwrap();
+        let endpoint = UdpEndpoint::new(transport(socket, relay), relay, uuid::Uuid::new_v4());
+
+        assert!(endpoint.take_first_reply_metric().is_some());
+        assert!(endpoint.take_first_reply_metric().is_none());
+        assert!(endpoint.take_alive_report_slot());
+        assert!(!endpoint.take_alive_report_slot());
+        endpoint
+            .next_alive_report_at
+            .store(monotonic_nanos().saturating_sub(1), Ordering::Relaxed);
+        assert!(endpoint.take_alive_report_slot());
+    }
 
     async fn recv_and_ack(
         pool: &UdpEndpointPool,

--- a/crates/honk-core/src/control/udp_endpoint/bench_support.rs
+++ b/crates/honk-core/src/control/udp_endpoint/bench_support.rs
@@ -263,6 +263,22 @@ pub fn reserve_rollback_batch(iterations: usize) {
     }
 }
 
+/// Repeatedly take the first-reply metric after its one true result.
+#[doc(hidden)]
+pub fn first_reply_metric_hot_batch(iterations: usize) {
+    assert!(iterations > 0, "benchmark batch must be non-empty");
+    let (_, destination) = bench_addresses();
+    let endpoint = UdpEndpoint::new(
+        Arc::new(BenchPacketTransport { relay: destination }),
+        destination,
+        uuid::Uuid::from_u128(0xbe9c4),
+    );
+    assert!(endpoint.take_first_reply_metric().is_some());
+    for _ in 0..iterations {
+        assert!(endpoint.take_first_reply_metric().is_none());
+    }
+}
+
 /// Prepared fixture for filling the exact 64-datagram bound and dropping newest.
 #[doc(hidden)]
 pub struct QueueSaturationBenchmark(QueuedBatch);

--- a/crates/honk-core/src/dns/bench_support.rs
+++ b/crates/honk-core/src/dns/bench_support.rs
@@ -160,6 +160,18 @@ pub fn record_observability_event() {
     crate::stats::record_dns_event(crate::stats::DnsStatEvent::CacheHit);
 }
 
+/// Validate a raw UDP query and return its derived advertised size.
+#[doc(hidden)]
+pub fn validate_udp_query_profile(raw: &[u8]) -> u16 {
+    match super::query::validate_exact_dns_query(raw)
+        .expect("benchmark query")
+        .ingress()
+    {
+        IngressProfile::Udp { advertised_size } => advertised_size,
+        _ => unreachable!("validated UDP query has a UDP ingress profile"),
+    }
+}
+
 pub fn observability_snapshot_checksum() -> u64 {
     let snapshot = crate::stats::dns::dns_snapshot();
     snapshot

--- a/crates/honk-core/src/dns/cache.rs
+++ b/crates/honk-core/src/dns/cache.rs
@@ -359,6 +359,7 @@ pub(crate) use key::{CacheKey, KeyIdentity, OperationKind};
 pub(crate) use service::PublicationEpoch;
 pub(crate) use service::{CacheSlot, DnsCacheService};
 pub use storage::{CachedEntry, NegativeCacheHit};
+pub(crate) use store::ExactLookup;
 
 use storage::{CacheValue, NegativeEntry};
 

--- a/crates/honk-core/src/dns/cache/key.rs
+++ b/crates/honk-core/src/dns/cache/key.rs
@@ -17,45 +17,72 @@ pub(crate) enum OperationKind {
 /// Immutable query identity shared by all cache and singleflight operations for
 /// one prepared DNS query.  The canonical wire form is deliberately retained
 /// as bytes; its textual representation is a persistence boundary only.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct KeyIdentity(Arc<KeyIdentityData>);
 
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, PartialEq, Eq)]
 struct KeyIdentityData {
     wire_identity: Arc<[u8]>,
     ingress: IngressProfile,
     policy_id: Option<PolicyId>,
+    identity_hash: u64,
+}
+
+impl Hash for KeyIdentity {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write_u64(self.0.identity_hash);
+    }
+}
+
+fn hash_identity(
+    wire_identity: &[u8],
+    ingress: IngressProfile,
+    policy_id: &Option<PolicyId>,
+) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    wire_identity.hash(&mut hasher);
+    ingress.hash(&mut hasher);
+    policy_id.hash(&mut hasher);
+    hasher.finish()
 }
 
 impl KeyIdentity {
     pub(crate) fn new(query: &QueryContext, policy_id: Option<PolicyId>) -> Self {
+        let wire_identity = query.canonical_wire_arc();
+        let ingress = query.ingress();
+        let identity_hash = hash_identity(wire_identity.as_ref(), ingress, &policy_id);
         Self(Arc::new(KeyIdentityData {
-            wire_identity: query.canonical_wire_arc(),
-            ingress: query.ingress(),
+            wire_identity,
+            ingress,
             policy_id,
+            identity_hash,
         }))
     }
 
     pub(crate) fn key(&self, scope: RequestScope, operation: OperationKind) -> CacheKey {
-        let mut hasher = DefaultHasher::new();
-        self.hash(&mut hasher);
-        scope.hash(&mut hasher);
-        operation.hash(&mut hasher);
+        // ponytail: one query's bounded scope/operation variants share a shard;
+        // mix them only if collision profiling shows contention.
         CacheKey {
             identity: self.clone(),
             scope,
             operation,
-            shard_hash: hasher.finish(),
+            shard_hash: self.0.identity_hash,
         }
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct CacheKey {
     identity: KeyIdentity,
     scope: RequestScope,
     operation: OperationKind,
     shard_hash: u64,
+}
+
+impl Hash for CacheKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write_u64(self.shard_hash);
+    }
 }
 
 impl CacheKey {
@@ -105,10 +132,14 @@ impl CacheKey {
         scope: RequestScope,
         operation: OperationKind,
     ) -> Self {
+        let wire_identity = Arc::<[u8]>::from(wire_identity);
+        let policy_id = None;
+        let identity_hash = hash_identity(wire_identity.as_ref(), ingress, &policy_id);
         KeyIdentity(Arc::new(KeyIdentityData {
-            wire_identity: wire_identity.into(),
+            wire_identity,
             ingress,
-            policy_id: None,
+            policy_id,
+            identity_hash,
         }))
         .key(scope, operation)
     }

--- a/crates/honk-core/src/dns/cache/store.rs
+++ b/crates/honk-core/src/dns/cache/store.rs
@@ -6,13 +6,95 @@ use super::{
     PublicationEpoch, lock,
 };
 
+pub(crate) enum ExactLookup {
+    Negative(NegativeCacheHit),
+    Positive(CachedEntry),
+    Miss,
+}
+
 impl DnsCacheService {
     pub fn get(&self, key: &str) -> Option<CachedEntry> {
         self.get_slot(&CacheSlot::Legacy(key.to_owned()))
     }
 
+    #[cfg(test)]
     pub(crate) fn get_exact(&self, key: &CacheKey) -> Option<CachedEntry> {
         self.get_slot(&CacheSlot::Exact(key.clone()))
+    }
+
+    pub(crate) fn lookup_exact(&self, key: &CacheKey) -> ExactLookup {
+        let key = CacheSlot::Exact(key.clone());
+        let index = self.shard_index(&key);
+        let now = Instant::now();
+        let mut shard = lock(&self.shards[index]);
+
+        let (negative, clear_negative) = match shard.peek(&key) {
+            Some(value) => match value.negative.as_ref() {
+                Some(negative) => match negative.expires_at.checked_duration_since(now) {
+                    Some(remaining) => {
+                        let rounded_secs = remaining
+                            .as_secs()
+                            .saturating_add(u64::from(remaining.subsec_nanos() > 0));
+                        (
+                            Some(NegativeCacheHit {
+                                rcode: negative.rcode,
+                                remaining_ttl: Duration::from_secs(rounded_secs),
+                            }),
+                            false,
+                        )
+                    }
+                    None => (None, true),
+                },
+                None => (None, false),
+            },
+            None => (None, false),
+        };
+
+        if clear_negative {
+            let remove_slot = shard.peek_mut(&key).is_some_and(|value| {
+                value.negative = None;
+                value.positive.is_none()
+            });
+            if remove_slot {
+                shard.pop(&key);
+            }
+        }
+
+        let result = if let Some(hit) = negative {
+            ExactLookup::Negative(hit)
+        } else {
+            let (positive, clear_positive) = match shard.get(&key) {
+                Some(value) => match value.positive.as_ref() {
+                    Some(entry) if entry.is_stale_retention_exceeded() => (None, true),
+                    Some(entry) if !entry.is_expired() => (Some(entry.clone()), false),
+                    Some(_) | None => (None, false),
+                },
+                None => (None, false),
+            };
+            if clear_positive {
+                shard.remove_positive(&key);
+            }
+            positive.map_or(ExactLookup::Miss, ExactLookup::Positive)
+        };
+
+        match &result {
+            ExactLookup::Negative(_) => {
+                self.counters.hits.fetch_add(1, Ordering::Relaxed);
+                crate::stats::record_dns_event(crate::stats::DnsStatEvent::CacheHit);
+                tracing::debug!(result = "negative_hit", "DNS cache lookup");
+            }
+            ExactLookup::Positive(_) => {
+                self.counters.hits.fetch_add(1, Ordering::Relaxed);
+                crate::stats::record_dns_event(crate::stats::DnsStatEvent::CacheHit);
+                tracing::debug!(result = "hit", "DNS cache lookup");
+            }
+            ExactLookup::Miss => {
+                self.counters.misses.fetch_add(1, Ordering::Relaxed);
+                crate::stats::record_dns_event(crate::stats::DnsStatEvent::CacheMiss);
+                tracing::debug!(result = "miss", "DNS cache lookup");
+            }
+        }
+        result
     }
 
     pub(crate) fn get_stale_exact(&self, key: &CacheKey) -> Option<CachedEntry> {
@@ -241,6 +323,7 @@ impl DnsCacheService {
         self.negative_hit_slot(&CacheSlot::Legacy(key.to_owned()))
     }
 
+    #[cfg(test)]
     pub(crate) fn negative_hit_exact(&self, key: &CacheKey) -> Option<NegativeCacheHit> {
         self.negative_hit_slot(&CacheSlot::Exact(key.clone()))
     }

--- a/crates/honk-core/src/dns/cache/tests/key.rs
+++ b/crates/honk-core/src/dns/cache/tests/key.rs
@@ -2,7 +2,7 @@ use crate::dns::planner::{RequestScope, UpstreamTag};
 use crate::dns::policy::PolicyId;
 use crate::dns::query::{IngressProfile, QueryContext};
 
-use super::{CacheKey, DnsCache, OperationKind, make_test_response};
+use super::{CacheKey, DnsCache, ExactLookup, OperationKind, make_test_response};
 
 #[test]
 fn exact_key_has_stable_typed_identity() {
@@ -207,4 +207,50 @@ fn expired_exact_negative_only_slot_is_removed() {
     assert_eq!(service.len(), 1);
     assert!(service.negative_hit_exact(&key).is_none());
     assert_eq!(service.len(), 0);
+}
+
+#[test]
+fn combined_exact_lookup_preserves_precedence_and_counts_once() {
+    let wire = crate::dns::forwarder::build_dns_query("combined.example", 1);
+    let query = QueryContext::parse(&wire).expect("query");
+    let key = CacheKey::new(
+        &query,
+        None,
+        RequestScope::Upstream(UpstreamTag::new("default").expect("scope")),
+        OperationKind::Resolve,
+    );
+    let miss = CacheKey::new(
+        &query,
+        None,
+        RequestScope::Upstream(UpstreamTag::new("other").expect("scope")),
+        OperationKind::Resolve,
+    );
+    let response = make_test_response([192, 0, 2, 1], 300);
+    let cache = DnsCache::new(4);
+    let service = cache.service();
+    service.put_exact(key.clone(), response.clone(), 300);
+    service.put_negative_exact(key.clone(), 60, 2);
+
+    let before = service.counters();
+    assert!(matches!(
+        service.lookup_exact(&key),
+        ExactLookup::Negative(hit) if hit.rcode == 2
+    ));
+    let after_negative = service.counters();
+    assert_eq!(after_negative.hits, before.hits + 1);
+    assert_eq!(after_negative.misses, before.misses);
+
+    service.insert_expired_negative_exact_for_test(key.clone(), 2);
+    match service.lookup_exact(&key) {
+        ExactLookup::Positive(entry) => assert_eq!(entry.response.as_ref(), response.as_slice()),
+        _ => panic!("expired negative must reveal the live positive"),
+    }
+    let after_positive = service.counters();
+    assert_eq!(after_positive.hits, before.hits + 2);
+    assert_eq!(after_positive.misses, before.misses);
+
+    assert!(matches!(service.lookup_exact(&miss), ExactLookup::Miss));
+    let after_miss = service.counters();
+    assert_eq!(after_miss.hits, before.hits + 2);
+    assert_eq!(after_miss.misses, before.misses + 1);
 }

--- a/crates/honk-core/src/dns/engine.rs
+++ b/crates/honk-core/src/dns/engine.rs
@@ -175,7 +175,7 @@ impl DnsEngine {
         strict: bool,
     ) -> Result<ResponseDirective, EngineError> {
         if strict {
-            ResponseTemplate::validate(&prepared.query, &wire)?;
+            ResponseTemplate::check(&prepared.query, &wire)?;
         }
         let class = classify_response(&wire);
         if matches!(class, ResponseClass::Nxdomain | ResponseClass::Servfail) {

--- a/crates/honk-core/src/dns/engine/pipeline.rs
+++ b/crates/honk-core/src/dns/engine/pipeline.rs
@@ -111,7 +111,6 @@ pub(super) struct ExecutionContext<'a> {
     pub(super) raw_query: &'a [u8],
     pub(super) original_dst: Option<SocketAddr>,
     pub(super) cache_key: CacheKey,
-    pub(super) refresh_key: CacheKey,
     pub(super) logical_upstream: UpstreamTag,
     pub(super) request_scope: RequestScope,
     pub(super) reuse_eligible: bool,
@@ -209,7 +208,6 @@ pub(crate) async fn resolve_with_owner(
 
     let (logical_upstream, request_scope) = request_exchange(&prepared)?;
     let resolve_key = prepared.cache_key(request_scope.clone(), OperationKind::Resolve);
-    let refresh_key = resolve_key.with_operation(OperationKind::Refresh);
     let context = ExecutionContext {
         forwarder,
         engine,
@@ -217,7 +215,6 @@ pub(crate) async fn resolve_with_owner(
         raw_query,
         original_dst,
         cache_key: resolve_key,
-        refresh_key,
         logical_upstream,
         request_scope: request_scope.clone(),
         reuse_eligible,

--- a/crates/honk-core/src/dns/engine/pipeline/cache.rs
+++ b/crates/honk-core/src/dns/engine/pipeline/cache.rs
@@ -2,7 +2,7 @@ use tracing::debug;
 
 use super::super::effective_expiry;
 use super::ExecutionContext;
-use crate::dns::cache::CacheKey;
+use crate::dns::cache::{CacheKey, ExactLookup, OperationKind};
 use crate::dns::forwarder::{
     DnsForwardError, extract_min_ttl, extract_soa_negative_ttl, rewrite_answer_ttls,
 };
@@ -16,37 +16,40 @@ pub(super) async fn lookup(
         return Ok(None);
     }
     let cache = context.forwarder.cache_service().await;
-    if let Some(hit) = cache.negative_hit_exact(&context.cache_key) {
-        let response = crate::dns::response::build_dns_error_response(context.raw_query, hit.rcode);
-        return context
-            .forwarder
-            .outcome_from_wire(
-                context.engine,
-                context.prepared,
-                response,
-                None,
-                OutcomeStatus::Accepted,
-                Provenance::Cache,
-                EffectiveExpiry::cacheable(hit.remaining_ttl),
-                None,
-                None,
-                Vec::new(),
-                context.mode,
-            )
-            .map(Some);
-    }
-    let Some(entry) = cache.get_exact(&context.cache_key) else {
-        return Ok(None);
+    let entry = match cache.lookup_exact(&context.cache_key) {
+        ExactLookup::Negative(hit) => {
+            let response =
+                crate::dns::response::build_dns_error_response(context.raw_query, hit.rcode);
+            return context
+                .forwarder
+                .outcome_from_wire(
+                    context.engine,
+                    context.prepared,
+                    response,
+                    None,
+                    OutcomeStatus::Accepted,
+                    Provenance::Cache,
+                    EffectiveExpiry::cacheable(hit.remaining_ttl),
+                    None,
+                    None,
+                    Vec::new(),
+                    context.mode,
+                )
+                .map(Some);
+        }
+        ExactLookup::Positive(entry) => entry,
+        ExactLookup::Miss => return Ok(None),
     };
     let remaining = entry.remaining_ttl_secs();
     debug!(remaining, "DNS forwarder: positive cache hit");
     let refresh_after = (entry.min_ttl as u64 / 10).max(1);
     if allow_refresh && remaining <= refresh_after {
+        let refresh_key = context.cache_key.with_operation(OperationKind::Refresh);
         context.forwarder.maybe_spawn_refresh(
             cache.clone(),
             context.raw_query,
             context.original_dst,
-            context.refresh_key.clone(),
+            refresh_key,
             context.publication_epoch,
         );
     }

--- a/crates/honk-core/src/dns/forwarder/resolution.rs
+++ b/crates/honk-core/src/dns/forwarder/resolution.rs
@@ -21,8 +21,7 @@ impl DnsForwarder {
         Ok(self
             .resolve_inner(raw_query, None, ingress, false, ResolveMode::Compatibility)
             .await?
-            .rendered()
-            .to_vec())
+            .into_rendered())
     }
 
     /// Resolve a raw DNS query with optional original destination.
@@ -55,8 +54,7 @@ impl DnsForwarder {
                 ResolveMode::Compatibility,
             )
             .await?
-            .rendered()
-            .to_vec())
+            .into_rendered())
     }
 
     pub(crate) async fn resolve_strict_with_context_and_profile(
@@ -68,8 +66,7 @@ impl DnsForwarder {
         Ok(self
             .resolve_inner(raw_query, original_dst, ingress, false, ResolveMode::Strict)
             .await?
-            .rendered()
-            .to_vec())
+            .into_rendered())
     }
 
     pub async fn resolve_outcome(&self, raw_query: &[u8]) -> Result<DnsOutcome, DnsForwardError> {

--- a/crates/honk-core/src/dns/outcome.rs
+++ b/crates/honk-core/src/dns/outcome.rs
@@ -154,6 +154,10 @@ impl DnsOutcome {
         &self.rendered
     }
 
+    pub(crate) fn into_rendered(self) -> Vec<u8> {
+        self.rendered
+    }
+
     pub const fn template(&self) -> Option<&ResponseTemplate> {
         self.template.as_ref()
     }

--- a/crates/honk-core/src/dns/outcome/tests.rs
+++ b/crates/honk-core/src/dns/outcome/tests.rs
@@ -34,6 +34,7 @@ fn typed_outcome_exposes_projection_metadata_when_upstream_is_accepted() {
         &["192.0.2.1".parse::<std::net::IpAddr>().expect("IP")]
     );
     assert_eq!(outcome.rendered(), &[0x12, 0x34]);
+    assert_eq!(outcome.into_rendered(), vec![0x12, 0x34]);
 }
 
 #[test]

--- a/crates/honk-core/src/dns/persist/codec.rs
+++ b/crates/honk-core/src/dns/persist/codec.rs
@@ -163,7 +163,7 @@ pub(super) fn decode(
     }
     let (query, policy, scope, operation) = decode_key(key_bytes, active_policy)?;
     let key = CacheKey::new(&query, policy, scope, operation);
-    ResponseTemplate::validate(&query, &response).map_err(|_| DecodeError::Corrupt)?;
+    ResponseTemplate::check(&query, &response).map_err(|_| DecodeError::Corrupt)?;
     Ok(DecodedEntry {
         key,
         response,

--- a/crates/honk-core/src/dns/planner.rs
+++ b/crates/honk-core/src/dns/planner.rs
@@ -1,19 +1,20 @@
 use std::collections::BTreeSet;
 use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
 
 use crate::dns::routing::{DnsRequestDecision, DnsResponseDecision, DnsRouter};
 
 pub const MAX_RESPONSE_UPSTREAMS: usize = 3;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct UpstreamTag(String);
+pub struct UpstreamTag(Arc<str>);
 
 impl UpstreamTag {
     pub fn new(value: &str) -> Result<Self, PlanError> {
         if value.is_empty() {
             return Err(PlanError::EmptyUpstream);
         }
-        Ok(Self(value.to_string()))
+        Ok(Self(Arc::from(value)))
     }
 
     pub fn as_str(&self) -> &str {

--- a/crates/honk-core/src/dns/query.rs
+++ b/crates/honk-core/src/dns/query.rs
@@ -11,30 +11,26 @@ const HEADER_LEN: usize = 12;
 const MIN_QUESTION_WIRE_LEN: usize = 5;
 const OPT_TYPE: u16 = 41;
 const ALLOWED_QUERY_FLAGS: u16 = 0x0130;
-/// Validate a complete DNS request structurally. Ingress adapters and the
-/// policy engine apply the stricter single-question contract before any raw
-/// query can be forwarded.
-pub(crate) fn is_dns_request(data: &[u8]) -> bool {
-    data.len() >= HEADER_LEN
-        && data[2] & 0x80 == 0
-        && QueryContext::parse(data)
-            .ok()
-            .and_then(|query| query.qname()?.to_domain_name())
-            .is_some()
+
+/// Unforgeable evidence that an ingress adapter validated the exact query.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ValidatedDnsQuery(IngressProfile);
+
+impl ValidatedDnsQuery {
+    pub(crate) const fn ingress(self) -> IngressProfile {
+        self.0
+    }
 }
 
-/// Return whether `data` is exactly one DNS query that the forwarding path
-/// can consume. Every record declared by the header must be complete and the
-/// message must end at the final record; compression pointers may only target
-/// previously observed label boundaries.
-pub(crate) fn is_exact_dns_query(data: &[u8]) -> bool {
+/// Validate exactly one complete, forwarder-consumable DNS query.
+pub(crate) fn validate_exact_dns_query(data: &[u8]) -> Option<ValidatedDnsQuery> {
     if data.len() < HEADER_LEN || data[2] & 0x80 != 0 {
-        return false;
+        return None;
     }
 
     let qdcount = usize::from(u16::from_be_bytes([data[4], data[5]]));
     if qdcount != 1 {
-        return false;
+        return None;
     }
     let counts = [
         usize::from(u16::from_be_bytes([data[6], data[7]])),
@@ -50,7 +46,7 @@ pub(crate) fn is_exact_dns_query(data: &[u8]) -> bool {
     if !skip_strict_dns_name(data, &mut pos, &mut label_boundaries)
         || pos.checked_add(4).is_none_or(|end| end > data.len())
     {
-        return false;
+        return None;
     }
     pos += 4; // QTYPE + QCLASS
 
@@ -59,27 +55,36 @@ pub(crate) fn is_exact_dns_query(data: &[u8]) -> bool {
             if !skip_strict_dns_name(data, &mut pos, &mut label_boundaries)
                 || pos.checked_add(10).is_none_or(|end| end > data.len())
             {
-                return false;
+                return None;
             }
             let rdlength = usize::from(u16::from_be_bytes([data[pos + 8], data[pos + 9]]));
             pos += 10; // TYPE + CLASS + TTL + RDLENGTH
-            let Some(rdata_end) = pos.checked_add(rdlength) else {
-                return false;
-            };
+            let rdata_end = pos.checked_add(rdlength)?;
             if rdata_end > data.len() {
-                return false;
+                return None;
             }
             pos = rdata_end;
         }
     }
 
     if pos != data.len() {
-        return false;
+        return None;
     }
 
-    is_dns_request(data)
+    let query = QueryContext::parse(data).ok()?;
+    query.qname()?.to_domain_name()?;
+    let advertised_size = query
+        .edns()
+        .map(|edns| edns.advertised_size())
+        .unwrap_or(512);
+    Some(ValidatedDnsQuery(IngressProfile::Udp { advertised_size }))
 }
 
+pub(crate) fn is_exact_dns_query(data: &[u8]) -> bool {
+    validate_exact_dns_query(data).is_some()
+}
+
+#[cfg(test)]
 /// Derive the response-size policy advertised by a UDP DNS query.
 pub(crate) fn udp_ingress_profile(data: &[u8]) -> IngressProfile {
     let advertised_size = QueryContext::parse(data)

--- a/crates/honk-core/src/dns/response.rs
+++ b/crates/honk-core/src/dns/response.rs
@@ -55,6 +55,10 @@ pub struct ResponseTemplate {
 }
 
 impl ResponseTemplate {
+    pub(crate) fn check(request: &QueryContext, response: &[u8]) -> Result<(), ResponseError> {
+        validate_layout(request, response).map(|_| ())
+    }
+
     pub fn validate(request: &QueryContext, response: &[u8]) -> Result<Self, ResponseError> {
         let (question_end, records) = validate_layout(request, response)?;
         Ok(Self {

--- a/crates/honk-core/src/routing/mod.rs
+++ b/crates/honk-core/src/routing/mod.rs
@@ -409,6 +409,10 @@ impl Router {
         })
     }
 
+    pub const fn default_outbound(&self) -> &str {
+        self.default_outbound.as_str()
+    }
+
     pub fn route(&self, conn: &ConnectionInfo) -> &str {
         match self.route_full(conn) {
             Some(r) => r.outbound_name,
@@ -428,7 +432,7 @@ impl Router {
     pub fn route_with_must(&self, conn: &ConnectionInfo) -> (&str, bool) {
         match self.route_full(conn) {
             Some(r) => (r.outbound_name, r.must),
-            None => (self.route(conn), false),
+            None => (self.default_outbound(), false),
         }
     }
 

--- a/crates/honk-core/src/stats.rs
+++ b/crates/honk-core/src/stats.rs
@@ -497,19 +497,26 @@ impl StatsManager {
 
     /// Record a new connection on an outbound.
     pub fn record_connection(&self, outbound: &str) {
+        if let Some(tracker) = self.trackers.get(outbound) {
+            tracker.increment_connections();
+            return;
+        }
         self.trackers
-            .entry(outbound.to_string())
+            .entry(outbound.to_owned())
             .or_default()
             .increment_connections();
     }
 
     /// Track one connection with an exactly-once active counter balance.
     pub fn track_connection(self: &Arc<Self>, outbound: &str) -> ActiveConnectionGuard {
-        let tracker = self
-            .trackers
-            .entry(outbound.to_string())
-            .or_default()
-            .clone();
+        let tracker = if let Some(tracker) = self.trackers.get(outbound) {
+            tracker.clone()
+        } else {
+            self.trackers
+                .entry(outbound.to_owned())
+                .or_default()
+                .clone()
+        };
         tracker.increment_connections();
         ActiveConnectionGuard { tracker }
     }
@@ -845,16 +852,24 @@ impl StatsManager {
 
     /// Record bytes transferred through an outbound.
     pub fn record_bytes(&self, outbound: &str, tx: u64, rx: u64) {
+        if let Some(tracker) = self.trackers.get(outbound) {
+            tracker.add_bytes(tx, rx);
+            return;
+        }
         self.trackers
-            .entry(outbound.to_string())
+            .entry(outbound.to_owned())
             .or_default()
             .add_bytes(tx, rx);
     }
 
     /// Record an error on an outbound.
     pub fn record_error(&self, outbound: &str) {
+        if let Some(tracker) = self.trackers.get(outbound) {
+            tracker.increment_errors();
+            return;
+        }
         self.trackers
-            .entry(outbound.to_string())
+            .entry(outbound.to_owned())
             .or_default()
             .increment_errors();
     }
@@ -923,6 +938,28 @@ mod tests {
         assert_eq!(snap.get("proxy1").unwrap().total_conns, 2);
         assert_eq!(snap.get("proxy2").unwrap().total_conns, 1);
         assert_eq!(snap.get("proxy2").unwrap().errors, 1);
+    }
+
+    #[test]
+    fn warmed_stats_methods_reuse_one_tracker() {
+        let manager = Arc::new(StatsManager::new());
+        manager.record_connection("proxy");
+        let guard = manager.track_connection("proxy");
+        manager.record_bytes("proxy", 100, 200);
+        manager.record_error("proxy");
+
+        assert_eq!(manager.trackers.len(), 1);
+        let snapshot = manager.snapshot();
+        let tracker = snapshot.get("proxy").unwrap();
+        assert_eq!(tracker.total_conns, 2);
+        assert_eq!(tracker.active_conns, 2);
+        assert_eq!(tracker.tx_bytes, 100);
+        assert_eq!(tracker.rx_bytes, 200);
+        assert_eq!(tracker.errors, 1);
+
+        drop(guard);
+        manager.record_close("proxy");
+        assert_eq!(manager.snapshot()["proxy"].active_conns, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- collapse repeated TCP routing/config work and avoid candidate/stat copies
- validate DNS queries once, combine exact cache lookups, and consume rendered responses without full-wire copies
- throttle UDP liveness reporting and remove repeated first-reply atomic writes

## Benchmarks
Criterion comparison against the pre-change `cp-pre` baseline:
- UDP first-reply hot path: **-91.3%** time (3.352 ms -> 290 us per 1M calls)
- DNS UDP validation/profile: **-40.6%** (654.6 ns -> 389.7 ns)
- DNS typed cache key: **-8.9%** (152.9 ns -> 135.5 ns)
- warmed positive DNS hit: **-11.0%**, throughput **+12.4%**
- warmed NXDOMAIN hit: **-14.1%**, throughput **+16.4%**
- DNS allocation probes: **-25.0% to -33.0%** depending on path

## Verification
- `cargo test -p honk-core --lib` (794 passed, 1 ignored)
- `just dns-ci`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all --check`
- release/mock-eBPF process smoke (ready, clean exit)
- independent correctness review: no blocking/high/medium findings

## Deployment
- gateway canary validation on `vyos@10.10.10.1` will be recorded after deployment