### PR TITLE
fix(dns): reject truncated upstream responses

### DIFF
--- a/crates/honk-core/src/control/dns_control.rs
+++ b/crates/honk-core/src/control/dns_control.rs
@@ -223,22 +223,27 @@ impl DnsController {
         use crate::dns::projection::{ProjectionFreshness, ProjectionObservation};
 
         let domain = outcome.domain();
-        let observation = match (outcome.status(), outcome.response_class()) {
-            (OutcomeStatus::Accepted, ResponseClass::Positive) => ProjectionObservation::Positive {
-                domain,
-                ips: outcome.answer_ips(),
-                advertised_ttl: outcome.expiry().ttl(),
-                freshness: if outcome.provenance() == Provenance::Stale {
-                    ProjectionFreshness::Stale
-                } else {
-                    ProjectionFreshness::Fresh
-                },
-            },
-            (OutcomeStatus::Accepted, ResponseClass::Nodata | ResponseClass::Nxdomain) => {
-                ProjectionObservation::Clear { domain }
-            }
-            (OutcomeStatus::Accepted, ResponseClass::Servfail) | (OutcomeStatus::Rejected, _) => {
-                ProjectionObservation::Retain
+        let observation = if crate::dns::response::is_truncated(outcome.reusable()) {
+            ProjectionObservation::Retain
+        } else {
+            match (outcome.status(), outcome.response_class()) {
+                (OutcomeStatus::Accepted, ResponseClass::Positive) => {
+                    ProjectionObservation::Positive {
+                        domain,
+                        ips: outcome.answer_ips(),
+                        advertised_ttl: outcome.expiry().ttl(),
+                        freshness: if outcome.provenance() == Provenance::Stale {
+                            ProjectionFreshness::Stale
+                        } else {
+                            ProjectionFreshness::Fresh
+                        },
+                    }
+                }
+                (OutcomeStatus::Accepted, ResponseClass::Nodata | ResponseClass::Nxdomain) => {
+                    ProjectionObservation::Clear { domain }
+                }
+                (OutcomeStatus::Accepted, ResponseClass::Servfail)
+                | (OutcomeStatus::Rejected, _) => ProjectionObservation::Retain,
             }
         };
         self.routing_projection

--- a/crates/honk-core/src/control/dns_control/tests/fixtures.rs
+++ b/crates/honk-core/src/control/dns_control/tests/fixtures.rs
@@ -104,7 +104,7 @@ impl DnsUpstreamPool for SnapshotUpstream {
     }
 }
 
-fn a_response(query: &[u8], ip: [u8; 4]) -> Vec<u8> {
+pub(super) fn a_response(query: &[u8], ip: [u8; 4]) -> Vec<u8> {
     let mut response = query.to_vec();
     response[2] = 0x81;
     response[3] = 0x80;

--- a/crates/honk-core/src/control/dns_control/tests/udp.rs
+++ b/crates/honk-core/src/control/dns_control/tests/udp.rs
@@ -132,3 +132,112 @@ async fn transparent_udp_routes_by_client_source() {
         ["selected", "fallback"]
     );
 }
+
+#[tokio::test]
+async fn truncated_upstream_response_is_not_cached_or_projected() {
+    let query = query_with_txid("example.com", 0x5151);
+    let mut truncated = a_response(&query, [192, 0, 2, 10]);
+    truncated[2..4].copy_from_slice(&0x8380_u16.to_be_bytes());
+    let upstream = Arc::new(SlowUpstream {
+        calls: AtomicUsize::new(0),
+        delay: Duration::ZERO,
+        response: truncated,
+    });
+    let cache = Arc::new(tokio::sync::Mutex::new(crate::dns::cache::DnsCache::new(8)));
+    let directory = tempfile::tempdir().expect("cache directory");
+    let database = Arc::new(
+        crate::cachedb::CacheDb::open(&honk_config::experimental::CacheFileConfig {
+            enabled: true,
+            path: directory
+                .path()
+                .join("cache.db")
+                .to_string_lossy()
+                .into_owned(),
+            store_dns: true,
+            ..Default::default()
+        })
+        .expect("cache database"),
+    );
+    let persister = crate::dns::persist::DnsCachePersister::spawn(Arc::clone(&database));
+    cache.lock().await.set_persister(Some(persister.clone()));
+    let forwarder = Arc::new(DnsForwarder::new(
+        upstream.clone(),
+        cache.clone(),
+        Arc::new(
+            crate::dns::routing::DnsRouter::new_from_dns_config(
+                &honk_config::dns::DnsConfig::default(),
+            )
+            .expect("DNS router"),
+        ),
+    ));
+    let route = honk_config::routing::RoutingRule {
+        name: "dns".into(),
+        condition: honk_config::routing::RoutingCondition {
+            domain: vec!["example.com".into()],
+            ..Default::default()
+        },
+        outbound: honk_config::routing::RoutingOutbound::Simple("direct".into()),
+        priority: 1,
+        must: false,
+        mark: 0,
+    };
+    let mut bitmap = honk_ebpf_common::DomainRouting::default();
+    bitmap.bitmap[0] = 1;
+    let snapshot = Arc::new(crate::dns::projection::RoutingProjectionSnapshot::new(
+        1,
+        Arc::new(Router::new(&[route], "direct").expect("routing matcher")),
+        std::collections::HashMap::from([("dns".into(), vec![bitmap])]),
+    ));
+    let runtime = crate::dns::runtime::DnsRuntime::new(crate::dns::runtime::DnsRuntimeParts {
+        generation: crate::dns::runtime::RuntimeGeneration::new(1),
+        forwarder,
+        routing_projection: Arc::clone(&snapshot),
+        outbound_runtime: None,
+        transport: Arc::new(NoopRuntimeTransport),
+    });
+    let ebpf: Arc<tokio::sync::RwLock<Box<dyn crate::ebpf::EbpfBackend>>> = Arc::new(
+        tokio::sync::RwLock::new(Box::new(crate::ebpf::mock::MockEbpfBackend::new())),
+    );
+    let controller = DnsController::new_with_runtime(
+        Arc::new(crate::dns::runtime::DnsServiceProvider::new(runtime)),
+        ebpf,
+    );
+    let learned_ip = "192.0.2.10".parse().expect("learned IP");
+    controller.routing_projection.submit(
+        Arc::clone(&snapshot),
+        crate::dns::projection::ProjectionObservation::Positive {
+            domain: "example.com",
+            ips: &[learned_ip],
+            advertised_ttl: Duration::from_secs(30),
+            freshness: crate::dns::projection::ProjectionFreshness::Fresh,
+        },
+    );
+    let projected = controller.project_routes(&snapshot);
+    assert_eq!(projected.len(), 1);
+
+    let (outcome, runtime) = controller
+        .dns_service()
+        .resolve_outcome_with_runtime(
+            &query,
+            DnsRequestMeta::EMPTY,
+            IngressProfile::Udp {
+                advertised_size: 1232,
+            },
+        )
+        .await
+        .expect("truncated outcome");
+    assert!(outcome.answer_ips().is_empty());
+    assert!(!outcome.expiry().is_cacheable());
+    controller.submit_projection(runtime.runtime(), &outcome);
+    drop(runtime);
+
+    assert!(cache.lock().await.is_empty());
+    assert_eq!(upstream.calls.load(Ordering::SeqCst), 1);
+    let projected_again = controller.project_routes(&snapshot);
+    assert_eq!(projected_again.len(), 1);
+    assert_eq!(projected_again[0].0, projected[0].0);
+    assert_eq!(projected_again[0].1.bitmap, projected[0].1.bitmap);
+    persister.shutdown().await.expect("persistence shutdown");
+    assert!(database.load_dns_v2().expect("persisted rows").is_empty());
+    controller.shutdown(Duration::from_secs(1)).await;
+}

--- a/crates/honk-core/src/dns/cache/store.rs
+++ b/crates/honk-core/src/dns/cache/store.rs
@@ -198,6 +198,9 @@ impl DnsCacheService {
         min_ttl: u32,
         strict_reusable: bool,
     ) -> bool {
+        if crate::dns::response::is_truncated(&response) {
+            return false;
+        }
         let ttl = min_ttl.max(1);
         let entry = CachedEntry {
             response,

--- a/crates/honk-core/src/dns/cache/tests/store.rs
+++ b/crates/honk-core/src/dns/cache/tests/store.rs
@@ -16,6 +16,17 @@ fn test_put_get() {
 }
 
 #[test]
+fn truncated_responses_are_not_cached() {
+    let mut cache = DnsCache::new(10);
+    let mut response = make_test_response([192, 0, 2, 1], 300);
+    response[2..4].copy_from_slice(&0x8380_u16.to_be_bytes());
+
+    cache.put("truncated.example:1".into(), response, 300);
+
+    assert!(cache.get("truncated.example:1").is_none());
+}
+
+#[test]
 fn legacy_negative_replaces_the_positive_for_the_same_key() {
     let mut cache = DnsCache::new(10);
     let key = "negative.example:1";

--- a/crates/honk-core/src/dns/engine.rs
+++ b/crates/honk-core/src/dns/engine.rs
@@ -176,11 +176,12 @@ impl DnsEngine {
         wire: Vec<u8>,
         strict: bool,
     ) -> Result<ResponseDirective, EngineError> {
+        let truncated = super::response::is_truncated(&wire);
         let strict_reusable = if strict {
             ResponseTemplate::check(&prepared.query, &wire)?;
-            true
+            !truncated
         } else {
-            ResponseTemplate::check(&prepared.query, &wire).is_ok()
+            ResponseTemplate::check(&prepared.query, &wire).is_ok() && !truncated
         };
         let class = classify_response(&wire);
         if matches!(class, ResponseClass::Nxdomain | ResponseClass::Servfail) {
@@ -194,7 +195,11 @@ impl DnsEngine {
                 traversal,
             });
         }
-        let answer_ips = super::forwarder::extract_answer_ips(&wire);
+        let answer_ips = if truncated {
+            Vec::new()
+        } else {
+            super::forwarder::extract_answer_ips(&wire)
+        };
         let current_traversal = traversal.clone();
         let planned = self.planner.plan_response(
             ResponseContext {

--- a/crates/honk-core/src/dns/engine/pipeline.rs
+++ b/crates/honk-core/src/dns/engine/pipeline.rs
@@ -34,11 +34,10 @@ mod flight {
         {
             return Ok(outcome);
         }
-        let response = template.render(context.prepared.query())?;
         context.forwarder.outcome_from_wire(
             context.engine,
             context.prepared,
-            response,
+            template.wire(),
             None,
             OutcomeStatus::Accepted,
             Provenance::Upstream,

--- a/crates/honk-core/src/dns/forwarder/exchange.rs
+++ b/crates/honk-core/src/dns/forwarder/exchange.rs
@@ -115,8 +115,10 @@ impl DnsForwarder {
             Some(template) => template.render(query)?,
             None => patch_txid(reusable.to_vec(), query.txid().get()),
         };
+        let truncated = crate::dns::response::is_truncated(&reusable);
         let response_class = crate::dns::engine::classify_response(&reusable);
-        let answer_ips = if status == OutcomeStatus::Accepted
+        let answer_ips = if !truncated
+            && status == OutcomeStatus::Accepted
             && response_class == crate::dns::outcome::ResponseClass::Positive
         {
             match analyzed_answer_ips {
@@ -221,7 +223,7 @@ impl DnsForwarder {
         match ingress {
             IngressProfile::Udp { .. } => {
                 let response = self.query_asis_udp(raw_query, destination).await?;
-                if response.get(2).is_some_and(|flags| flags & 0x02 != 0) {
+                if crate::dns::response::is_truncated(&response) {
                     debug!(
                         destination = %destination,
                         "DNS forwarder: truncated asis UDP response, retrying over TCP"

--- a/crates/honk-core/src/dns/response.rs
+++ b/crates/honk-core/src/dns/response.rs
@@ -12,6 +12,12 @@ const TC: u16 = 0x0200;
 const OPCODE_MASK: u16 = 0x7800;
 const RA: u16 = 0x0080;
 const QUERY_ECHO_MASK: u16 = OPCODE_MASK | 0x0110;
+pub(crate) fn is_truncated(response: &[u8]) -> bool {
+    let Some(flags) = response.get(2..4) else {
+        return false;
+    };
+    u16::from_be_bytes([flags[0], flags[1]]) & TC != 0
+}
 
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum ResponseError {
@@ -80,6 +86,9 @@ impl ResponseTemplate {
             question_end,
             records,
         })
+    }
+    pub(crate) fn wire(&self) -> Bytes {
+        self.wire.clone()
     }
 
     pub fn render(&self, caller: &QueryContext) -> Result<Vec<u8>, ResponseError> {

--- a/crates/honk-core/src/dns/upstream_pool/query.rs
+++ b/crates/honk-core/src/dns/upstream_pool/query.rs
@@ -138,7 +138,7 @@ impl UpstreamPool {
         let response = transport
             .exchange(raw_query, route.feedback.as_ref())
             .await?;
-        let response = if response.len() >= 4 && response[2] & 0x02 != 0 {
+        let response = if crate::dns::response::is_truncated(&response) {
             let tcp_feedback = self.tcp_feedback_for_route(entry, route);
             debug!(
                 "DNS upstream '{}' proxied UDP answer has TC set — retrying over proxied TCP",
@@ -170,7 +170,7 @@ impl UpstreamPool {
     ) -> anyhow::Result<Vec<u8>> {
         let (response, _admission, injected) = exchange;
         let effective_query = injected.as_ref().map_or(raw_query, EcsQuery::wire);
-        let response = if response.len() >= 4 && response[2] & 0x02 != 0 {
+        let response = if crate::dns::response::is_truncated(&response) {
             debug!(
                 "DNS upstream '{}' UDP answer has TC set — retrying over TCP",
                 upstream_name


### PR DESCRIPTION
## Summary

- Centralize DNS TC-bit detection and preserve the full reusable wire for waiters.
- Prevent upstream-truncated responses from cache publication, persistence, answer-IP extraction, or domain-route projection.
- Keep UDP/as-is TCP fallback behavior unchanged.

## Verification

- cargo test -p honk-core --lib --no-default-features --features clash-api
- cargo fmt --all --check
- cargo clippy -p honk-core --lib --no-default-features --features clash-api -- -D warnings
