### PR TITLE
fix(routing): preserve mixed IPv4 and IPv6 CIDRs

### DIFF
--- a/crates/honk-core/src/dns/routing/tests/response.rs
+++ b/crates/honk-core/src/dns/routing/tests/response.rs
@@ -70,7 +70,11 @@ fn cidr_match_preserves_requery_and_fallback() {
             rules: vec![DnsResponseRule {
                 conditions: vec![DnsCond::Ip {
                     not: false,
-                    cidrs: vec!["10.0.0.0/8".into(), "192.168.0.0/16".into()],
+                    cidrs: vec![
+                        "10.0.0.0/8".into(),
+                        "192.168.0.0/16".into(),
+                        "2001:db8::/32".into(),
+                    ],
                     geoip: vec![],
                 }],
                 action: DnsResponseAction::Upstream("googledns".into()),
@@ -83,6 +87,11 @@ fn cidr_match_preserves_requery_and_fallback() {
     let private_ip: IpAddr = "10.1.2.3".parse().expect("valid private IP");
     assert_eq!(
         router.select_response("test.com", 1, &[private_ip], "any"),
+        DnsResponseDecision::Requery("googledns".into())
+    );
+    let private_v6: IpAddr = "2001:db8::1".parse().expect("valid private IPv6 address");
+    assert_eq!(
+        router.select_response("test.com", 1, &[private_v6], "any"),
         DnsResponseDecision::Requery("googledns".into())
     );
     let public_ip: IpAddr = "8.8.8.8".parse().expect("valid public IP");

--- a/crates/honk-core/src/routing/lpm.rs
+++ b/crates/honk-core/src/routing/lpm.rs
@@ -1,11 +1,11 @@
 use super::*;
 
 /// Binary LPM trie. Insert CIDRs and check IP matches in O(key_bits) time.
-/// Handles IPv4 (32-bit trie) and IPv6 (128-level trie).
+/// Handles IPv4 and IPv6 CIDRs in the same matcher.
 #[derive(Debug, Clone)]
 pub(crate) struct BinaryLpmTrie {
-    nodes: Vec<TrieNode>,
-    key_bits: u8,
+    v4_nodes: Vec<TrieNode>,
+    v6_nodes: Vec<TrieNode>,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -17,53 +17,38 @@ struct TrieNode {
 
 impl BinaryLpmTrie {
     pub(crate) fn from_nets(nets: &[ipnet::IpNet]) -> Self {
-        if nets.is_empty() {
-            return Self {
-                nodes: vec![TrieNode::default()],
-                key_bits: 32,
-            };
-        }
-
-        let first = nets[0].addr();
-        let (key_bits, to_chunks) = if first.is_ipv4() {
-            (32u8, ipv4_to_chunks as fn(IpAddr) -> Vec<u8>)
-        } else {
-            (128u8, ipv6_to_chunks as fn(IpAddr) -> Vec<u8>)
-        };
-
         let mut trie = Self {
-            nodes: vec![TrieNode::default()],
-            key_bits,
+            v4_nodes: vec![TrieNode::default()],
+            v6_nodes: vec![TrieNode::default()],
         };
 
         for net in nets {
-            if net.addr().is_ipv4() != (key_bits == 32) {
-                continue;
-            }
-            let chunks = to_chunks(net.addr());
             let prefix = net.prefix_len() as u32;
-            trie.insert(&chunks, prefix);
+            match net.addr() {
+                IpAddr::V4(ip) => Self::insert(&mut trie.v4_nodes, &ip.octets(), prefix),
+                IpAddr::V6(ip) => Self::insert(&mut trie.v6_nodes, &ip.octets(), prefix),
+            }
         }
 
         trie
     }
 
-    fn insert(&mut self, chunks: &[u8], prefix: u32) {
+    fn insert(nodes: &mut Vec<TrieNode>, bytes: &[u8], prefix: u32) {
         let mut node_idx = 0u32;
         for bit_idx in 0..prefix {
-            let byte = chunks[(bit_idx / 8) as usize];
+            let byte = bytes[(bit_idx / 8) as usize];
             let bit = (byte >> (7 - (bit_idx % 8))) & 1;
 
             let child_val = if bit == 0 {
-                self.nodes[node_idx as usize].zero
+                nodes[node_idx as usize].zero
             } else {
-                self.nodes[node_idx as usize].one
+                nodes[node_idx as usize].one
             };
 
             let next_idx = if child_val == 0 {
-                let new_idx = self.nodes.len() as u32;
-                self.nodes.push(TrieNode::default());
-                let parent = &mut self.nodes[node_idx as usize];
+                let new_idx = nodes.len() as u32;
+                nodes.push(TrieNode::default());
+                let parent = &mut nodes[node_idx as usize];
                 if bit == 0 {
                     parent.zero = new_idx;
                 } else {
@@ -75,59 +60,40 @@ impl BinaryLpmTrie {
             };
             node_idx = next_idx;
         }
-        self.nodes[node_idx as usize].matched = true;
+        nodes[node_idx as usize].matched = true;
     }
 
-    pub(crate) fn matches(&self, ip: &IpAddr) -> bool {
-        if self.nodes.len() <= 1 {
-            return false; // only root, no entries
+    fn matches_nodes(nodes: &[TrieNode], bytes: &[u8], key_bits: u32) -> bool {
+        if nodes.is_empty() {
+            return false;
         }
 
-        let chunks: Vec<u8> = if ip.is_ipv4() {
-            if self.key_bits != 32 {
-                return false;
-            }
-            ipv4_to_chunks(*ip)
-        } else {
-            if self.key_bits != 128 {
-                return false;
-            }
-            ipv6_to_chunks(*ip)
-        };
-
         let mut node_idx = 0u32;
-        for bit_idx in 0..self.key_bits as u32 {
-            if self.nodes[node_idx as usize].matched {
+        for bit_idx in 0..key_bits {
+            if nodes[node_idx as usize].matched {
                 return true;
             }
-            let byte = chunks[(bit_idx / 8) as usize];
+            let byte = bytes[(bit_idx / 8) as usize];
             let bit = (byte >> (7 - (bit_idx % 8))) & 1;
 
             let child = if bit == 0 {
-                self.nodes[node_idx as usize].zero
+                nodes[node_idx as usize].zero
             } else {
-                self.nodes[node_idx as usize].one
+                nodes[node_idx as usize].one
             };
 
             if child == 0 {
-                return self.nodes[node_idx as usize].matched;
+                return nodes[node_idx as usize].matched;
             }
             node_idx = child;
         }
-        self.nodes[node_idx as usize].matched
+        nodes[node_idx as usize].matched
     }
-}
 
-fn ipv4_to_chunks(ip: IpAddr) -> Vec<u8> {
-    match ip {
-        IpAddr::V4(v4) => v4.octets().to_vec(),
-        IpAddr::V6(_) => unreachable!(),
-    }
-}
-
-fn ipv6_to_chunks(ip: IpAddr) -> Vec<u8> {
-    match ip {
-        IpAddr::V6(v6) => v6.octets().to_vec(),
-        IpAddr::V4(_) => unreachable!(),
+    pub(crate) fn matches(&self, ip: &IpAddr) -> bool {
+        match ip {
+            IpAddr::V4(ip) => Self::matches_nodes(&self.v4_nodes, &ip.octets(), 32),
+            IpAddr::V6(ip) => Self::matches_nodes(&self.v6_nodes, &ip.octets(), 128),
+        }
     }
 }

--- a/crates/honk-core/src/routing/tests.rs
+++ b/crates/honk-core/src/routing/tests.rs
@@ -64,6 +64,17 @@ fn test_trie_ipv4_wrong_family_rejected() {
     // IPv6 address should not match an IPv4-only trie
     assert!(!trie.matches(&"::ffff:10.0.0.1".parse().unwrap()));
 }
+#[test]
+fn test_trie_mixed_families() {
+    let nets: Vec<ipnet::IpNet> = vec![
+        "10.0.0.0/8".parse().unwrap(),
+        "2001:db8::/32".parse().unwrap(),
+    ];
+    let trie = BinaryLpmTrie::from_nets(&nets);
+    assert!(trie.matches(&"10.1.2.3".parse().unwrap()));
+    assert!(trie.matches(&"2001:db8::1".parse().unwrap()));
+    assert!(!trie.matches(&"2001:db9::1".parse().unwrap()));
+}
 
 #[test]
 fn test_empty_router() {
@@ -645,6 +656,31 @@ fn test_ip_version_route() {
     assert_eq!(router.route(&conn), "proxy");
 
     conn.dst_ip = "1.1.1.1".parse().unwrap();
+    assert_eq!(router.route(&conn), "direct");
+}
+#[test]
+fn test_mixed_family_ip_route() {
+    let rules = vec![RoutingRule {
+        name: "mixed-family".into(),
+        condition: RoutingCondition {
+            ip: vec!["10.0.0.0/8".into(), "2001:db8::/32".into()],
+            ..Default::default()
+        },
+        outbound: RoutingOutbound::Simple("proxy".into()),
+        priority: 0,
+        must: false,
+        mark: 0,
+    }];
+
+    let router = Router::new(&rules, "direct").unwrap();
+    let mut conn = make_conn(None, None);
+    conn.dst_ip = "10.1.2.3".parse().unwrap();
+    assert_eq!(router.route(&conn), "proxy");
+
+    conn.dst_ip = "2001:db8::1".parse().unwrap();
+    assert_eq!(router.route(&conn), "proxy");
+
+    conn.dst_ip = "2001:db9::1".parse().unwrap();
     assert_eq!(router.route(&conn), "direct");
 }
 

--- a/crates/honk-outbound/src/proxy/hysteria2/tests.rs
+++ b/crates/honk-outbound/src/proxy/hysteria2/tests.rs
@@ -755,8 +755,12 @@ async fn test_connection_reuse_across_dials() {
         let payload = format!("req{i}");
         stream.stream.write_all(payload.as_bytes()).await.unwrap();
         let mut buf = [0u8; 16];
-        let n = stream.stream.read(&mut buf).await.unwrap();
-        assert_eq!(&buf[..n], payload.as_bytes());
+        stream
+            .stream
+            .read_exact(&mut buf[..payload.len()])
+            .await
+            .unwrap();
+        assert_eq!(&buf[..payload.len()], payload.as_bytes());
     }
 }
 


### PR DESCRIPTION
## Summary

- Keep IPv4 and IPv6 CIDRs in separate userspace LPM tries.
- Preserve mixed-family GeoIP, routing, and DNS IP-condition matches.
- Add mixed-family routing and IPv6 DNS regression coverage.

The bug caused `geoip: cn` IPv6 prefixes to be discarded when the first CIDR was IPv4. The target `2401:b180:7003::ed` now matches `2401:b180::/32` and routes to `direct` under `config.dae`.

## Validation

- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY cargo test -p honk-core --lib`
- `cargo clippy -p honk-core --lib --tests -- -D warnings`
- `cargo fmt --all -- --check`
- Focused target-IP probe: `2401:b180:7003::ed` → `CN 2401:b180::/32` → `direct`

`config_dae_routing_test` still has a separate existing expectation mismatch for `jogiyw.sbs` (`direct` expected, `omg` observed); it is unrelated to the trie change.

Fixes #52
