### PR TITLE
refactor(quic): reuse Chrome TLS context setup

### DIFF
--- a/crates/honk-outbound/src/quic_boring.rs
+++ b/crates/honk-outbound/src/quic_boring.rs
@@ -23,7 +23,7 @@ use std::sync::{Arc, LazyLock};
 use aes::cipher::{BlockCipherEncrypt, KeyInit};
 use boring::aead::{AeadCtx, Algorithm as AeadAlgorithm};
 use boring::error::ErrorStack;
-use boring::ssl::{Ssl, SslContext};
+use boring::ssl::{Ssl, SslContext, SslContextBuilder, SslMethod, SslVerifyMode, SslVersion};
 use bytes::BytesMut;
 use foreign_types::ForeignTypeRef;
 use hkdf::Hkdf;
@@ -583,8 +583,26 @@ impl BoringQuicClientConfig {
             pin_sha256,
             ticket_key,
         } = options;
-        let has_pin = pin_sha256.is_some();
-        let builder = crate::tls::build_quic_context(skip_cert_verify, pin_sha256, chrome)?;
+        let mut builder = SslContextBuilder::new(SslMethod::tls())?;
+        // QUIC mandates TLS 1.3.
+        builder.set_min_proto_version(Some(SslVersion::TLS1_3))?;
+        builder.set_max_proto_version(Some(SslVersion::TLS1_3))?;
+
+        if let Some(pin) = pin_sha256 {
+            // pinSHA256: fingerprint check replaces PKI + hostname checks.
+            builder.set_custom_verify_callback(
+                SslVerifyMode::PEER,
+                crate::tls::pin_sha256_custom_verify(pin),
+            );
+        } else if skip_cert_verify {
+            builder.set_verify(SslVerifyMode::NONE);
+        } else {
+            builder.set_verify(SslVerifyMode::PEER);
+            builder.set_verify_cert_store(crate::tls::root_store()?)?;
+        }
+        if chrome {
+            crate::tls::apply_chrome_ctx(&mut builder)?;
+        }
         // Client-side TLS 1.3 session ticket cache: a repeat connection to
         // the same server can resume (and offer 0-RTT early data when the
         // server accepts it). BoringSSL has no implicit internal cache —
@@ -602,7 +620,7 @@ impl BoringQuicClientConfig {
             alpn_wire,
             chrome,
             ech_config_list,
-            has_pin,
+            has_pin: pin_sha256.is_some(),
             ticket_key,
         })
     }

--- a/crates/honk-outbound/src/quic_boring.rs
+++ b/crates/honk-outbound/src/quic_boring.rs
@@ -23,7 +23,7 @@ use std::sync::{Arc, LazyLock};
 use aes::cipher::{BlockCipherEncrypt, KeyInit};
 use boring::aead::{AeadCtx, Algorithm as AeadAlgorithm};
 use boring::error::ErrorStack;
-use boring::ssl::{Ssl, SslContext, SslMethod, SslVerifyMode, SslVersion};
+use boring::ssl::{Ssl, SslContext};
 use bytes::BytesMut;
 use foreign_types::ForeignTypeRef;
 use hkdf::Hkdf;
@@ -583,29 +583,8 @@ impl BoringQuicClientConfig {
             pin_sha256,
             ticket_key,
         } = options;
-        let mut builder = SslContext::builder(SslMethod::tls())?;
-        // QUIC mandates TLS 1.3.
-        builder.set_min_proto_version(Some(SslVersion::TLS1_3))?;
-        builder.set_max_proto_version(Some(SslVersion::TLS1_3))?;
-
-        if let Some(pin) = pin_sha256 {
-            // pinSHA256: fingerprint check replaces PKI + hostname checks.
-            builder.set_custom_verify_callback(
-                SslVerifyMode::PEER,
-                crate::tls::pin_sha256_custom_verify(pin),
-            );
-        } else if skip_cert_verify {
-            builder.set_verify(SslVerifyMode::NONE);
-        } else {
-            builder.set_verify(SslVerifyMode::PEER);
-            builder.set_verify_cert_store(crate::tls::root_store()?)?;
-        }
-        if chrome {
-            builder.set_grease_enabled(true);
-            builder.set_sigalgs_list(crate::tls::CHROME_SIGALGS)?;
-            builder.set_curves_list(crate::tls::CHROME_CURVES)?;
-            builder.add_certificate_compression_algorithm(crate::tls::BrotliCertCompression)?;
-        }
+        let has_pin = pin_sha256.is_some();
+        let builder = crate::tls::build_quic_context(skip_cert_verify, pin_sha256, chrome)?;
         // Client-side TLS 1.3 session ticket cache: a repeat connection to
         // the same server can resume (and offer 0-RTT early data when the
         // server accepts it). BoringSSL has no implicit internal cache —
@@ -623,7 +602,7 @@ impl BoringQuicClientConfig {
             alpn_wire,
             chrome,
             ech_config_list,
-            has_pin: pin_sha256.is_some(),
+            has_pin,
             ticket_key,
         })
     }

--- a/crates/honk-outbound/src/tls.rs
+++ b/crates/honk-outbound/src/tls.rs
@@ -464,29 +464,6 @@ fn base_builder(skip_cert_verify: bool) -> anyhow::Result<boring::ssl::SslConnec
     Ok(builder)
 }
 
