### PR TITLE
fix(udp): separate congestion from tunnel death

### DIFF
--- a/crates/honk-core/src/control/connection/udp.rs
+++ b/crates/honk-core/src/control/connection/udp.rs
@@ -171,11 +171,7 @@ impl ControlPlaneHandle {
             use crate::control::packet_sniffer::QuicSniffOutcome;
             let sniffer_key =
                 crate::control::packet_sniffer::PacketSnifferKey::new(client_addr, original_dst);
-            let mut outcome = if self.sniffer_pool.is_dcid_failed(&sniffer_key) {
-                QuicSniffOutcome::NotQuic
-            } else {
-                self.sniffer_pool.feed_quic_initial(sniffer_key, &data)
-            };
+            let mut outcome = self.sniffer_pool.feed_quic_initial(sniffer_key, &data);
             // A fragmented ClientHello: collect the rest of the Initial
             // flight before deciding which outbound owns the flow.
             if matches!(outcome, QuicSniffOutcome::Incomplete) {
@@ -571,8 +567,8 @@ impl ControlPlaneHandle {
         driver.start_with_followers(first, sniffed_followers)?;
         self.spawn_process_path_enrichment(conn_id, handoff.as_ref());
         if let Err(error) = driver.wait_first_ack().await {
-            // PacketTransport Err and timeout are ambiguous: the winner may
-            // have received part of the initial flight, so never replay it.
+            // First-send failures are terminal for this endpoint; once the
+            // transport call starts, the packet is never replayed.
             self.stats.record_error(&outbound_name);
             return Err(error.into());
         }

--- a/crates/honk-core/src/control/packet_sniffer.rs
+++ b/crates/honk-core/src/control/packet_sniffer.rs
@@ -28,6 +28,8 @@ const NO_SNI_BYPASS_TTL: Duration = Duration::from_secs(1);
 /// Upper bound on Initial packets sniffed per flow while a ClientHello
 /// stays fragmented; beyond it the flow is treated as unresolvable.
 const MAX_INITIAL_SNIFF_PACKETS: u32 = 8;
+/// Keep unrelated Initial decryptions off one pool mutex.
+const SNIFFER_SHARDS: usize = 32;
 
 /// Outcome of feeding one datagram to the QUIC Initial sniffer.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -138,10 +140,6 @@ impl SnifferSession {
         }
     }
 
-    fn is_expired(&self) -> bool {
-        Instant::now() > self.expires_at
-    }
-
     fn should_bypass(&self) -> bool {
         self.no_sni_count >= NO_SNI_THRESHOLD
     }
@@ -149,24 +147,62 @@ impl SnifferSession {
 
 /// Pool of packet sniffers with DCID negative caching.
 pub struct PacketSnifferPool {
-    sessions: Mutex<HashMap<PacketSnifferKey, SnifferSession>>,
-    failed_dcids: Mutex<HashMap<PacketSnifferKey, Instant>>,
+    sessions: Box<[Mutex<HashMap<PacketSnifferKey, SnifferSession>>]>,
+    failed_dcids: Box<[Mutex<HashMap<PacketSnifferKey, Instant>>]>,
 }
 
 impl PacketSnifferPool {
     pub fn new() -> Self {
+        let sessions = (0..SNIFFER_SHARDS)
+            .map(|_| Mutex::new(HashMap::new()))
+            .collect();
+        let failed_dcids = (0..SNIFFER_SHARDS)
+            .map(|_| Mutex::new(HashMap::new()))
+            .collect();
         Self {
-            sessions: Mutex::new(HashMap::new()),
-            failed_dcids: Mutex::new(HashMap::new()),
+            sessions,
+            failed_dcids,
         }
+    }
+
+    fn shard_index(key: &PacketSnifferKey) -> usize {
+        let mut hash = 0xcbf29ce484222325u64;
+        for byte in key.src_ip.iter().chain(key.dst_ip.iter()) {
+            hash ^= u64::from(*byte);
+            hash = hash.wrapping_mul(0x100000001b3);
+        }
+        for value in [key.src_port, key.dst_port] {
+            hash ^= u64::from(value);
+            hash = hash.wrapping_mul(0x100000001b3);
+        }
+        (hash as usize) & (SNIFFER_SHARDS - 1)
+    }
+
+    fn terminal_outcome(&self, shard: usize, key: &PacketSnifferKey) -> Option<QuicSniffOutcome> {
+        let sessions = self.sessions[shard].lock();
+        let session = sessions.get(key)?;
+        if !session.done {
+            return None;
+        }
+        Some(
+            session
+                .domain
+                .clone()
+                .map(QuicSniffOutcome::Domain)
+                .unwrap_or(QuicSniffOutcome::CompleteNoDomain),
+        )
+    }
+
+    fn is_dcid_failed_at(&self, shard: usize, key: &PacketSnifferKey) -> bool {
+        self.failed_dcids[shard]
+            .lock()
+            .get(key)
+            .is_some_and(|expires_at| Instant::now() < *expires_at)
     }
 
     /// Check if a DCID is in the failed cache (should skip sniffing).
     pub fn is_dcid_failed(&self, key: &PacketSnifferKey) -> bool {
-        self.failed_dcids
-            .lock()
-            .get(key)
-            .is_some_and(|expires_at| Instant::now() < *expires_at)
+        self.is_dcid_failed_at(Self::shard_index(key), key)
     }
 
     /// Record a failed DCID with a soft bypass duration.
@@ -179,12 +215,17 @@ impl PacketSnifferPool {
         self.mark_dcid_failed_for(key, Duration::from_secs(30));
     }
 
-    fn mark_dcid_failed_for(&self, key: PacketSnifferKey, ttl: Duration) {
-        let mut cache = self.failed_dcids.lock();
-        cache.insert(key, Instant::now() + ttl);
-        if cache.len() > 16_384 {
-            cache.retain(|_, expires_at| Instant::now() < *expires_at);
+    fn mark_dcid_failed_for_shard(&self, shard: usize, key: PacketSnifferKey, ttl: Duration) {
+        let mut cache = self.failed_dcids[shard].lock();
+        let now = Instant::now();
+        cache.insert(key, now + ttl);
+        if cache.len() > 512 {
+            cache.retain(|_, expires_at| *expires_at > now);
         }
+    }
+
+    fn mark_dcid_failed_for(&self, key: PacketSnifferKey, ttl: Duration) {
+        self.mark_dcid_failed_for_shard(Self::shard_index(&key), key, ttl);
     }
 
     /// Feed a UDP datagram (expected to carry QUIC Initial packet(s)) to the
@@ -192,16 +233,21 @@ impl PacketSnifferPool {
     /// a genuine QUIC Initial, carrying the SNI hostname when extraction
     /// succeeded — see [`QuicSniffOutcome`].
     pub fn feed_quic_initial(&self, key: PacketSnifferKey, data: &[u8]) -> QuicSniffOutcome {
-        if self.is_dcid_failed(&key) {
+        let shard = Self::shard_index(&key);
+        if self.is_dcid_failed_at(shard, &key) {
             return QuicSniffOutcome::NotQuic;
         }
+        if let Some(outcome) = self.terminal_outcome(shard, &key) {
+            return outcome;
+        }
 
-        // Decrypt the Initial packet(s) first (stateless, no lock needed).
+        // Decrypt the Initial packet(s) without holding a pool lock.
         let fragments = quic::decrypt_initial_datagram(data);
 
-        let mut sessions = self.sessions.lock();
+        let mut sessions = self.sessions[shard].lock();
         let session = sessions.entry(key).or_insert_with(SnifferSession::new);
 
+        // Another packet on this flow may have completed while decryption ran.
         if session.done {
             return session
                 .domain
@@ -218,7 +264,7 @@ impl PacketSnifferPool {
             // open — marking it done would later read as CompleteNoDomain
             // and make an unresolved flow offloadable.
             drop(sessions);
-            self.mark_dcid_failed_soft(key);
+            self.mark_dcid_failed_for_shard(shard, key, NO_SNI_BYPASS_TTL);
             debug!("QUIC ClientHello never completed; flow bypassed");
             return QuicSniffOutcome::NotQuic;
         }
@@ -236,7 +282,7 @@ impl PacketSnifferPool {
                 drop(sessions);
                 if failed {
                     debug!("QUIC sniffing bypassed after repeated decrypt failures: {err:?}");
-                    self.mark_dcid_failed_decrypt(key);
+                    self.mark_dcid_failed_for_shard(shard, key, Duration::from_secs(30));
                 }
                 return QuicSniffOutcome::NotQuic;
             }
@@ -267,7 +313,7 @@ impl PacketSnifferPool {
                 // a domain.
                 session.done = true;
                 drop(sessions);
-                self.mark_dcid_failed_soft(key);
+                self.mark_dcid_failed_for_shard(shard, key, NO_SNI_BYPASS_TTL);
                 debug!("QUIC ClientHello carried no SNI; flow bypassed");
                 QuicSniffOutcome::CompleteNoDomain
             }
@@ -285,7 +331,7 @@ impl PacketSnifferPool {
                 }
                 drop(sessions);
                 if should_bypass {
-                    self.mark_dcid_failed_soft(key);
+                    self.mark_dcid_failed_for_shard(shard, key, NO_SNI_BYPASS_TTL);
                     debug!("QUIC DCID marked failed after no-SNI threshold");
                 }
                 QuicSniffOutcome::CompleteNoDomain
@@ -295,20 +341,23 @@ impl PacketSnifferPool {
 
     /// Run a janitor cycle: remove expired sessions.
     pub fn janitor_cycle(&self) -> usize {
-        let mut sessions = self.sessions.lock();
-        let before = sessions.len();
-        sessions.retain(|_, s| !s.is_expired());
-        let removed = before - sessions.len();
+        let now = Instant::now();
+        let mut removed = 0;
+        for shard in &self.sessions {
+            let mut sessions = shard.lock();
+            let before = sessions.len();
+            sessions.retain(|_, session| now <= session.expires_at);
+            removed += before - sessions.len();
+        }
+        for shard in &self.failed_dcids {
+            shard.lock().retain(|_, expires_at| *expires_at > now);
+        }
         if removed > 0 {
             debug!(
                 "Packet sniffer janitor removed {} expired sessions",
                 removed
             );
         }
-
-        let mut dcids = self.failed_dcids.lock();
-        dcids.retain(|_, expires_at| Instant::now() < *expires_at);
-
         removed
     }
 

--- a/crates/honk-core/src/control/udp_endpoint/driver.rs
+++ b/crates/honk-core/src/control/udp_endpoint/driver.rs
@@ -10,6 +10,54 @@ pub(super) const DRIVER_ABORT_TIMEOUT: Duration = Duration::from_secs(1);
 /// Includes the eagerly-created original-destination socket. Reaching the
 /// bound fails the endpoint closed rather than replying from the wrong source.
 const MAX_REPLY_SOCKETS_PER_ENDPOINT: usize = 8;
+#[derive(Debug)]
+enum PacketSendFailure {
+    Congestion(io::Error),
+    Transport(io::Error),
+}
+/// Marker separating receiver-idle expiry from a transport send timeout.
+#[derive(Debug)]
+pub(super) struct ReplyIdleTimeout;
+
+impl std::fmt::Display for ReplyIdleTimeout {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("UDP endpoint reply idle timeout")
+    }
+}
+
+impl std::error::Error for ReplyIdleTimeout {}
+
+fn is_reply_idle_timeout(error: &io::Error) -> bool {
+    error
+        .get_ref()
+        .and_then(|source| source.downcast_ref::<ReplyIdleTimeout>())
+        .is_some()
+}
+
+impl PacketSendFailure {
+    fn into_io_error(self) -> io::Error {
+        match self {
+            Self::Congestion(error) => io::Error::new(io::ErrorKind::WouldBlock, error),
+            Self::Transport(error) => error,
+        }
+    }
+}
+
+fn classify_send_error(
+    transport: &dyn honk_outbound::proxy::PacketTransport,
+    error: io::Error,
+) -> PacketSendFailure {
+    if matches!(
+        honk_outbound::proxy::packet_error_class(&error),
+        honk_outbound::proxy::PacketErrorClass::Congestion
+    ) || (error.kind() == io::ErrorKind::TimedOut && transport.send_timeout_is_congestion())
+    {
+        PacketSendFailure::Congestion(error)
+    } else {
+        PacketSendFailure::Transport(error)
+    }
+}
+
 pub(super) struct TaskRegistry {
     pub(super) closed: bool,
     pub(super) tasks: tokio::task::JoinSet<()>,
@@ -211,7 +259,15 @@ pub(super) fn score_driver_outcome(
     }
     match result {
         Ok(()) => ScoreOutcome::Success,
-        Err(error) if error.kind() == io::ErrorKind::TimedOut => {
+        Err(error)
+            if matches!(
+                honk_outbound::proxy::packet_error_class(error),
+                honk_outbound::proxy::PacketErrorClass::Congestion
+            ) =>
+        {
+            ScoreOutcome::Cancelled
+        }
+        Err(error) if is_reply_idle_timeout(error) => {
             if endpoint.has_reply() {
                 ScoreOutcome::Success
             } else {
@@ -335,33 +391,43 @@ pub(super) async fn run_endpoint_driver(
     // Send that retained prefix before the untouched receiver queue so the
     // server sees the original flight in order without waiting for a PTO.
     let UdpDriverStart { first, followers } = initial;
-    let mut initial_result = send_one(&endpoint, &stats, &outbound_tracker, first, true).await;
-    if initial_result.is_ok() {
-        for follower in followers {
-            if let Err(error) =
-                send_one(&endpoint, &stats, &outbound_tracker, follower, false).await
-            {
-                initial_result = Err(error);
-                break;
-            }
+    if let Err(failure) = send_one(&endpoint, &stats, &outbound_tracker, first, true).await {
+        let congested = matches!(&failure, PacketSendFailure::Congestion(_));
+        let error = failure.into_io_error();
+        if !congested && !endpoint.dead.load(Ordering::Acquire) {
+            alive_set.report_unavailable_traffic(
+                endpoint.node_id,
+                honk_outbound::alive::ProbeDomain::DataUdp,
+                health_family,
+            );
         }
+        let _ = first_ack.send(Err(io::Error::new(error.kind(), error.to_string())));
+        return Err(error);
     }
-    match initial_result {
-        Ok(()) => {
-            let _ = first_ack.send(Ok(()));
-        }
-        Err(error) => {
-            if !endpoint.dead.load(Ordering::Acquire) {
-                alive_set.report_unavailable_traffic(
-                    endpoint.node_id,
-                    honk_outbound::alive::ProbeDomain::DataUdp,
-                    health_family,
+
+    for follower in followers {
+        match send_one(&endpoint, &stats, &outbound_tracker, follower, false).await {
+            Ok(()) => {}
+            Err(PacketSendFailure::Congestion(error)) => {
+                debug!(
+                    "UDP endpoint packet dropped under send congestion: {}",
+                    error
                 );
             }
-            let _ = first_ack.send(Err(io::Error::new(error.kind(), error.to_string())));
-            return Err(error);
+            Err(PacketSendFailure::Transport(error)) => {
+                if !endpoint.dead.load(Ordering::Acquire) {
+                    alive_set.report_unavailable_traffic(
+                        endpoint.node_id,
+                        honk_outbound::alive::ProbeDomain::DataUdp,
+                        health_family,
+                    );
+                }
+                let _ = first_ack.send(Err(io::Error::new(error.kind(), error.to_string())));
+                return Err(error);
+            }
         }
     }
+    let _ = first_ack.send(Ok(()));
 
     let sender = send_followers(
         Arc::clone(&endpoint),
@@ -385,7 +451,14 @@ pub(super) async fn run_endpoint_driver(
         result = &mut sender => result,
         result = &mut receiver => result,
     };
-    if result.is_err() && !endpoint.dead.load(Ordering::Acquire) {
+    if let Err(error) = &result
+        && !endpoint.dead.load(Ordering::Acquire)
+        && !matches!(
+            honk_outbound::proxy::packet_error_class(error),
+            honk_outbound::proxy::PacketErrorClass::Congestion
+        )
+        && !(is_reply_idle_timeout(error) && endpoint.has_reply())
+    {
         alive_set.report_unavailable_traffic(
             endpoint.node_id,
             honk_outbound::alive::ProbeDomain::DataUdp,
@@ -402,10 +475,19 @@ async fn send_followers(
     outbound_tracker: OutboundTracker,
 ) -> io::Result<()> {
     while let Some(packet) = queue_rx.recv().await {
-        send_one(&endpoint, &stats, &outbound_tracker, packet, false).await?;
+        match send_one(&endpoint, &stats, &outbound_tracker, packet, false).await {
+            Ok(()) => {}
+            Err(PacketSendFailure::Congestion(error)) => {
+                debug!(
+                    "UDP endpoint packet dropped under send congestion: {}",
+                    error
+                );
+            }
+            Err(PacketSendFailure::Transport(error)) => return Err(error),
+        }
     }
     Err(io::Error::new(
-        io::ErrorKind::BrokenPipe,
+        io::ErrorKind::Interrupted,
         "UDP endpoint queue closed",
     ))
 }
@@ -416,11 +498,13 @@ async fn send_one(
     outbound_tracker: &OutboundTracker,
     packet: QueuedDatagram,
     first: bool,
-) -> io::Result<()> {
+) -> Result<(), PacketSendFailure> {
     // This is the application-send linearization point. Node death that wins
-    // before it prevents any transport call; death after it is ambiguous, so
-    // this driver never retries the packet or starts later followers.
-    endpoint.begin_send_attempt()?;
+    // before it prevents any transport call; congestion or a post-send error
+    // never causes this packet to be replayed.
+    endpoint
+        .begin_send_attempt()
+        .map_err(PacketSendFailure::Transport)?;
     let started = first.then(Instant::now);
     let sent = tokio::time::timeout(TRANSPORT_SEND_TIMEOUT, async {
         if first {
@@ -434,10 +518,14 @@ async fn send_one(
     })
     .await;
     let result = match sent {
-        Ok(result) => result,
-        Err(_) => Err(io::Error::new(
-            io::ErrorKind::TimedOut,
-            "UDP PacketTransport send timed out",
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(error)) => Err(classify_send_error(endpoint.proxy_socket.as_ref(), error)),
+        Err(_) => Err(classify_send_error(
+            endpoint.proxy_socket.as_ref(),
+            io::Error::new(
+                io::ErrorKind::TimedOut,
+                "UDP PacketTransport send timed out",
+            ),
         )),
     };
     if let Some(started) = started {
@@ -450,11 +538,11 @@ async fn send_one(
             outbound_tracker.add_bytes(packet.data.len() as u64, 0);
             Ok(())
         }
-        Err(error) => {
+        Err(failure) => {
             if first {
                 stats.record_udp_first_send_failure();
             }
-            Err(error)
+            Err(failure)
         }
     }
 }
@@ -485,10 +573,7 @@ async fn receive_loop(
             Ok(Ok(packet)) => packet,
             Ok(Err(error)) => return Err(error),
             Err(_) => {
-                return Err(io::Error::new(
-                    io::ErrorKind::TimedOut,
-                    "UDP endpoint reply idle timeout",
-                ));
+                return Err(io::Error::new(io::ErrorKind::TimedOut, ReplyIdleTimeout));
             }
         };
         if source != endpoint.relay_addr

--- a/crates/honk-core/src/control/udp_endpoint/mod.rs
+++ b/crates/honk-core/src/control/udp_endpoint/mod.rs
@@ -399,7 +399,7 @@ use driver::{
 };
 #[cfg(test)]
 use driver::{
-    REPLY_IDLE_TIMEOUT, TRANSPORT_SEND_TIMEOUT, UdpDriverContext, UdpDriverStart,
+    REPLY_IDLE_TIMEOUT, ReplyIdleTimeout, TRANSPORT_SEND_TIMEOUT, UdpDriverContext, UdpDriverStart,
     run_endpoint_driver,
 };
 

--- a/crates/honk-core/src/control/udp_endpoint/tests.rs
+++ b/crates/honk-core/src/control/udp_endpoint/tests.rs
@@ -42,6 +42,29 @@ async fn explicit_retirement_is_neutral_until_a_reply_makes_it_useful() {
     );
 }
 
+#[tokio::test]
+async fn send_timeout_after_reply_is_not_idle_success() {
+    let socket = Arc::new(UdpSocket::bind("127.0.0.1:0").await.unwrap());
+    let relay = "127.0.0.1:53".parse().unwrap();
+    let endpoint = UdpEndpoint::new(transport(socket, relay), relay, uuid::Uuid::new_v4());
+    endpoint.has_reply.store(true, Ordering::Relaxed);
+
+    let send_timeout = Err(io::Error::new(
+        io::ErrorKind::TimedOut,
+        "UDP PacketTransport send timed out",
+    ));
+    assert_eq!(
+        score_driver_outcome(&endpoint, &send_timeout),
+        ScoreOutcome::Io(io::ErrorKind::TimedOut)
+    );
+
+    let idle_timeout = Err(io::Error::new(io::ErrorKind::TimedOut, ReplyIdleTimeout));
+    assert_eq!(
+        score_driver_outcome(&endpoint, &idle_timeout),
+        ScoreOutcome::Success
+    );
+}
+
 async fn recv_and_ack(
     pool: &UdpEndpointPool,
     rx: &mut mpsc::Receiver<EndpointRemoval>,
@@ -133,6 +156,7 @@ fn make_addr(ip: &str, port: u16) -> SocketAddr {
 enum DriverSendAction {
     Ok,
     Error,
+    Congestion,
     Panic,
     Pending,
     WaitThenOk(Arc<tokio::sync::Notify>),
@@ -232,6 +256,10 @@ impl honk_outbound::proxy::PacketTransport for ScriptedPacketTransport {
         match action {
             DriverSendAction::Ok => Ok(()),
             DriverSendAction::Error => Err(io::Error::other("scripted UDP send failure")),
+            DriverSendAction::Congestion => Err(io::Error::new(
+                io::ErrorKind::WouldBlock,
+                "scripted UDP send congestion",
+            )),
             DriverSendAction::Panic => panic!("scripted UDP send panic"),
             DriverSendAction::Pending => std::future::pending::<io::Result<()>>().await,
             DriverSendAction::WaitThenOk(release) => {
@@ -1247,7 +1275,7 @@ async fn udp_endpoint_worker_sends_first_then_fifo_followers() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn udp_endpoint_worker_times_out_first_send_after_five_seconds() {
+async fn udp_endpoint_worker_treats_stream_send_timeout_as_connection_dead() {
     let pool = Arc::new(UdpEndpointPool::new());
     let stats = Arc::new(StatsManager::new());
     let client = make_addr("10.0.0.1", 12345);
@@ -1283,13 +1311,15 @@ async fn udp_endpoint_worker_times_out_first_send_after_five_seconds() {
         worker.await.unwrap().unwrap_err().kind(),
         io::ErrorKind::TimedOut
     );
+
     assert_eq!(stats.udp_snapshot().first_send_failures, 1);
 }
 
 #[tokio::test(start_paused = true)]
-async fn udp_endpoint_worker_times_out_steady_send_after_five_seconds() {
+async fn udp_endpoint_worker_keeps_flow_alive_on_congested_steady_send() {
     let pool = Arc::new(UdpEndpointPool::new());
     let stats = Arc::new(StatsManager::new());
+    let alive = Arc::new(honk_outbound::alive::AliveDialerSet::new());
     let client = make_addr("10.0.0.1", 12345);
     let dst = make_addr("8.8.8.8", 53);
     let relay = make_addr("192.168.1.1", 1080);
@@ -1297,7 +1327,7 @@ async fn udp_endpoint_worker_times_out_steady_send_after_five_seconds() {
         reserve_driver_packets(&pool, &stats, client, dst, b"first", &[b"steady"]);
     let transport = Arc::new(ScriptedPacketTransport::new(
         relay,
-        [DriverSendAction::Ok, DriverSendAction::Pending],
+        [DriverSendAction::Ok, DriverSendAction::Congestion],
     ));
     let endpoint = driver_test_endpoint(Arc::clone(&transport), relay);
     let (first_ack_tx, first_ack_rx) = oneshot::channel();
@@ -1307,21 +1337,30 @@ async fn udp_endpoint_worker_times_out_steady_send_after_five_seconds() {
         test_reply_socket().await,
         client,
         dst,
-        Arc::new(honk_outbound::alive::AliveDialerSet::new()),
+        Arc::clone(&alive),
         Arc::clone(&stats),
         "test-node".to_owned(),
         first,
         first_ack_tx,
     ));
 
-    first_ack_rx.await.unwrap().unwrap();
+    assert!(first_ack_rx.await.unwrap().is_ok());
     transport.wait_for_send_count(2).await;
-    tokio::time::advance(TRANSPORT_SEND_TIMEOUT).await;
     assert_eq!(
         worker.await.unwrap().unwrap_err().kind(),
-        io::ErrorKind::TimedOut
+        io::ErrorKind::Interrupted
     );
     assert_eq!(stats.udp_snapshot().first_send_failures, 0);
+    assert!(
+        alive
+            .get_probe_history(
+                TEST_NODE_ID,
+                honk_outbound::alive::ProbeDomain::DataUdp,
+                honk_outbound::alive::IpVersion::V4,
+            )
+            .is_empty(),
+        "send congestion must not report the node unavailable"
+    );
 }
 
 #[tokio::test]

--- a/crates/honk-core/src/stats.rs
+++ b/crates/honk-core/src/stats.rs
@@ -646,7 +646,7 @@ impl StatsManager {
         self.udp.first_send_latency.record(elapsed);
     }
 
-    /// Record a first-send error or timeout (both are ambiguous sends).
+    /// Record a first-send failure; the packet is never replayed.
     pub fn record_udp_first_send_failure(&self) {
         self.udp.first_send_failures.fetch_add(1, Ordering::Relaxed);
     }

--- a/crates/honk-outbound/src/proxy/hysteria2/mod.rs
+++ b/crates/honk-outbound/src/proxy/hysteria2/mod.rs
@@ -821,6 +821,9 @@ impl PacketTransport for Hy2UdpTransport {
     fn relay_addr(&self) -> SocketAddr {
         self.target
     }
+    fn send_timeout_is_congestion(&self) -> bool {
+        true
+    }
 
     async fn send_packet(&self, data: &[u8]) -> io::Result<()> {
         if data.len() > MAX_UDP_SIZE {
@@ -845,7 +848,8 @@ impl PacketTransport for Hy2UdpTransport {
         for packet in packets {
             self.state
                 .conn
-                .send_datagram(bytes::Bytes::from(packet))
+                .send_datagram_wait(bytes::Bytes::from(packet))
+                .await
                 .map_err(io::Error::other)?;
         }
         Ok(())

--- a/crates/honk-outbound/src/proxy/mod.rs
+++ b/crates/honk-outbound/src/proxy/mod.rs
@@ -183,6 +183,60 @@ impl ProxyStream {
     }
 }
 
+/// Coarse classification for packet-send failures shared with the control plane.
+///
+/// Congestion is deliberately separate from a dead tunnel: dropping one UDP
+/// packet under backpressure must not demote an otherwise live outbound.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PacketErrorClass {
+    Congestion,
+    ConnectionDead,
+    Other,
+}
+
+/// Classify an error returned by a [`PacketTransport`] operation.
+pub fn packet_error_class(error: &std::io::Error) -> PacketErrorClass {
+    if matches!(
+        error.kind(),
+        std::io::ErrorKind::WouldBlock | std::io::ErrorKind::Interrupted
+    ) || error.raw_os_error() == Some(libc::ENOBUFS)
+    {
+        return PacketErrorClass::Congestion;
+    }
+
+    let mut source = error
+        .get_ref()
+        .map(|source| source as &(dyn std::error::Error + 'static));
+    while let Some(current) = source {
+        if let Some(quic_error) = current.downcast_ref::<quinn::SendDatagramError>() {
+            return match quic_error {
+                quinn::SendDatagramError::ConnectionLost(_) => PacketErrorClass::ConnectionDead,
+                quinn::SendDatagramError::TooLarge => PacketErrorClass::Congestion,
+                quinn::SendDatagramError::UnsupportedByPeer
+                | quinn::SendDatagramError::Disabled => PacketErrorClass::Other,
+            };
+        }
+        source = current.source();
+    }
+
+    if matches!(
+        error.kind(),
+        std::io::ErrorKind::ConnectionAborted
+            | std::io::ErrorKind::ConnectionReset
+            | std::io::ErrorKind::BrokenPipe
+            | std::io::ErrorKind::UnexpectedEof
+            | std::io::ErrorKind::NotConnected
+            | std::io::ErrorKind::ConnectionRefused
+            | std::io::ErrorKind::NetworkUnreachable
+            | std::io::ErrorKind::HostUnreachable
+            | std::io::ErrorKind::AddrNotAvailable
+    ) {
+        PacketErrorClass::ConnectionDead
+    } else {
+        PacketErrorClass::Other
+    }
+}
+
 /// Framed UDP packet transport — the production UDP contract. Native UDP
 /// protocols wrap a real `UdpSocket`; tunnel protocols implement their
 /// framing directly on the tunnel instead of bouncing datagrams through a
@@ -194,6 +248,12 @@ pub trait PacketTransport: Send + Sync + Debug {
     /// Whether server-carried metadata may authoritatively name a logical
     /// reply source before the endpoint has observed its first response.
     fn allows_full_cone_replies(&self) -> bool {
+        false
+    }
+    /// Whether a driver send deadline is packet-local congestion rather than
+    /// evidence that the tunnel died. Stream-framed transports keep the safe
+    /// default of `false`; atomic datagram/QUIC waits opt in.
+    fn send_timeout_is_congestion(&self) -> bool {
         false
     }
     async fn send_packet(&self, data: &[u8]) -> std::io::Result<()>;
@@ -263,6 +323,9 @@ impl<T: Send + Sync> PacketTransport for RuntimeOwnedPacketTransport<T> {
     }
     fn allows_full_cone_replies(&self) -> bool {
         self.inner.allows_full_cone_replies()
+    }
+    fn send_timeout_is_congestion(&self) -> bool {
+        self.inner.send_timeout_is_congestion()
     }
 
     async fn send_packet(&self, data: &[u8]) -> std::io::Result<()> {
@@ -378,6 +441,9 @@ impl UdpSocketTransport {
 impl PacketTransport for UdpSocketTransport {
     fn relay_addr(&self) -> SocketAddr {
         self.relay_addr
+    }
+    fn send_timeout_is_congestion(&self) -> bool {
+        true
     }
     async fn send_packet(&self, data: &[u8]) -> std::io::Result<()> {
         self.socket.send_to(data, self.relay_addr).await?;
@@ -957,6 +1023,45 @@ mod tests {
         assert!(registry.find(NodeProtocol::VMess).is_some());
         assert!(registry.find(NodeProtocol::Tuic).is_some());
         assert!(registry.find(NodeProtocol::Juicity).is_some());
+    }
+    #[test]
+    fn packet_error_class_separates_backpressure_from_dead_tunnel() {
+        for kind in [
+            std::io::ErrorKind::WouldBlock,
+            std::io::ErrorKind::Interrupted,
+        ] {
+            assert_eq!(
+                packet_error_class(&std::io::Error::new(kind, "backpressure")),
+                PacketErrorClass::Congestion
+            );
+        }
+        assert_eq!(
+            packet_error_class(&std::io::Error::from_raw_os_error(libc::ENOBUFS)),
+            PacketErrorClass::Congestion
+        );
+        assert_eq!(
+            packet_error_class(&std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "closed",
+            )),
+            PacketErrorClass::ConnectionDead
+        );
+        assert_eq!(
+            packet_error_class(&std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "operation timeout",
+            )),
+            PacketErrorClass::Other
+        );
+        let quic_error = std::io::Error::other(quinn::SendDatagramError::ConnectionLost(
+            quinn::ConnectionError::Reset,
+        ));
+        assert_eq!(
+            packet_error_class(&quic_error),
+            PacketErrorClass::ConnectionDead
+        );
+        let too_large = std::io::Error::other(quinn::SendDatagramError::TooLarge);
+        assert_eq!(packet_error_class(&too_large), PacketErrorClass::Congestion);
     }
 
     /// Without the `rprx` feature a parsed VLESS/VMess node must hit the

--- a/crates/honk-outbound/src/proxy/shadowsocks.rs
+++ b/crates/honk-outbound/src/proxy/shadowsocks.rs
@@ -544,6 +544,9 @@ impl PacketTransport for SsUdpTransport {
     fn relay_addr(&self) -> SocketAddr {
         self.target
     }
+    fn send_timeout_is_congestion(&self) -> bool {
+        true
+    }
 
     async fn send_packet(&self, data: &[u8]) -> std::io::Result<()> {
         // The endpoint driver already serializes this flow's sends. Receive

--- a/crates/honk-outbound/src/proxy/socks5.rs
+++ b/crates/honk-outbound/src/proxy/socks5.rs
@@ -473,6 +473,9 @@ impl PacketTransport for Socks5UdpTransport {
     fn relay_addr(&self) -> SocketAddr {
         self.target_addr
     }
+    fn send_timeout_is_congestion(&self) -> bool {
+        true
+    }
 
     async fn send_packet(&self, data: &[u8]) -> io::Result<()> {
         let mut packet = Vec::with_capacity(self.destination_header.len() + data.len());

--- a/crates/honk-outbound/src/proxy/trojan.rs
+++ b/crates/honk-outbound/src/proxy/trojan.rs
@@ -262,10 +262,13 @@ impl PacketTransport for TrojanUdpTransport {
                 "trojan udp frame too large",
             ));
         }
-        // Drop instead of contending on the writer: parking the flow task
-        // behind another packet's TLS write costs more than the loss.
+        // The endpoint driver drops this packet on `WouldBlock` without
+        // treating writer contention as a dead tunnel.
         let Ok(mut writer) = self.writer.try_lock() else {
-            return Ok(());
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::WouldBlock,
+                "trojan UDP writer is busy",
+            ));
         };
         let mut frame = Vec::with_capacity(self.addr_header.len() + 4 + data.len());
         frame.extend_from_slice(&self.addr_header);

--- a/crates/honk-outbound/src/proxy/tuic.rs
+++ b/crates/honk-outbound/src/proxy/tuic.rs
@@ -729,7 +729,7 @@ impl PacketTransport for TuicUdpTransport {
         self.target
     }
     fn send_timeout_is_congestion(&self) -> bool {
-        true
+        !self.state.udp_over_stream
     }
 
     async fn send_packet(&self, data: &[u8]) -> io::Result<()> {
@@ -1016,6 +1016,7 @@ mod tests {
             .await
             .expect("dial_udp_transport should succeed");
         assert_eq!(transport.relay_addr(), target);
+        assert!(transport.send_timeout_is_congestion());
         transport.send_packet(b"dns-query").await.unwrap();
         let mut buf = [0u8; 256];
         let (n, src) =
@@ -1039,6 +1040,7 @@ mod tests {
             .dial_udp_transport(&node, target, None, Duration::from_secs(5))
             .await
             .expect("dial_udp_transport should succeed");
+        assert!(!transport.send_timeout_is_congestion());
         transport.send_packet(b"stream-query").await.unwrap();
         let mut buf = [0u8; 256];
         let (n, src) =

--- a/crates/honk-outbound/src/proxy/tuic.rs
+++ b/crates/honk-outbound/src/proxy/tuic.rs
@@ -557,7 +557,11 @@ impl TuicHandler {
         }
         let max_datagram = state.conn.max_datagram_size().unwrap_or(1200);
         for pkt in fragment_udp_packets(session_id, packet_id, addr, data, max_datagram)? {
-            state.conn.send_datagram(bytes::Bytes::from(pkt))?;
+            state
+                .conn
+                .send_datagram_wait(bytes::Bytes::from(pkt))
+                .await
+                .map_err(io::Error::other)?;
         }
         Ok(())
     }
@@ -723,6 +727,9 @@ impl Drop for TuicUdpTransport {
 impl PacketTransport for TuicUdpTransport {
     fn relay_addr(&self) -> SocketAddr {
         self.target
+    }
+    fn send_timeout_is_congestion(&self) -> bool {
+        true
     }
 
     async fn send_packet(&self, data: &[u8]) -> io::Result<()> {


### PR DESCRIPTION
## Summary

- classify UDP backpressure separately from proxy/tunnel death;
- keep first-send fail-closed and never replay an ambiguous datagram;
- wait for TUIC and Hysteria2 QUIC datagram capacity instead of silently evicting queued packets;
- retain terminal timeout handling for TUIC's stream fallback, where cancellation can leave a partial frame;
- shard QUIC Initial sniffing state to reduce unrelated-flow lock contention;
- keep receiver-idle expiry distinct from transport-send timeout for health and Score reporting.

## Why

A full UDP send queue is packet-local congestion, not evidence that the outbound tunnel is dead. Treating both as the same failure demoted healthy nodes and retired usable endpoints. The opposite mistake is unsafe for stream-framed transports: cancelling a timed-out write can leave a partial frame in the tunnel, so those transports retain terminal timeout semantics.

## Validation

Local focused checks:

- `cargo check -p honk-core -p honk-outbound`
- `cargo clippy -p honk-core -p honk-outbound --all-targets -- -D warnings`
- `cargo test -p honk-core control::udp_endpoint --lib` (48 passed)
- `cargo test -p honk-core control::packet_sniffer::tests --lib` (5 passed)
- `cargo test -p honk-outbound --lib` (511 passed)
- `cargo fmt --all -- --check`
- `git diff --check`

PR CI passed:

- workspace tests;
- formatting and all-target Clippy;
- eBPF object build and BTF validation;
- eBPF-feature unit tests;
- real-VM eBPF lifecycle, pinned-map, NFQUEUE, and network-namespace tests;
- mechanical PR review.

## Risk

The change is limited to UDP transport error classification, endpoint scoring/retirement, QUIC datagram admission, and sniffer locking. No eBPF ABI or NFQUEUE map layout changed. Stream-framed transports remain fail-closed on send timeout; only atomic datagram paths opt into packet-local congestion handling.
