### PR TITLE
perf(tls): build the webpki root store once per process

### DIFF
--- a/crates/honk-outbound/src/tls.rs
+++ b/crates/honk-outbound/src/tls.rs
@@ -295,7 +295,21 @@ pub(crate) fn add_chrome_alps(cfg: &mut ConnectConfiguration) -> anyhow::Result<
 }
 
 /// Mozilla root CAs (full DER certs) loaded into a BoringSSL store.
+///
+/// The store is built once per process (~150 parsed certs, ~0.8 MiB) and
+/// every caller gets a refcounted clone (`X509_STORE_up_ref`) — with a
+/// per-node-per-probe-cycle call pattern, building it fresh each time would
+/// pin hundreds of megabytes in connector caches.
 pub(crate) fn root_store() -> Result<boring::x509::store::X509Store, ErrorStack> {
+    static ROOT_STORE: LazyLock<Option<boring::x509::store::X509Store>> =
+        LazyLock::new(|| build_root_store().ok());
+    match &*ROOT_STORE {
+        Some(store) => Ok(store.clone()),
+        None => build_root_store(),
+    }
+}
+
+fn build_root_store() -> Result<boring::x509::store::X509Store, ErrorStack> {
     let mut builder = X509StoreBuilder::new()?;
     for der in webpki_root_certs::TLS_SERVER_ROOT_CERTS {
         if let Ok(cert) = X509::from_der(der.as_ref()) {
@@ -564,6 +578,14 @@ pub fn build_http_probe_connector(skip_cert_verify: bool) -> anyhow::Result<TlsC
 mod tests {
     use super::*;
     use boring::pkey::PKey;
+
+    #[test]
+    fn root_store_clones_share_one_store() {
+        use foreign_types::ForeignType;
+        let a = root_store().unwrap();
+        let b = root_store().unwrap();
+        assert_eq!(a.as_ptr(), b.as_ptr());
+    }
     use boring::ssl::{SslAcceptor, SslStream};
     use std::io::Read;
     use std::net::TcpListener;


### PR DESCRIPTION
## Problem

`tls::root_store()` parses ~150 webpki root CAs into a **fresh** `X509Store` on every call (measured ~0.8 MiB per store), and the per-node `TlsConnectorSlot` caches the resulting connector for a 10-minute idle TTL. When `check_interval` is on the same order as the TTL (e.g. the common 600s), every node holds its own private root store across every probe cycle:

- At 209 nodes: 209 × 0.8 MiB ≈ **170 MiB RSS**, never released at steady state.
- This is the dominant hotspot behind the "RSS climbs to 300MB" report (baseline 125MB → ~240MB after one probe round).
- Dead nodes pay the same cost: the connector is built before the dial and lands in the slot regardless of probe outcome.

## Fix

`root_store()` now builds the store once per process (`LazyLock`) and hands out refcounted clones (`X509_STORE_up_ref`). Both call sites (proxy connectors, QUIC connector) benefit automatically; the REALITY / pin / skip_cert_verify paths never touched the root store and are unaffected.

## Verification

- New unit test `root_store_clones_share_one_store`: two `root_store()` calls return the same underlying pointer.
- Allocation measurement: 209 independent stores = 170.7 MiB; shared = 0.8 MiB.
- Live test on 10.10.10.49 (real 209-node subscription + slow-download load): steady-state RSS dropped from ~158MB to ~128MB and keeps converging toward the stock-allocator baseline (~120MB). About half the nodes fail probing on that network (no connector is ever built for them), so only part of the win is visible there; on a gateway where all nodes probe successfully, the expected saving is the full ~150-170MB.
- `cargo test -p honk-outbound` passes (the single red `test_salamander_obfs_tcp_udp_echo` is a known flake that was already flaky in CI before this change); clippy and fmt are clean.