-/// Build the TLS 1.3 context shared by all QUIC backends.
-pub(crate) fn build_quic_context(
-    skip_cert_verify: bool,
-    pin_sha256: Option<[u8; 32]>,
-    chrome: bool,
-) -> anyhow::Result<SslContextBuilder> {
-    let mut builder = SslContextBuilder::new(SslMethod::tls())?;
-    builder.set_min_proto_version(Some(SslVersion::TLS1_3))?;
-    builder.set_max_proto_version(Some(SslVersion::TLS1_3))?;
-    if let Some(pin) = pin_sha256 {
-        builder.set_custom_verify_callback(SslVerifyMode::PEER, pin_sha256_custom_verify(pin));
-    } else if skip_cert_verify {
-        builder.set_verify(SslVerifyMode::NONE);
-    } else {
-        builder.set_verify(SslVerifyMode::PEER);
-        builder.set_verify_cert_store(root_store()?)?;
-    }
-    if chrome {
-        apply_chrome_ctx(&mut builder)?;
-    }
-    Ok(builder)
-}
-
 /// Parse a `pinSHA256` value (hex, optionally colon-separated) into 32 bytes.
 pub fn parse_pin_sha256(s: &str) -> Option<[u8; 32]> {
     let hex: String = s
@@ -525,7 +502,7 @@ pub fn pin_sha256_custom_verify(
     }
 }
 
-fn apply_chrome_ctx(builder: &mut SslContextBuilder) -> anyhow::Result<()> {
+pub(crate) fn apply_chrome_ctx(builder: &mut SslContextBuilder) -> anyhow::Result<()> {
     builder.set_grease_enabled(true);
     builder.set_sigalgs_list(CHROME_SIGALGS)?;
     builder.set_curves_list(CHROME_CURVES)?;

--- a/crates/honk-outbound/src/tls.rs
+++ b/crates/honk-outbound/src/tls.rs
@@ -24,7 +24,7 @@ use base64::engine::general_purpose;
 use boring::error::ErrorStack;
 use boring::ssl::{
     CertificateCompressionAlgorithm, CertificateCompressor, ConnectConfiguration, SslConnector,
-    SslMethod, SslVerifyMode, SslVersion,
+    SslContextBuilder, SslMethod, SslVerifyMode, SslVersion,
 };
 use boring::x509::X509;
 use boring::x509::store::X509StoreBuilder;
@@ -464,6 +464,29 @@ fn base_builder(skip_cert_verify: bool) -> anyhow::Result<boring::ssl::SslConnec
     Ok(builder)
 }
 
+/// Build the TLS 1.3 context shared by all QUIC backends.
+pub(crate) fn build_quic_context(
+    skip_cert_verify: bool,
+    pin_sha256: Option<[u8; 32]>,
+    chrome: bool,
+) -> anyhow::Result<SslContextBuilder> {
+    let mut builder = SslContextBuilder::new(SslMethod::tls())?;
+    builder.set_min_proto_version(Some(SslVersion::TLS1_3))?;
+    builder.set_max_proto_version(Some(SslVersion::TLS1_3))?;
+    if let Some(pin) = pin_sha256 {
+        builder.set_custom_verify_callback(SslVerifyMode::PEER, pin_sha256_custom_verify(pin));
+    } else if skip_cert_verify {
+        builder.set_verify(SslVerifyMode::NONE);
+    } else {
+        builder.set_verify(SslVerifyMode::PEER);
+        builder.set_verify_cert_store(root_store()?)?;
+    }
+    if chrome {
+        apply_chrome_ctx(&mut builder)?;
+    }
+    Ok(builder)
+}
+
 /// Parse a `pinSHA256` value (hex, optionally colon-separated) into 32 bytes.
 pub fn parse_pin_sha256(s: &str) -> Option<[u8; 32]> {
     let hex: String = s
@@ -502,7 +525,7 @@ pub fn pin_sha256_custom_verify(
     }
 }
 
-fn apply_chrome_ctx(builder: &mut boring::ssl::SslConnectorBuilder) -> anyhow::Result<()> {
+fn apply_chrome_ctx(builder: &mut SslContextBuilder) -> anyhow::Result<()> {
     builder.set_grease_enabled(true);
     builder.set_sigalgs_list(CHROME_SIGALGS)?;
     builder.set_curves_list(CHROME_CURVES)?;


### PR DESCRIPTION
## Summary
- reuse the existing Chrome TLS-context setup for QUIC and the TCP/HTTP/DNS connectors
- keep QUIC's one-caller TLS 1.3 context construction local to `BoringQuicClientConfig::new`
- preserve pinSHA256 verification, webpki roots, ECH, ticket caching, and Chrome wire settings
- add no dependency or configuration surface

## Scope
The earlier revision extracted the complete QUIC context builder into `tls.rs`, but it had one caller. This revision removes that abstraction and shares only the Chrome setup used by the four context builders.

The abandoned local quiche/DoQ experiment remains excluded; this PR contains no quiche code or dependency.

## Verification
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY ci/outbound-ci.sh` — `outbound-ci: ALL GREEN`
- `cargo check -p honk-outbound`
- focused QUIC/TLS tests