### PR TITLE
fix(config): accept packetEncoding=none in share links

### DIFF
--- a/crates/honk-config/src/share_link.rs
+++ b/crates/honk-config/src/share_link.rs
@@ -139,7 +139,8 @@ impl Node {
             query.insert(key, value.into_owned());
         }
         if protocol != NodeProtocol::VLess
-            && (query.contains_key("vless_mode") || query.contains_key("packetEncoding"))
+            && (query.contains_key("vless_mode")
+                || query.get("packetEncoding").is_some_and(|v| v != "none"))
         {
             return Err(ConfigError::Parse(
                 "vless_mode/packetEncoding are valid only for VLESS share links".into(),
@@ -383,12 +384,16 @@ impl Node {
                 if let Some(mode) = query.get("vless_mode") {
                     node.vless_mode = mode.parse()?;
                 } else if let Some(encoding) = query.get("packetEncoding") {
-                    if encoding != "xudp" {
-                        return Err(ConfigError::Parse(
-                            "unsupported VLESS packetEncoding (expected xudp)".into(),
-                        ));
+                    // `none` is the explicit spelling of legacy plain VLESS.
+                    match encoding.as_str() {
+                        "xudp" => node.vless_mode = crate::node::WireMode::Xudp,
+                        "none" => {}
+                        _ => {
+                            return Err(ConfigError::Parse(
+                                "unsupported VLESS packetEncoding (expected xudp or none)".into(),
+                            ));
+                        }
                     }
-                    node.vless_mode = crate::node::WireMode::Xudp;
                 }
             }
             // `security=reality` carries the REALITY handshake parameters.

--- a/crates/honk-config/tests/share_link.rs
+++ b/crates/honk-config/tests/share_link.rs
@@ -533,6 +533,10 @@ fn test_vless_mode_query() {
         Node::from_share_link("vless://uuid@example.com:443?packetEncoding=xudp#node").unwrap();
     assert_eq!(xudp.vless_mode, honk_config::node::WireMode::Xudp);
 
+    let legacy =
+        Node::from_share_link("vless://uuid@example.com:443?packetEncoding=none#node").unwrap();
+    assert_eq!(legacy.vless_mode, honk_config::node::WireMode::Legacy);
+
     let error =
         Node::from_share_link("vless://uuid@example.com:443?vless_mode=smux#node").unwrap_err();
     assert!(error.to_string().contains("unsupported wire mode"));
@@ -566,6 +570,17 @@ fn test_rejects_vless_mode_on_other_protocols() {
 }
 
 #[test]
+fn test_packet_encoding_none_is_a_noop_on_other_protocols() {
+    // Converters append packetEncoding=none to anytls/trojan links; it spells
+    // the default behavior and must not reject the node.
+    let node = Node::from_share_link(
+        "anytls://00000000-0000-0000-0000-000000000000@example.com:443?security=tls&packetEncoding=none&udp=1#node",
+    )
+    .unwrap();
+    assert_eq!(node.protocol, honk_config::types::NodeProtocol::AnyTLS);
+}
+
+#[test]
 fn test_vless_share_link_rejects_external_mux_fields() {
     for parameter in [
         "smux=h2mux",
@@ -590,7 +605,7 @@ fn test_vless_share_link_rejects_external_mux_fields() {
     let error =
         Node::from_share_link("vless://uuid@example.com:443?packetEncoding=packetaddr#node")
             .unwrap_err();
-    assert!(error.to_string().contains("expected xudp"));
+    assert!(error.to_string().contains("expected xudp or none"));
 }
 
 #[test]


### PR DESCRIPTION
## Problem

Subscription converters (e.g. subconverter) append `packetEncoding=none` to links of every protocol. honk rejected them:

- VLESS: `packetEncoding` only accepted `xudp`, so `none` was a parse error; the subscription import's `filter_map(...ok())` then silently dropped every such node (observed: 41 of 63 upstream nodes lost, only hysteria2 survived).
- non-VLESS (anytls/trojan/...): any `packetEncoding` key was rejected as "only for VLESS".

`packetEncoding=none` is the explicit spelling of the default no-packet-encoding behavior, so rejecting it loses nodes for no reason.

## Fix

- VLESS: `packetEncoding=none` maps to legacy plain VLESS (same as omitting the parameter); `xudp` still maps to `WireMode::Xudp`; other values still rejected.
- non-VLESS: `packetEncoding=none` is accepted and ignored; any other value (e.g. `xudp`) is still rejected as VLESS-only.

No other VLESS parameter validation was loosened.

## Verification

- New regression tests: VLESS `packetEncoding=none` → Legacy; anytls with `packetEncoding=none` parses; `packetEncoding=xudp` on trojan still rejected.
- Real-world check: the affected subscription's 84 share links all parse (previously the VLESS and anytls lines were dropped).
- `cargo test -p honk-config`, `cargo test -p honk-core --lib subscription`, clippy, fmt: all green.