### PR TITLE
fix(control): preserve TCP backlog under flow pressure

### DIFF
--- a/crates/honk-core/src/clash_api.rs
+++ b/crates/honk-core/src/clash_api.rs
@@ -885,6 +885,7 @@ async fn get_outbound_stats(State(s): State<Arc<ClashState>>) -> Json<serde_json
         })
         .collect();
     let pool = s.connection_pool.ready_metrics();
+    let tcp = s.stats.tcp_snapshot();
     let udp = s.stats.udp_snapshot();
     let warm = s
         .stats
@@ -911,6 +912,13 @@ async fn get_outbound_stats(State(s): State<Arc<ClashState>>) -> Json<serde_json
                 "tuic": warm.tuic_clients,
                 "juicity": warm.juicity_clients,
                 "hysteria2": warm.hysteria2_clients,
+            },
+        },
+        "tcp": {
+            "activeFlows": tcp.active_flows,
+            "limit": tcp.limit,
+            "capacity": {
+                "rejected": tcp.capacity_rejections,
             },
         },
         "udp": {

--- a/crates/honk-core/src/control/bootstrap.rs
+++ b/crates/honk-core/src/control/bootstrap.rs
@@ -135,6 +135,7 @@ impl ControlPlane {
             nofile = resource_budget.effective_nofile,
             fixed = resource_budget.fixed_reserve,
             tcp_flows = resource_budget.active_tcp_flows,
+            tcp_max = resource_budget.active_tcp_flows.saturating_mul(2),
             tcp_pool = resource_budget.tcp_pool_entries,
             dials = dial_limit,
             dial_ceiling = resource_budget.transient_dials,
@@ -237,7 +238,9 @@ impl ControlPlane {
             dns_controller,
             group_manager,
             runtime_registry,
-            stats: Arc::new(StatsManager::new()),
+            stats: Arc::new(StatsManager::with_tcp_flow_limit(
+                resource_budget.active_tcp_flows,
+            )),
             drain_tracker: Arc::new(DrainTracker::new()),
             udp_pool: Arc::new(UdpEndpointPool::with_capacity_limit(
                 resource_budget.udp_endpoints,

--- a/crates/honk-core/src/control/mod.rs
+++ b/crates/honk-core/src/control/mod.rs
@@ -145,8 +145,8 @@ pub struct ControlPlane {
     /// shared with the alive set's outbound resolver; rebuilt on reload.
     outbound_id_map: Arc<parking_lot::RwLock<std::collections::HashMap<uuid::Uuid, u8>>>,
     resource_budget: ResourceBudget,
-    /// Active TCP flow admission. Each permit accounts for the accepted
-    /// client socket and one outbound socket in the descriptor budget.
+    /// Active TCP flow admission. The permit target starts at the descriptor
+    /// floor and elastically borrows idle non-TCP headroom.
     concurrency_limit: Arc<tokio::sync::Semaphore>,
     /// Cold non-DNS UDP initialization budget. Ready endpoints bypass it.
     udp_concurrency_limit: Arc<tokio::sync::Semaphore>,

--- a/crates/honk-core/src/control/resource_budget.rs
+++ b/crates/honk-core/src/control/resource_budget.rs
@@ -3,7 +3,7 @@
 use crate::control::udp_endpoint::MAX_ENDPOINTS;
 use crate::pool::MAX_TOTAL_ENTRIES;
 
-pub(crate) const MAX_EFFECTIVE_NOFILE: usize = 16_384;
+pub(crate) const MAX_EFFECTIVE_NOFILE: usize = 32_768;
 const MAX_FIXED_RESERVE: usize = 256;
 const MAX_ACTIVE_TCP_FLOWS: usize = 1_024;
 const MAX_TRANSIENT_DIALS: usize = 1_024;
@@ -184,12 +184,12 @@ mod tests {
         assert_eq!(
             ResourceBudget::for_nofile(usize::MAX),
             ResourceBudget {
-                effective_nofile: 16_384,
+                effective_nofile: 32_768,
                 fixed_reserve: 256,
-                active_tcp_flows: 672,
-                tcp_pool_entries: 2_016,
-                transient_dials: 1_008,
-                udp_endpoints: 3_024,
+                active_tcp_flows: 1_024,
+                tcp_pool_entries: 2_048,
+                transient_dials: 1_024,
+                udp_endpoints: 7_765,
                 udp_slow_path: 256,
                 dns_slow_path: 256,
             }
@@ -216,7 +216,7 @@ mod tests {
         let cap_tcp_only_fds = cap.fixed_reserve + cap.active_tcp_flows * TCP_FLOW_DESCRIPTOR_COST;
         assert_eq!(
             cap.elastic_tcp_flows(cap.active_tcp_flows, cap_tcp_only_fds),
-            1_344
+            2_048
         );
     }
     #[test]

--- a/crates/honk-core/src/control/resource_budget.rs
+++ b/crates/honk-core/src/control/resource_budget.rs
@@ -11,6 +11,8 @@ const MAX_UDP_SLOW_PATH: usize = 256;
 const MAX_DNS_SLOW_PATH: usize = 256;
 const TCP_FLOW_DESCRIPTOR_COST: usize = 6;
 const UDP_ENDPOINT_DESCRIPTOR_COST: usize = 3;
+// Keep half of the non-TCP budget available for bursty gateway DNS/UDP work.
+const ELASTIC_NON_TCP_RESERVE_DIVISOR: usize = 2;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ResourceBudget {
@@ -69,6 +71,30 @@ impl ResourceBudget {
         requested.max(1).min(self.transient_dials)
     }
 
+    /// Returns the TCP permit target after borrowing currently idle non-TCP headroom.
+    pub(crate) fn elastic_tcp_flows(self, active_permits: usize, open_fds: usize) -> usize {
+        let floor = self.active_tcp_flows;
+        if floor == 0 {
+            return active_permits;
+        }
+        let non_tcp_budget = self
+            .tcp_pool_entries
+            .saturating_add(self.transient_dials)
+            .saturating_add(
+                self.udp_endpoints
+                    .saturating_mul(UDP_ENDPOINT_DESCRIPTOR_COST),
+            );
+        let non_tcp_used = open_fds
+            .saturating_sub(self.fixed_reserve)
+            .saturating_sub(active_permits.saturating_mul(TCP_FLOW_DESCRIPTOR_COST));
+        let idle_non_tcp = non_tcp_budget
+            .saturating_sub(non_tcp_budget / ELASTIC_NON_TCP_RESERVE_DIVISOR)
+            .saturating_sub(non_tcp_used);
+        floor
+            .saturating_add(idle_non_tcp / TCP_FLOW_DESCRIPTOR_COST)
+            .min(floor.saturating_mul(2))
+            .max(active_permits)
+    }
     #[cfg(test)]
     fn accounted_descriptors(self) -> usize {
         self.fixed_reserve
@@ -143,6 +169,19 @@ mod tests {
             }
         );
         assert_eq!(
+            ResourceBudget::for_nofile(4_096),
+            ResourceBudget {
+                effective_nofile: 4_096,
+                fixed_reserve: 256,
+                active_tcp_flows: 160,
+                tcp_pool_entries: 480,
+                transient_dials: 240,
+                udp_endpoints: 720,
+                udp_slow_path: 256,
+                dns_slow_path: 240,
+            }
+        );
+        assert_eq!(
             ResourceBudget::for_nofile(usize::MAX),
             ResourceBudget {
                 effective_nofile: 16_384,
@@ -156,7 +195,30 @@ mod tests {
             }
         );
     }
+    #[test]
+    fn elastic_tcp_flows_borrow_only_idle_non_tcp_headroom() {
+        let budget = ResourceBudget::for_nofile(4_096);
+        let tcp_only_fds =
+            budget.fixed_reserve + budget.active_tcp_flows * TCP_FLOW_DESCRIPTOR_COST;
+        let fully_reserved_fds = tcp_only_fds
+            + budget.tcp_pool_entries
+            + budget.transient_dials
+            + budget.udp_endpoints * UDP_ENDPOINT_DESCRIPTOR_COST;
 
+        assert_eq!(
+            budget.elastic_tcp_flows(budget.active_tcp_flows, tcp_only_fds),
+            320
+        );
+        assert_eq!(budget.elastic_tcp_flows(0, fully_reserved_fds), 160);
+        assert_eq!(budget.elastic_tcp_flows(300, fully_reserved_fds), 300);
+
+        let cap = ResourceBudget::for_nofile(usize::MAX);
+        let cap_tcp_only_fds = cap.fixed_reserve + cap.active_tcp_flows * TCP_FLOW_DESCRIPTOR_COST;
+        assert_eq!(
+            cap.elastic_tcp_flows(cap.active_tcp_flows, cap_tcp_only_fds),
+            1_344
+        );
+    }
     #[test]
     fn configured_dials_are_clamped_to_reserved_ceiling() {
         let budget = ResourceBudget::for_nofile(1_024);

--- a/crates/honk-core/src/control/runtime.rs
+++ b/crates/honk-core/src/control/runtime.rs
@@ -17,6 +17,109 @@ fn accepts_transparent_connection(drain: &DrainTracker) -> bool {
     !drain.should_reject()
 }
 
+// Reserve one shared slot before either listener accepts so full capacity leaves
+// unread client data in the kernel backlog instead of closing an accepted socket.
+async fn accept_tcp_with_admission(
+    tcp4_listener: &TcpListener,
+    tcp6_listener: Option<&TcpListener>,
+    concurrency_limit: Arc<tokio::sync::Semaphore>,
+    stats: Arc<StatsManager>,
+) -> io::Result<(
+    TcpStream,
+    SocketAddr,
+    &'static str,
+    tokio::sync::OwnedSemaphorePermit,
+)> {
+    let permit = match concurrency_limit.clone().try_acquire_owned() {
+        Ok(permit) => permit,
+        Err(_) => {
+            stats.record_tcp_capacity_rejection();
+            concurrency_limit
+                .acquire_owned()
+                .await
+                .map_err(|_| io::Error::other("TCP flow admission closed"))?
+        }
+    };
+    let accepted = tokio::select! {
+        result = tcp4_listener.accept() => {
+            result.map(|(stream, addr)| (stream, addr, "v4"))
+        }
+        result = async {
+            match tcp6_listener {
+                Some(listener) => listener.accept().await,
+                None => std::future::pending::<io::Result<(TcpStream, SocketAddr)>>().await,
+            }
+        } => {
+            result.map(|(stream, addr)| (stream, addr, "v6"))
+        }
+    }?;
+    Ok((accepted.0, accepted.1, accepted.2, permit))
+}
+
+const TCP_ADMISSION_SCALE_INTERVAL: Duration = Duration::from_secs(1);
+
+#[cfg(target_os = "linux")]
+fn open_fd_count() -> Option<usize> {
+    // ponytail: one procfs scan per second avoids a platform-specific fd broker.
+    let count = std::fs::read_dir("/proc/self/fd").ok()?.count();
+    Some(count.saturating_sub(1))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn open_fd_count() -> Option<usize> {
+    None
+}
+
+fn resize_tcp_admission(
+    semaphore: &Arc<tokio::sync::Semaphore>,
+    target: &mut usize,
+    budget: ResourceBudget,
+    stats: &StatsManager,
+    open_fds: usize,
+) {
+    let active_permits = target.saturating_sub(semaphore.available_permits());
+    let desired = budget.elastic_tcp_flows(active_permits, open_fds);
+    if desired == *target {
+        return;
+    }
+
+    let previous = *target;
+    if desired > previous {
+        semaphore.add_permits(desired - previous);
+        *target = desired;
+    } else {
+        let removed = semaphore.forget_permits(previous - desired);
+        if removed == 0 {
+            return;
+        }
+        *target = previous - removed;
+    }
+    stats.set_tcp_flow_limit(*target);
+    debug!(
+        previous,
+        limit = *target,
+        active_permits,
+        open_fds,
+        "resized TCP flow admission budget"
+    );
+}
+
+async fn run_tcp_admission_scaler(
+    semaphore: Arc<tokio::sync::Semaphore>,
+    budget: ResourceBudget,
+    stats: Arc<StatsManager>,
+) {
+    let mut target = budget.active_tcp_flows;
+    let mut interval = tokio::time::interval(TCP_ADMISSION_SCALE_INTERVAL);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        interval.tick().await;
+        if let Some(open_fds) = open_fd_count() {
+            resize_tcp_admission(&semaphore, &mut target, budget, &stats, open_fds);
+        }
+    }
+}
+
 #[cfg(feature = "ebpf")]
 pub(super) fn disable_nfqueue_for_startup(config: &mut Config, enabled: &mut bool) {
     config.global.nfqueue_enable = false;
@@ -492,6 +595,12 @@ impl ControlPlane {
             return Err(anyhow::anyhow!("open eBPF datapath admission: {error}"));
         }
         info!("eBPF datapath admission opened after listener publication");
+        let tcp_scaler = tokio::spawn(run_tcp_admission_scaler(
+            Arc::clone(&self.concurrency_limit),
+            self.resource_budget,
+            Arc::clone(&self.stats),
+        ));
+        self.background_tasks.lock().await.push(tcp_scaler);
         #[cfg(target_os = "linux")]
         if let Err(error) =
             libsystemd::daemon::notify(false, &[libsystemd::daemon::NotifyState::Ready])
@@ -500,6 +609,8 @@ impl ControlPlane {
         }
 
         let mut rx = self.command_rx.take().expect("command_rx already taken");
+        let tcp_concurrency_limit = Arc::clone(&self.concurrency_limit);
+        let tcp_stats = Arc::clone(&self.stats);
         let drain = self.drain_tracker.clone();
         let fatal_ebpf = Arc::clone(&self.ebpf);
         let mut fatal_error = None;
@@ -545,10 +656,15 @@ impl ControlPlane {
                     );
                     continue;
                 }
-                accept_result = tcp4_listener.accept() => {
+                accept_result = accept_tcp_with_admission(
+                    &tcp4_listener,
+                    tcp6_listener.as_ref(),
+                    Arc::clone(&tcp_concurrency_limit),
+                    Arc::clone(&tcp_stats),
+                ), if accepts_transparent_connection(&drain) => {
                     match accept_result {
-                        Ok((stream, addr)) => {
-                            debug!("Accepted TPROXY TCPv4 connection from {}", addr);
+                        Ok((stream, addr, family, permit)) => {
+                            debug!("Accepted TPROXY TCP{} connection from {}", family, addr);
                             if let Err(e) = set_so_mark_zero(&stream) {
                                 warn!("Failed to clear SO_MARK on accepted socket from {}: {}", addr, e);
                             }
@@ -556,76 +672,20 @@ impl ControlPlane {
                                 debug!("Rejecting new connection from {} (draining)", addr);
                                 continue;
                             }
-                            // try_acquire: never blocks the accept loop.
-                            let permit = match self.concurrency_limit.clone().try_acquire_owned() {
-                                Ok(p) => p,
-                                Err(_) => {
-                                    // At capacity — drop the connection
-                                    // immediately.  Holding the fd while
-                                    // waiting on the semaphore would exhaust
-                                    // the file-descriptor limit far faster
-                                    // than the limit's headroom allows.
-                                    debug!("Dropping TCPv4 from {} (at capacity)", addr);
-                                    continue;
-                                }
-                            };
+                            let tcp_flow = tcp_stats.track_tcp_flow();
+                            let guard = ConnectionGuard::new(Arc::clone(&drain));
                             let handle = self.spawn_handle();
-                            let drain = drain.clone();
                             tokio::spawn(async move {
                                 let _permit = permit;
-                                let _guard = ConnectionGuard::new(drain);
+                                let _tcp_flow = tcp_flow;
+                                let _guard = guard;
                                 if let Err(e) = handle.serve_connection(stream, addr).await {
-                                    warn!("Error handling TCPv4 from {}: {}", addr, e);
+                                    warn!("Error handling TCP{} from {}: {}", family, addr, e);
                                 }
                             });
                         }
                         Err(e) => {
-                            error!("TCPv4 accept error: {}", e);
-                            // On EMFILE, back off briefly to avoid a tight
-                            // spin that floods the log.
-                            if e.raw_os_error() == Some(libc::EMFILE) {
-                                tokio::time::sleep(Duration::from_millis(100)).await;
-                            }
-                        }
-                    }
-                }
-
-                accept6_result = async {
-                    if let Some(ref l) = tcp6_listener {
-                        l.accept().await
-                    } else {
-                        std::future::pending::<io::Result<(TcpStream, SocketAddr)>>().await
-                    }
-                } => {
-                    match accept6_result {
-                        Ok((stream, addr)) => {
-                            debug!("Accepted TPROXY TCPv6 connection from {}", addr);
-                            if let Err(e) = set_so_mark_zero(&stream) {
-                                warn!("Failed to clear SO_MARK on accepted socket from {}: {}", addr, e);
-                            }
-                            if !accepts_transparent_connection(&drain) {
-                                debug!("Rejecting new connection from {} (draining)", addr);
-                                continue;
-                            }
-                            let permit = match self.concurrency_limit.clone().try_acquire_owned() {
-                                Ok(p) => p,
-                                Err(_) => {
-                                    debug!("Dropping TCPv6 from {} (at capacity)", addr);
-                                    continue;
-                                }
-                            };
-                            let handle = self.spawn_handle();
-                            let drain = drain.clone();
-                            tokio::spawn(async move {
-                                let _permit = permit;
-                                let _guard = ConnectionGuard::new(drain);
-                                if let Err(e) = handle.serve_connection(stream, addr).await {
-                                    warn!("Error handling TCPv6 from {}: {}", addr, e);
-                                }
-                            });
-                        }
-                        Err(e) => {
-                            error!("TCPv6 accept error: {}", e);
+                            error!("TPROXY TCP accept error: {}", e);
                             if e.raw_os_error() == Some(libc::EMFILE) {
                                 tokio::time::sleep(Duration::from_millis(100)).await;
                             }
@@ -1102,5 +1162,79 @@ pub(super) fn try_admit_udp_slow_path(
             stats.record_udp_slow_permit_rejected();
             None
         }
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    #[test]
+    fn tcp_admission_resize_tracks_descriptor_headroom() {
+        let budget = ResourceBudget::for_nofile(4_096);
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(budget.active_tcp_flows));
+        let stats = StatsManager::with_tcp_flow_limit(budget.active_tcp_flows);
+        let mut target = budget.active_tcp_flows;
+
+        resize_tcp_admission(
+            &semaphore,
+            &mut target,
+            budget,
+            &stats,
+            budget.fixed_reserve,
+        );
+        assert_eq!(target, 320);
+        assert_eq!(semaphore.available_permits(), 320);
+        assert_eq!(stats.tcp_snapshot().limit, 320);
+
+        resize_tcp_admission(
+            &semaphore,
+            &mut target,
+            budget,
+            &stats,
+            budget.effective_nofile,
+        );
+        assert_eq!(target, budget.active_tcp_flows);
+        assert_eq!(semaphore.available_permits(), budget.active_tcp_flows);
+        assert_eq!(stats.tcp_snapshot().limit, budget.active_tcp_flows as u64);
+    }
+
+    #[tokio::test]
+    async fn tcp_admission_waits_before_accepting_when_full() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let limit = Arc::new(tokio::sync::Semaphore::new(1));
+        let held = limit.clone().try_acquire_owned().unwrap();
+        let stats = Arc::new(StatsManager::with_tcp_flow_limit(1));
+        let task_stats = Arc::clone(&stats);
+        let task_limit = Arc::clone(&limit);
+        let mut task = tokio::spawn(async move {
+            accept_tcp_with_admission(&listener, None, task_limit, task_stats).await
+        });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while stats.tcp_snapshot().capacity_rejections == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        let mut client = TcpStream::connect(address).await.unwrap();
+        client.write_all(b"hello").await.unwrap();
+
+        tokio::select! {
+            _ = &mut task => panic!("accepted while admission was full"),
+            _ = tokio::time::sleep(Duration::from_millis(50)) => {}
+        }
+        drop(held);
+
+        let (mut accepted, _, _, _) = tokio::time::timeout(Duration::from_secs(1), task)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        let mut payload = [0u8; 5];
+        accepted.read_exact(&mut payload).await.unwrap();
+        assert_eq!(&payload, b"hello");
+        assert_eq!(stats.tcp_snapshot().capacity_rejections, 1);
     }
 }

--- a/crates/honk-core/src/lib.rs
+++ b/crates/honk-core/src/lib.rs
@@ -587,6 +587,15 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
         }
     };
     let resource_budget = control::ResourceBudget::for_nofile(effective_nofile);
+    let tcp_flow_max = resource_budget.active_tcp_flows.saturating_mul(2);
+    if tcp_flow_max < 256 {
+        warn!(
+            nofile = resource_budget.effective_nofile,
+            tcp_floor = resource_budget.active_tcp_flows,
+            tcp_max = tcp_flow_max,
+            "Low TCP flow admission ceiling; raise RLIMIT_NOFILE in the service limits to avoid gateway-wide backpressure"
+        );
+    }
 
     // Install the bootstrap resolver for proxy-server hostname lookups so
     // node dials never depend on the (potentially self-intercepted) regular

--- a/crates/honk-core/src/stats.rs
+++ b/crates/honk-core/src/stats.rs
@@ -143,6 +143,23 @@ impl UdpLatencyHistogramSnapshot {
 }
 
 #[derive(Debug, Default)]
+struct TcpStats {
+    limit: AtomicU64,
+    active_flows: AtomicU64,
+    /// Admission-loop attempts that found all TCP permits occupied.
+    capacity_rejections: AtomicU64,
+}
+
+#[cfg(any(feature = "clash-api", test))]
+/// Fixed TCP admission metrics exposed by `/stats`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct TcpStatsSnapshot {
+    pub limit: u64,
+    pub active_flows: u64,
+    pub capacity_rejections: u64,
+}
+
+#[derive(Debug, Default)]
 struct UdpNfqueueStats {
     received: AtomicU64,
     active_flows: AtomicU64,
@@ -348,11 +365,26 @@ impl Drop for ActiveConnectionGuard {
     }
 }
 
+pub(crate) struct TcpFlowGuard {
+    stats: Arc<StatsManager>,
+}
+
+impl Drop for TcpFlowGuard {
+    fn drop(&mut self) {
+        let _ = self.stats.tcp.active_flows.try_update(
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+            |active| Some(active.saturating_sub(1)),
+        );
+    }
+}
+
 /// Statistics manager that tracks per-outbound metrics.
 #[derive(Debug)]
 pub struct StatsManager {
     trackers: DashMap<String, OutboundTracker>,
     udp: UdpStats,
+    tcp: TcpStats,
     /// Warm-reason attribution bits per node id, pruned at snapshot time to
     /// nodes that still hold warm resources.
     warm_marks: DashMap<uuid::Uuid, AtomicU8>,
@@ -425,8 +457,30 @@ impl StatsManager {
         Self {
             trackers: DashMap::new(),
             udp: UdpStats::default(),
+            tcp: TcpStats::default(),
             warm_marks: DashMap::new(),
         }
+    }
+
+    pub(crate) fn with_tcp_flow_limit(limit: usize) -> Self {
+        let stats = Self::new();
+        stats.set_tcp_flow_limit(limit);
+        stats
+    }
+
+    pub(crate) fn set_tcp_flow_limit(&self, limit: usize) {
+        self.tcp.limit.store(limit as u64, Ordering::Relaxed);
+    }
+
+    pub(crate) fn track_tcp_flow(self: &Arc<Self>) -> TcpFlowGuard {
+        self.tcp.active_flows.fetch_add(1, Ordering::Relaxed);
+        TcpFlowGuard {
+            stats: Arc::clone(self),
+        }
+    }
+
+    pub(crate) fn record_tcp_capacity_rejection(&self) {
+        self.tcp.capacity_rejections.fetch_add(1, Ordering::Relaxed);
     }
 
     /// Attribute a node's current warm resources to a reason.
@@ -886,6 +940,14 @@ impl StatsManager {
     pub fn udp_snapshot(&self) -> UdpStatsSnapshot {
         self.udp.snapshot()
     }
+    #[cfg(any(feature = "clash-api", test))]
+    pub(crate) fn tcp_snapshot(&self) -> TcpStatsSnapshot {
+        TcpStatsSnapshot {
+            limit: self.tcp.limit.load(Ordering::Relaxed),
+            active_flows: self.tcp.active_flows.load(Ordering::Relaxed),
+            capacity_rejections: self.tcp.capacity_rejections.load(Ordering::Relaxed),
+        }
+    }
 }
 
 impl Default for StatsManager {
@@ -979,6 +1041,25 @@ mod tests {
         assert_eq!(tracker.total_conns, 1);
         assert_eq!(tracker.active_conns, 0);
         assert_eq!(tracker.errors, 0);
+    }
+
+    #[test]
+    fn tcp_admission_stats_track_active_flows_and_capacity_waits() {
+        let manager = Arc::new(StatsManager::with_tcp_flow_limit(3));
+        manager.record_tcp_capacity_rejection();
+        let guard = manager.track_tcp_flow();
+
+        assert_eq!(
+            manager.tcp_snapshot(),
+            TcpStatsSnapshot {
+                limit: 3,
+                active_flows: 1,
+                capacity_rejections: 1,
+            }
+        );
+
+        drop(guard);
+        assert_eq!(manager.tcp_snapshot().active_flows, 0);
     }
 
     #[test]

--- a/crates/honk-core/tests/clash_api_test.rs
+++ b/crates/honk-core/tests/clash_api_test.rs
@@ -1979,6 +1979,11 @@ async fn stats_exposes_udp_metrics() {
     assert!(body["outbounds"].is_array());
     assert!(body["pool"].is_object());
 
+    let tcp = &body["tcp"];
+    assert!(tcp["activeFlows"].is_u64());
+    assert!(tcp["limit"].is_u64());
+    assert_eq!(tcp["capacity"]["rejected"], 0);
+
     let udp = &body["udp"];
     assert_eq!(udp["endpoint"]["hits"], 1);
     assert_eq!(udp["endpoint"]["misses"], 0);

--- a/doc/en/design/control-plane.md
+++ b/doc/en/design/control-plane.md
@@ -99,6 +99,7 @@ At startup, `honk-core` tries to raise the soft `RLIMIT_NOFILE`, snapshots the a
 | Transient outbound dials | 1008 | 1 each = 1008 |
 | UDP endpoints | 3024 | 3 each = 9072 |
 | **Total** |  | **16,384** |
+TCP starts with the descriptor-derived floor and elastically borrows idle non-TCP descriptor headroom up to twice that floor, while retaining half of the non-TCP budget as burst reserve; a 4,096-descriptor service can scale from 160 to 320 flow permits while that headroom is idle. Existing flows are never cut, and a fixed reserve protects control-plane descriptors.
 
 A TCP flow budgets the accepted socket, outbound socket, and two two-FD splice pipes. A UDP endpoint budgets the worst common ownership shape: relay socket, SOCKS5 control stream, and anyfrom reply socket. Smaller `RLIMIT_NOFILE` values scale the same partition with saturating arithmetic.
 
@@ -106,12 +107,14 @@ Admission ceilings are distinct:
 
 | Admission | Ceiling |
 | --- | ---: |
-| TCP flow permits | Descriptor-derived; 672 at the 16,384 cap, with a compile-time maximum of 1024 |
+| TCP flow permits | Descriptor-derived floor; 672 at the 16,384 cap, with elastic scaling up to 1344 |
 | Cold non-DNS UDP slow path | `min(udp_endpoints, 256)` |
 | Port-53 ingress slow path | `min(transient_dials, 256)` |
 | NFQUEUE ingest actor | 256 entries and 8 MiB |
 
 There is no separate 256-entry TCP slow-path ceiling. TCP accepts use the descriptor-derived flow budget. The endpoint-removal channel is bounded to 1024 messages and drains in batches of 128. If nonblocking delivery finds it full, a deduplicating `removal_dirty` set retains compensation; the worker flushes that set after each batch before acknowledging exact endpoint tombstones.
+
+Transparent TCP reserves one shared permit before either IP-family listener accepts. When all permits are occupied, new connections remain in the kernel listen backlog instead of being accepted and closed with unread data. The `tcp` object in `/stats` exposes `activeFlows`, `limit`, and `capacity.rejected`; the latter counts accept-loop waits for a permit rather than drops after accept. Startup warns when the elastic ceiling is below 256; raise the service `RLIMIT_NOFILE` limit for gateway deployments.
 
 ## TCP relay and conn-state ownership
 

--- a/doc/en/design/control-plane.md
+++ b/doc/en/design/control-plane.md
@@ -89,17 +89,17 @@ Reload advances a cancellation epoch before waiting. Initializers capture that e
 
 Each UDP flow retains at most 64 datagrams including its first packet. All flows share an exact 8 MiB payload-permit budget. Admission obtains per-flow slots and global byte permits before copying; FIFO saturation drops the newest datagram. NFQUEUE has a separate ingest actor bounded to 256 entries and 8 MiB of queued payload.
 
-At startup, `honk-core` tries to raise the soft `RLIMIT_NOFILE`, snapshots the active value once, and caps the budgeting input at 16,384. At that cap the immutable partition is:
+At startup, `honk-core` tries to raise the soft `RLIMIT_NOFILE`, snapshots the active value once, and caps the budgeting input at 32,768. At that cap the fixed partition is:
 
 | Owner | Capacity | Descriptor accounting |
 | --- | ---: | ---: |
 | Fixed/runtime reserve | 256 | 256 |
-| Accepted TCP flows | 672 | 6 each = 4032 |
-| Retained TCP pool | 2016 | 1 each = 2016 |
-| Transient outbound dials | 1008 | 1 each = 1008 |
-| UDP endpoints | 3024 | 3 each = 9072 |
-| **Total** |  | **16,384** |
-TCP starts with the descriptor-derived floor and elastically borrows idle non-TCP descriptor headroom up to twice that floor, while retaining half of the non-TCP budget as burst reserve; a 4,096-descriptor service can scale from 160 to 320 flow permits while that headroom is idle. Existing flows are never cut, and a fixed reserve protects control-plane descriptors.
+| Accepted TCP flows | 1024 | 6 each = 6144 |
+| Retained TCP pool | 2048 | 1 each = 2048 |
+| Transient outbound dials | 1024 | 1 each = 1024 |
+| UDP endpoints | 7765 | 3 each = 23,295 |
+| **Total** |  | **32,767** |
+The remaining descriptor is partition-rounding slack. TCP starts with the descriptor-derived floor and elastically borrows idle non-TCP descriptor headroom up to twice that floor, while retaining half of the non-TCP budget as burst reserve; a 4,096-descriptor service can scale from 160 to 320 flow permits while that headroom is idle. Existing flows are never cut, and a fixed reserve protects control-plane descriptors.
 
 A TCP flow budgets the accepted socket, outbound socket, and two two-FD splice pipes. A UDP endpoint budgets the worst common ownership shape: relay socket, SOCKS5 control stream, and anyfrom reply socket. Smaller `RLIMIT_NOFILE` values scale the same partition with saturating arithmetic.
 
@@ -107,7 +107,7 @@ Admission ceilings are distinct:
 
 | Admission | Ceiling |
 | --- | ---: |
-| TCP flow permits | Descriptor-derived floor; 672 at the 16,384 cap, with elastic scaling up to 1344 |
+| TCP flow permits | Descriptor-derived floor; 1024 at the 32,768 cap, with elastic scaling up to 2048 |
 | Cold non-DNS UDP slow path | `min(udp_endpoints, 256)` |
 | Port-53 ingress slow path | `min(transient_dials, 256)` |
 | NFQUEUE ingest actor | 256 entries and 8 MiB |

--- a/doc/en/reference/api.md
+++ b/doc/en/reference/api.md
@@ -85,7 +85,7 @@ The download follows honk's current traffic routing decision. A `direct` result 
 
 ## `GET /stats`
 
-`GET /stats` is a userspace snapshot. It is not the eBPF `OUTBOUND_STATS` map and does not expose its packet counters. The fixed UDP/NFQUEUE schema creates no dynamic per-node labels.
+`GET /stats` is a userspace snapshot. It is not the eBPF `OUTBOUND_STATS` map and does not expose its packet counters. The fixed TCP, UDP, and NFQUEUE schemas create no dynamic per-node labels.
 
 ```text
 {
@@ -94,6 +94,9 @@ The download follows honk's current traffic routing decision. A `direct` result 
   warm: {
     nodes: { preconnect, health, udp, selector, traffic },
     sessions: { anytls, vless, tuic, juicity, hysteria2 }
+  },
+  tcp: {
+    activeFlows, limit, capacity: { rejected }
   },
   score: {
     groups: [{ name, tcp: R, udp: R }]
@@ -125,6 +128,14 @@ R = {
   incumbentHeld, freshFailureBypass, deadFiltered
 } // every R value is a u64 count
 ```
+
+### TCP fields
+
+| Field | Meaning |
+| --- | --- |
+| `activeFlows` | Accepted transparent TCP flows currently holding an admission permit. |
+| `limit` | Current process-wide TCP-flow admission ceiling; it starts at the descriptor-derived floor and scales with idle descriptor headroom. |
+| `capacity.rejected` | Monotonic count of accept-loop iterations that waited for a permit because the TCP budget was full; accepted sockets remain in the kernel backlog rather than being dropped. |
 
 ### Score selection-reason fields
 

--- a/doc/zh/design/control-plane.md
+++ b/doc/zh/design/control-plane.md
@@ -90,17 +90,17 @@ Reload 在等待前推进 cancellation epoch。Initializer 捕获该 epoch 和 i
 
 每个 UDP 流最多保留 64 个 datagram，包括首包。所有流共享精确的 8 MiB payload permit 预算。准入在复制前取得每流 slot 和全局 byte permit；FIFO 饱和时丢弃最新 datagram。NFQUEUE 有独立 ingest actor，限制为 256 个条目和 8 MiB 排队 payload。
 
-启动时，`honk-core` 尝试提升软 `RLIMIT_NOFILE`，只快照一次活动值，并把预算输入上限设为 16,384。在该上限处，不可变分区为：
+启动时，`honk-core` 尝试提升软 `RLIMIT_NOFILE`，只快照一次活动值，并把预算输入上限设为 32,768。在该上限处，固定分区为：
 
 | 所有者 | 容量 | 描述符记账 |
 | --- | ---: | ---: |
 | 固定/运行时预留 | 256 | 256 |
-| 已接受 TCP 流 | 672 | 每个 6 = 4032 |
-| 保留 TCP pool | 2016 | 每个 1 = 2016 |
-| 临时出站 dial | 1008 | 每个 1 = 1008 |
-| UDP endpoint | 3024 | 每个 3 = 9072 |
-| **合计** |  | **16,384** |
-TCP 从描述符导出的 floor 开始，在不使用的 non-TCP 描述符余量内动态扩容，最多达到该 floor 的两倍，同时保留一半 non-TCP 预算作为突发余量；4,096 描述符服务在余量空闲时可从 160 个流 permit 扩展到 320 个。已有流不会被切断，固定预留用于保护控制平面描述符。
+| 已接受 TCP 流 | 1024 | 每个 6 = 6144 |
+| 保留 TCP pool | 2048 | 每个 1 = 2048 |
+| 临时出站 dial | 1024 | 每个 1 = 1024 |
+| UDP endpoint | 7765 | 每个 3 = 23,295 |
+| **合计** |  | **32,767** |
+剩余 1 个描述符是分区取整余量。TCP 从描述符导出的 floor 开始，在不使用的 non-TCP 描述符余量内动态扩容，最多达到该 floor 的两倍，同时保留一半 non-TCP 预算作为突发余量；4,096 描述符服务在余量空闲时可从 160 个流 permit 扩展到 320 个。已有流不会被切断，固定预留用于保护控制平面描述符。
 
 一个 TCP 流为 accepted socket、outbound socket 和两组各含两个 FD 的 splice pipe 记账。一个 UDP endpoint 按常见最坏所有权形态记账：relay socket、SOCKS5 控制流和 anyfrom reply socket。较小的 `RLIMIT_NOFILE` 值以相同的饱和算术缩放分区。
 
@@ -108,7 +108,7 @@ TCP 从描述符导出的 floor 开始，在不使用的 non-TCP 描述符余量
 
 | 准入 | 上限 |
 | --- | ---: |
-| TCP 流 permit | 描述符导出的 floor；16,384 上限时为 672，动态扩容最多到 1344 |
+| TCP 流 permit | 描述符导出的 floor；32,768 上限时为 1024，动态扩容最多到 2048 |
 | 冷 non-DNS UDP slow path | `min(udp_endpoints, 256)` |
 | 端口 53 入口 slow path | `min(transient_dials, 256)` |
 | NFQUEUE ingest actor | 256 个条目和 8 MiB |

--- a/doc/zh/design/control-plane.md
+++ b/doc/zh/design/control-plane.md
@@ -100,6 +100,7 @@ Reload 在等待前推进 cancellation epoch。Initializer 捕获该 epoch 和 i
 | 临时出站 dial | 1008 | 每个 1 = 1008 |
 | UDP endpoint | 3024 | 每个 3 = 9072 |
 | **合计** |  | **16,384** |
+TCP 从描述符导出的 floor 开始，在不使用的 non-TCP 描述符余量内动态扩容，最多达到该 floor 的两倍，同时保留一半 non-TCP 预算作为突发余量；4,096 描述符服务在余量空闲时可从 160 个流 permit 扩展到 320 个。已有流不会被切断，固定预留用于保护控制平面描述符。
 
 一个 TCP 流为 accepted socket、outbound socket 和两组各含两个 FD 的 splice pipe 记账。一个 UDP endpoint 按常见最坏所有权形态记账：relay socket、SOCKS5 控制流和 anyfrom reply socket。较小的 `RLIMIT_NOFILE` 值以相同的饱和算术缩放分区。
 
@@ -107,12 +108,14 @@ Reload 在等待前推进 cancellation epoch。Initializer 捕获该 epoch 和 i
 
 | 准入 | 上限 |
 | --- | ---: |
-| TCP 流 permit | 由描述符导出；16,384 上限时为 672，编译期最大值为 1024 |
+| TCP 流 permit | 描述符导出的 floor；16,384 上限时为 672，动态扩容最多到 1344 |
 | 冷 non-DNS UDP slow path | `min(udp_endpoints, 256)` |
 | 端口 53 入口 slow path | `min(transient_dials, 256)` |
 | NFQUEUE ingest actor | 256 个条目和 8 MiB |
 
 不存在单独的 256 条 TCP slow-path 上限。TCP accept 使用由描述符导出的流预算。Endpoint-removal channel 限制为 1024 条消息，每批排空 128 条。非阻塞投递遇到满队列时，去重的 `removal_dirty` 集保留补偿；worker 每批完成后刷新该集合，再确认精确 endpoint tombstone。
+
+透明 TCP 在任一 IP 族监听器 accept 之前预留一个共享 permit。所有 permit 占用时，新连接留在内核 listen backlog 中，不会先 accept 再关闭含有未读数据的 socket。`/stats` 的 `tcp` 对象提供 `activeFlows`、`limit` 和 `capacity.rejected`；后者统计等待 permit 的 accept-loop，而不是 accept 后被丢弃的连接。动态上限低于 256 时启动会告警；网关部署应提高服务的 `RLIMIT_NOFILE` 限制。
 
 ## TCP 中继与 conn-state 所有权
 

--- a/doc/zh/reference/api.md
+++ b/doc/zh/reference/api.md
@@ -85,7 +85,7 @@ Hysteria2 还遵循 sing-box 的 lazy-handshake 规则：其目标请求与首�
 
 ## `GET /stats`
 
-`GET /stats` 是用户态快照，而不是 eBPF `OUTBOUND_STATS` map，也不暴露该 map 的报文 counter。固定 UDP/NFQUEUE schema 不创建动态的逐节点 label。
+`GET /stats` 是用户态快照，而不是 eBPF `OUTBOUND_STATS` map，也不暴露该 map 的报文 counter。固定 TCP、UDP 和 NFQUEUE schema 不创建动态的逐节点 label。
 
 ```text
 {
@@ -94,6 +94,9 @@ Hysteria2 还遵循 sing-box 的 lazy-handshake 规则：其目标请求与首�
   warm: {
     nodes: { preconnect, health, udp, selector, traffic },
     sessions: { anytls, vless, tuic, juicity, hysteria2 }
+  },
+  tcp: {
+    activeFlows, limit, capacity: { rejected }
   },
   score: {
     groups: [{ name, tcp: R, udp: R }]
@@ -125,6 +128,14 @@ R = {
   incumbentHeld, freshFailureBypass, deadFiltered
 } // R 的每个值均为 u64 计数
 ```
+
+### TCP 字段
+
+| 字段 | 含义 |
+| --- | --- |
+| `activeFlows` | 当前持有 TCP admission permit 的透明 TCP 流。 |
+| `limit` | 当前进程级 TCP 流准入上限；从描述符导出的 floor 开始，并随空闲描述符余量动态扩缩。 |
+| `capacity.rejected` | 因 TCP 预算已满而等待 permit 的 accept-loop 单调计数；accepted socket 保留在内核 backlog 中，不会被丢弃。 |
 
 ### Score 选路原因字段
 


### PR DESCRIPTION
## Summary

- Reserve a shared TCP admission permit before either transparent listener accepts.
- Keep new sockets in the kernel listen backlog when the flow budget is full instead of accepting and resetting them.
- Elastically borrow idle descriptor headroom while retaining non-TCP burst reserve.
- Raise the budgeting input ceiling to 32,768 for high-`RLIMIT_NOFILE` gateways; the current VyOS service now reports a 1,024-flow floor and 2,048-flow elastic ceiling.
- Expose TCP admission metrics through `/stats`, add a low-ceiling startup warning, and update bilingual docs.

Closes #68

## Verification

- `cargo test --workspace --no-fail-fast -- --skip test_routing_with_config_dae` — 1,753 passed.
- Focused control and Clash API suites — 334 passed.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
