### PR TITLE
fix(hysteria2): harden official transport interoperability

### DIFF
--- a/crates/honk-outbound/src/proxy/hysteria2/mod.rs
+++ b/crates/honk-outbound/src/proxy/hysteria2/mod.rs
@@ -26,13 +26,11 @@
 //! - **Salamander obfuscation** (`salamander.go`): when `hy2_obfs` is set,
 //!   every UDP datagram on the wire gets an 8-byte random salt prefix and the
 //!   payload XORed with `BLAKE2b-256(password ++ salt)` repeated. Implemented
-//!   as a custom quinn `AsyncUdpSocket` (`SalamanderSocket`).
+//!   as a custom quinn `AsyncUdpSocket` (`Hy2UdpSocket`).
 //! - **Congestion control**: without bandwidth hints the connection runs BBR
-//!   and sends `Hysteria-CC-RX: 0` (sing-quic's non-brutal default,
-//!   `client.go:580-588`). When `hy2_up_mbps` is set the send side uses a
-//!   fixed-rate brutal sender ([`crate::quic::BrutalConfig`]); when
-//!   `hy2_down_mbps` is set it is advertised via `Hysteria-CC-RX` so the
-//!   server's brutal sender paces the downlink.
+//!   and sends `Hysteria-CC-RX: 0`. `hy2_up_mbps` selects the fixed-rate
+//!   Brutal sender. `hy2_down_mbps` is serialized as bytes/s in
+//!   `Hysteria-CC-RX` so the server can pace its sender.
 //!
 //! ## HTTP/3 layer
 //!
@@ -90,10 +88,9 @@ use wire::{
 };
 
 /// Auth request: HEADERS frame for `POST https://hysteria/auth`
-/// (`client.go:540-549`, `protocol/http.go:41-45`). `rx_bps` is our receive
-/// bandwidth in bits/s; 0 = unset (server falls back to its configured
-/// congestion controller instead of brutal).
-fn auth_request_frame(password: &str, rx_bps: u64) -> Vec<u8> {
+/// (`client.go:540-549`, `protocol/http.go:41-45`). The receive limit is
+/// bytes/s; 0 asks the server to use its configured congestion controller.
+fn auth_request_frame(password: &str, rx_bytes_per_second: u64) -> Vec<u8> {
     let padding = random_padding(AUTH_PADDING_MIN, AUTH_PADDING_MAX);
     let section = qpack_encode_request_fields(&[
         (":authority", URL_HOST),
@@ -101,7 +98,7 @@ fn auth_request_frame(password: &str, rx_bps: u64) -> Vec<u8> {
         (":path", URL_PATH),
         (":scheme", "https"),
         (HEADER_AUTH, password),
-        (HEADER_CC_RX, &rx_bps.to_string()),
+        (HEADER_CC_RX, &rx_bytes_per_second.to_string()),
         (HEADER_PADDING, padding.as_str()),
         ("content-length", "0"),
     ]);
@@ -390,8 +387,8 @@ impl AsyncWrite for Hy2TcpStream {
 struct Hy2Client {
     quic: QuicClient<Hy2ConnState>,
     password: String,
-    /// Receive bandwidth advertised in the auth exchange, bits/s (0 = unset).
-    rx_bps: u64,
+    /// Receive bandwidth advertised in the auth exchange, bytes/s (0 = unset).
+    rx_bytes_per_second: u64,
 }
 
 #[async_trait]
@@ -415,10 +412,10 @@ impl Hy2Client {
         connect_timeout: Duration,
     ) -> anyhow::Result<(quinn::Connection, Arc<Hy2ConnState>)> {
         let password = self.password.clone();
-        let rx_bps = self.rx_bps;
+        let rx_bytes_per_second = self.rx_bytes_per_second;
         self.quic
             .connection_with(connect_timeout, move |conn| async move {
-                authenticate(&conn, &password, rx_bps, connect_timeout).await
+                authenticate(&conn, &password, rx_bytes_per_second, connect_timeout).await
             })
             .await
     }
@@ -430,7 +427,7 @@ impl Hy2Client {
 async fn authenticate(
     conn: &quinn::Connection,
     password: &str,
-    rx_bps: u64,
+    rx_bytes_per_second: u64,
     timeout: Duration,
 ) -> anyhow::Result<Hy2ConnState> {
     tokio::time::timeout(timeout, async {
@@ -466,7 +463,7 @@ async fn authenticate(
             .open_bi()
             .await
             .context("Hysteria2: open auth stream")?;
-        send.write_all(&auth_request_frame(password, rx_bps))
+        send.write_all(&auth_request_frame(password, rx_bytes_per_second))
             .await
             .context("Hysteria2: send auth request")?;
         send.finish().context("Hysteria2: finish auth request")?;
@@ -527,25 +524,31 @@ impl Hysteria2Handler {
     async fn build_client(&self, node: &Node) -> anyhow::Result<Arc<Hy2Client>> {
         let password = Self::resolve_password(node);
         let obfs = node.hy2_obfs.as_deref().filter(|s| !s.is_empty());
-        // Receive bandwidth for the auth header, bits/s (0 = unset).
-        let rx_bps = u64::from(node.hy2_down_mbps.unwrap_or(0)) * 1_000_000;
+        if let Some(obfs) = obfs
+            && obfs.len() < SALAMANDER_MIN_PSK_LEN
+        {
+            anyhow::bail!(
+                "Hysteria2: Salamander password must be at least {SALAMANDER_MIN_PSK_LEN} bytes"
+            );
+        }
+        // Hysteria-CC-RX is bytes/s; configuration uses decimal Mbit/s.
+        let rx_bytes_per_second = u64::from(node.hy2_down_mbps.unwrap_or(0)) * 125_000;
         // Port hopping (`mport`/`mhop`): destination port rotates among the
         // list every interval (default 30s, official client parity).
         let hop = node
             .hy2_port_hopping
             .as_deref()
-            .and_then(parse_port_hopping)
-            .map(|ports| {
-                (
+            .map(|spec| {
+                let ports = parse_port_hopping(spec)
+                    .ok_or_else(|| anyhow!("Hysteria2: invalid port hopping list"))?;
+                Ok::<_, anyhow::Error>((
                     ports,
-                    Duration::from_secs(node.hy2_hop_interval.unwrap_or(30).max(1)),
-                )
-            });
+                    Duration::from_secs(node.hy2_hop_interval.unwrap_or(30).max(5)),
+                ))
+            })
+            .transpose()?;
         let server_name = node.sni.clone().unwrap_or_else(|| node.host().to_string());
-        // ALPN "h3" (hysteria2 runs its auth over HTTP/3, `client.go:100-102`).
-        // With `hy2_up_mbps` the send side runs a fixed-rate brutal sender;
-        // otherwise BBR — sing-quic's default when no bandwidth is
-        // configured (`client.go:580-588`).
+        // A positive upload hint selects the fixed-rate sender; no hint uses BBR.
         let factory: Arc<dyn quinn::congestion::ControllerFactory + Send + Sync> =
             match node.hy2_up_mbps {
                 Some(mbps) if mbps > 0 => Arc::new(crate::quic::BrutalConfig::from_bps(
@@ -587,7 +590,7 @@ impl Hysteria2Handler {
         Ok(Arc::new(Hy2Client {
             quic,
             password: password.to_string(),
-            rx_bps,
+            rx_bytes_per_second,
         }))
     }
 

--- a/crates/honk-outbound/src/proxy/hysteria2/salamander.rs
+++ b/crates/honk-outbound/src/proxy/hysteria2/salamander.rs
@@ -107,19 +107,43 @@ pub(super) fn blake2b256(data: &[u8]) -> [u8; 32] {
 // Salamander obfuscation (sing-quic hysteria2/salamander.go).
 
 pub(super) const SALAMANDER_SALT_LEN: usize = 8;
+pub(super) const SALAMANDER_MIN_PSK_LEN: usize = 4;
+
+#[inline]
+fn salamander_key(password: &[u8], salt: &[u8; SALAMANDER_SALT_LEN]) -> [u8; 32] {
+    // Hysteria passwords are normally short. Keep the common key derivation
+    // allocation-free; retain the heap fallback for unusually long secrets.
+    const STACK_INPUT_LEN: usize = 128;
+    if password.len() <= STACK_INPUT_LEN - SALAMANDER_SALT_LEN {
+        let mut input = [0u8; STACK_INPUT_LEN];
+        input[..password.len()].copy_from_slice(password);
+        input[password.len()..password.len() + SALAMANDER_SALT_LEN].copy_from_slice(salt);
+        return blake2b256(&input[..password.len() + SALAMANDER_SALT_LEN]);
+    }
+    let mut input = Vec::with_capacity(password.len() + SALAMANDER_SALT_LEN);
+    input.extend_from_slice(password);
+    input.extend_from_slice(salt);
+    blake2b256(&input)
+}
+
+fn salamander_seal_into(password: &[u8], data: &[u8], out: &mut Vec<u8>) {
+    out.resize(SALAMANDER_SALT_LEN + data.len(), 0);
+    rand::rng().fill_bytes(&mut out[..SALAMANDER_SALT_LEN]);
+    let salt: [u8; SALAMANDER_SALT_LEN] = out[..SALAMANDER_SALT_LEN]
+        .try_into()
+        .expect("fixed salt length");
+    let key = salamander_key(password, &salt);
+    for (index, byte) in data.iter().enumerate() {
+        out[SALAMANDER_SALT_LEN + index] = byte ^ key[index % 32];
+    }
+}
 
 /// Encrypt one datagram: 8-byte random salt, then payload XORed with
 /// BLAKE2b-256(password ++ salt) cycled (`salamander.go:57-70`).
+#[cfg(test)]
 pub(super) fn salamander_seal(password: &[u8], data: &[u8]) -> Vec<u8> {
-    let mut salt = [0u8; SALAMANDER_SALT_LEN];
-    rand::rng().fill_bytes(&mut salt);
-    let mut key_input = Vec::with_capacity(password.len() + SALAMANDER_SALT_LEN);
-    key_input.extend_from_slice(password);
-    key_input.extend_from_slice(&salt);
-    let key = blake2b256(&key_input);
     let mut out = Vec::with_capacity(SALAMANDER_SALT_LEN + data.len());
-    out.extend_from_slice(&salt);
-    out.extend(data.iter().enumerate().map(|(i, b)| b ^ key[i % 32]));
+    salamander_seal_into(password, data, &mut out);
     out
 }
 
@@ -129,10 +153,8 @@ pub(super) fn salamander_open(password: &[u8], buf: &mut [u8]) -> Option<usize> 
     if buf.len() <= SALAMANDER_SALT_LEN {
         return None;
     }
-    let mut key_input = Vec::with_capacity(password.len() + SALAMANDER_SALT_LEN);
-    key_input.extend_from_slice(password);
-    key_input.extend_from_slice(&buf[..SALAMANDER_SALT_LEN]);
-    let key = blake2b256(&key_input);
+    let salt: [u8; SALAMANDER_SALT_LEN] = buf[..SALAMANDER_SALT_LEN].try_into().ok()?;
+    let key = salamander_key(password, &salt);
     let len = buf.len() - SALAMANDER_SALT_LEN;
     for i in 0..len {
         buf[i] = buf[i + SALAMANDER_SALT_LEN] ^ key[i % 32];
@@ -147,12 +169,10 @@ pub(super) fn salamander_open(password: &[u8], buf: &mut [u8]) -> Option<usize> 
 /// `Transmit`/`RecvMeta` carries exactly one datagram to (de)obfuscate.
 #[derive(Debug)]
 pub(super) struct Hy2UdpSocket {
-    // pub(super): hysteria2 tests construct the socket directly for the
-    // obfuscated-server fixture.
-    pub(super) socket: Arc<tokio::net::UdpSocket>,
-    /// Salamander obfuscation password; `None` sends/receives plaintext.
-    pub(super) obfs: Option<Arc<[u8]>>,
-    pub(super) hop: Mutex<Option<HopState>>,
+    socket: Arc<tokio::net::UdpSocket>,
+    obfs: Option<Arc<[u8]>>,
+    obfs_send: Option<Mutex<Vec<u8>>>,
+    hop: Mutex<Option<HopState>>,
 }
 
 impl Hy2UdpSocket {
@@ -161,13 +181,22 @@ impl Hy2UdpSocket {
         obfs: Option<Arc<[u8]>>,
         hop: Option<(Vec<u16>, Duration)>,
     ) -> io::Result<Self> {
-        let std_socket = crate::quic::marked_udp_socket(ipv6)?;
-        let socket = tokio::net::UdpSocket::from_std(std_socket)?;
-        Ok(Self {
+        let socket = tokio::net::UdpSocket::from_std(crate::quic::marked_udp_socket(ipv6)?)?;
+        Ok(Self::from_socket(socket, obfs, hop))
+    }
+
+    pub(super) fn from_socket(
+        socket: tokio::net::UdpSocket,
+        obfs: Option<Arc<[u8]>>,
+        hop: Option<(Vec<u16>, Duration)>,
+    ) -> Self {
+        let obfs_send = obfs.as_ref().map(|_| Mutex::new(Vec::with_capacity(2048)));
+        Self {
             socket: Arc::new(socket),
             obfs,
+            obfs_send,
             hop: Mutex::new(hop.map(|(ports, interval)| HopState::new(ports, interval))),
-        })
+        }
     }
 }
 
@@ -201,10 +230,8 @@ impl HopState {
     }
 
     /// Destination port for the next outbound datagram. The very first call
-    /// already hops (official client parity: the initial handshake dials a
-    /// random port from the hopping list, never the base port — mixing a
-    /// direct base-port flow with DNAT'd hop flows makes NAT clash
-    /// resolution remap the source port mid-connection).
+    /// already hops, so the connection never mixes the base port with the
+    /// redirected range.
     pub(super) fn port(&mut self, base: u16) -> u16 {
         if self.ports.is_empty() {
             return base;
@@ -220,9 +247,9 @@ impl HopState {
         } else {
             let mut rng = rand::rng();
             loop {
-                let p = self.ports[rng.random_range(0..self.ports.len())];
-                if Some(p) != self.current {
-                    break p;
+                let port = self.ports[rng.random_range(0..self.ports.len())];
+                if Some(port) != self.current {
+                    break port;
                 }
             }
         };
@@ -249,12 +276,18 @@ pub(super) fn parse_port_hopping(spec: &str) -> Option<Vec<u16>> {
             Some((lo, hi)) => {
                 let lo: u16 = lo.trim().parse().ok()?;
                 let hi: u16 = hi.trim().parse().ok()?;
-                if hi < lo {
+                if lo == 0 || hi < lo {
                     return None;
                 }
                 ports.extend(lo..=hi);
             }
-            None => ports.push(part.parse().ok()?),
+            None => {
+                let port: u16 = part.parse().ok()?;
+                if port == 0 {
+                    return None;
+                }
+                ports.push(port);
+            }
         }
     }
     (!ports.is_empty()).then_some(ports)
@@ -279,20 +312,21 @@ impl AsyncUdpSocket for Hy2UdpSocket {
     }
 
     fn try_send(&self, transmit: &quinn::udp::Transmit) -> io::Result<()> {
-        let dest = match &mut *self.hop.lock() {
-            Some(state) => SocketAddr::new(
+        let destination = match &mut *self.hop.lock() {
+            Some(hop) => SocketAddr::new(
                 transmit.destination.ip(),
-                state.port(transmit.destination.port()),
+                hop.port(transmit.destination.port()),
             ),
             None => transmit.destination,
         };
-        match &self.obfs {
-            Some(password) => {
-                let packet = salamander_seal(password, transmit.contents);
-                self.socket.try_send_to(&packet, dest)?;
+        match (&self.obfs, &self.obfs_send) {
+            (Some(password), Some(send_buffer)) => {
+                let mut packet = send_buffer.lock();
+                salamander_seal_into(password, transmit.contents, &mut packet);
+                self.socket.try_send_to(&packet, destination)?;
             }
-            None => {
-                self.socket.try_send_to(transmit.contents, dest)?;
+            _ => {
+                self.socket.try_send_to(transmit.contents, destination)?;
             }
         }
         Ok(())
@@ -304,6 +338,7 @@ impl AsyncUdpSocket for Hy2UdpSocket {
         bufs: &mut [IoSliceMut<'_>],
         meta: &mut [quinn::udp::RecvMeta],
     ) -> Poll<io::Result<usize>> {
+        let base_port = self.hop.lock().as_ref().and_then(HopState::base_port);
         let mut count = 0;
         for (buf, meta_slot) in bufs.iter_mut().zip(meta.iter_mut()) {
             let mut read_buf = ReadBuf::new(&mut buf[..]);
@@ -314,11 +349,8 @@ impl AsyncUdpSocket for Hy2UdpSocket {
                         None => Some(read_buf.filled().len()),
                     };
                     if let Some(len) = len {
-                        // With port hopping, DNAT on the server side rewrites
-                        // reply sources to the current hop port; present the
-                        // nominal remote to QUIC instead (see `HopState`).
-                        let addr = match self.hop.lock().as_ref().and_then(|h| h.base_port()) {
-                            Some(base) => SocketAddr::new(addr.ip(), base),
+                        let addr = match base_port {
+                            Some(port) => SocketAddr::new(addr.ip(), port),
                             None => addr,
                         };
                         *meta_slot = quinn::udp::RecvMeta {
@@ -330,11 +362,10 @@ impl AsyncUdpSocket for Hy2UdpSocket {
                         };
                         count += 1;
                     }
-                    // Malformed obfuscated packets are dropped.
                 }
-                Poll::Ready(Err(e)) => {
+                Poll::Ready(Err(error)) => {
                     return if count == 0 {
-                        Poll::Ready(Err(e))
+                        Poll::Ready(Err(error))
                     } else {
                         Poll::Ready(Ok(count))
                     };
@@ -353,6 +384,13 @@ impl AsyncUdpSocket for Hy2UdpSocket {
 
     fn local_addr(&self) -> io::Result<SocketAddr> {
         self.socket.local_addr()
+    }
+    /// Salamander adds eight wire bytes, and quic-go can send 1280-byte
+    /// handshake packets despite a smaller advertised peer maximum. Giving
+    /// Quinn two receive segments enlarges its buffer without raising that
+    /// advertised steady-state MTU; each `RecvMeta` still describes one packet.
+    fn max_receive_segments(&self) -> usize {
+        2
     }
 
     /// The tokio socket does not set DONTFRAG; reporting `true` also keeps

--- a/crates/honk-outbound/src/proxy/hysteria2/tests.rs
+++ b/crates/honk-outbound/src/proxy/hysteria2/tests.rs
@@ -10,7 +10,6 @@ use honk_config::types::NodeProtocol;
 use quinn::EndpointConfig;
 use std::time::Instant;
 
-use parking_lot::Mutex;
 use std::sync::atomic::AtomicBool;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
@@ -121,12 +120,26 @@ async fn start_server_with_response(
     response_delay: Duration,
     response_status: u8,
 ) -> SocketAddr {
+    start_server_config(password, response_delay, response_status, true).await
+}
+
+async fn start_server_with_udp(password: &'static str, udp_enabled: bool) -> SocketAddr {
+    start_server_config(password, Duration::ZERO, 0, udp_enabled).await
+}
+
+async fn start_server_config(
+    password: &'static str,
+    response_delay: Duration,
+    response_status: u8,
+    udp_enabled: bool,
+) -> SocketAddr {
     let (endpoint, addr) = testutil::server_endpoint(&[b"h3"], true).unwrap();
     tokio::spawn(async move {
         while let Some(incoming) = endpoint.accept().await {
             tokio::spawn(async move {
                 let Ok(conn) = incoming.await else { return };
-                handle_connection(conn, password, response_delay, response_status).await;
+                handle_connection(conn, password, response_delay, response_status, udp_enabled)
+                    .await;
             });
         }
     });
@@ -138,11 +151,11 @@ async fn start_obfs_server(password: &'static str, obfs_password: &'static [u8])
     let config = testutil::server_config(&[b"h3"], true).unwrap();
     let std_socket = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
     std_socket.set_nonblocking(true).unwrap();
-    let socket = Arc::new(Hy2UdpSocket {
-        socket: Arc::new(tokio::net::UdpSocket::from_std(std_socket).unwrap()),
-        obfs: Some(Arc::from(obfs_password)),
-        hop: Mutex::new(None),
-    });
+    let socket = Arc::new(Hy2UdpSocket::from_socket(
+        tokio::net::UdpSocket::from_std(std_socket).unwrap(),
+        Some(Arc::from(obfs_password)),
+        None,
+    ));
     let runtime = quinn::default_runtime().unwrap();
     let endpoint = Endpoint::new_with_abstract_socket(
         EndpointConfig::default(),
@@ -156,7 +169,7 @@ async fn start_obfs_server(password: &'static str, obfs_password: &'static [u8])
         while let Some(incoming) = endpoint.accept().await {
             tokio::spawn(async move {
                 let Ok(conn) = incoming.await else { return };
-                handle_connection(conn, password, Duration::ZERO, 0).await;
+                handle_connection(conn, password, Duration::ZERO, 0, true).await;
             });
         }
     });
@@ -168,6 +181,7 @@ async fn handle_connection(
     password: &'static str,
     response_delay: Duration,
     response_status: u8,
+    udp_enabled: bool,
 ) {
     let authenticated = Arc::new(AtomicBool::new(false));
     // Uni streams: the client preface (control + QPACK encoder/decoder).
@@ -194,8 +208,16 @@ async fn handle_connection(
             };
             let auth = Arc::clone(&bi_auth);
             tokio::spawn(async move {
-                handle_server_stream(send, recv, auth, password, response_delay, response_status)
-                    .await;
+                handle_server_stream(
+                    send,
+                    recv,
+                    auth,
+                    password,
+                    response_delay,
+                    response_status,
+                    udp_enabled,
+                )
+                .await;
             });
         }
     });
@@ -215,13 +237,14 @@ async fn handle_server_stream(
     password: &str,
     response_delay: Duration,
     response_status: u8,
+    udp_enabled: bool,
 ) {
     let Ok(frame_type) = read_varint_stream(&mut recv).await else {
         return;
     };
     match frame_type {
         H3_FRAME_HEADERS => {
-            handle_auth_request(&mut send, &mut recv, authenticated, password).await
+            handle_auth_request(&mut send, &mut recv, authenticated, password, udp_enabled).await
         }
         FRAME_TYPE_TCP_REQUEST if authenticated.load(Ordering::Relaxed) => {
             handle_tcp_request(&mut send, &mut recv, response_delay, response_status).await
@@ -235,6 +258,7 @@ async fn handle_auth_request(
     recv: &mut quinn::RecvStream,
     authenticated: Arc<AtomicBool>,
     password: &str,
+    server_udp_enabled: bool,
 ) {
     let Ok(len) = read_varint_stream(recv).await else {
         return;
@@ -260,7 +284,7 @@ async fn handle_auth_request(
         && get(":path") == Some(URL_PATH)
         && get(HEADER_AUTH) == Some(password);
     let (status, udp_enabled) = if authed {
-        (STATUS_AUTH_OK, true)
+        (STATUS_AUTH_OK, server_udp_enabled)
     } else {
         (404u16, false)
     };
@@ -524,6 +548,37 @@ fn test_salamander_roundtrip() {
     assert_eq!(salamander_open(password, &mut short), None);
 }
 
+#[tokio::test]
+async fn test_salamander_receives_quic_go_initial_size() {
+    let password: Arc<[u8]> = Arc::from(&b"obfs-password"[..]);
+    let std_socket = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+    std_socket.set_nonblocking(true).unwrap();
+    let socket = Arc::new(Hy2UdpSocket::from_socket(
+        tokio::net::UdpSocket::from_std(std_socket).unwrap(),
+        Some(Arc::clone(&password)),
+        None,
+    ));
+    let sender = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let payload = vec![0x5a; 1280];
+    let packet = salamander_seal(&password, &payload);
+    sender
+        .send_to(&packet, socket.local_addr().unwrap())
+        .await
+        .unwrap();
+
+    let mut output = vec![0; 1252 * socket.max_receive_segments()];
+    let mut meta = [quinn::udp::RecvMeta::default()];
+    let count = {
+        let mut bufs = [std::io::IoSliceMut::new(&mut output)];
+        std::future::poll_fn(|cx| socket.poll_recv(cx, &mut bufs, &mut meta))
+            .await
+            .unwrap()
+    };
+    assert_eq!(count, 1);
+    assert_eq!(meta[0].len, payload.len());
+    assert_eq!(&output[..payload.len()], payload);
+}
+
 #[test]
 fn test_udp_message_codec_roundtrip() {
     let pkt = encode_udp_message(0xdead_beef, 42, 0, 1, "8.8.8.8:53", b"payload");
@@ -554,6 +609,62 @@ fn test_fragmentation_and_defrag() {
             .or(out);
     }
     assert_eq!(out.expect("reassembled payload"), data);
+}
+
+#[test]
+fn test_udp_message_rejects_invalid_fragments() {
+    let mut zero_total = encode_udp_message(1, 2, 0, 1, "x:1", b"payload");
+    zero_total[7] = 0;
+    assert!(decode_udp_message(&zero_total).is_none());
+
+    let out_of_range = encode_udp_message(1, 2, 1, 1, "x:1", b"payload");
+    assert!(decode_udp_message(&out_of_range).is_none());
+
+    let empty = encode_udp_message(1, 2, 0, 1, "x:1", b"");
+    assert!(decode_udp_message(&empty).is_none());
+}
+
+#[tokio::test]
+async fn test_short_salamander_password_rejected_before_dial() {
+    let mut node = test_node(443, TEST_PASSWORD);
+    node.hy2_obfs = Some("abc".to_string());
+    let result = Hysteria2Handler::new().build_client(&node).await;
+    let error = match result {
+        Ok(_) => panic!("short Salamander password must be rejected"),
+        Err(error) => error,
+    };
+    assert!(error.to_string().contains("at least 4 bytes"));
+}
+
+#[tokio::test]
+async fn test_invalid_port_hopping_rejected_before_dial() {
+    let mut node = test_node(443, TEST_PASSWORD);
+    node.hy2_port_hopping = Some("0-10".to_string());
+    let error = match Hysteria2Handler::new().build_client(&node).await {
+        Ok(_) => panic!("invalid port hopping list must be rejected"),
+        Err(error) => error,
+    };
+    assert!(error.to_string().contains("invalid port hopping list"));
+}
+
+#[tokio::test]
+async fn test_downlink_mbps_is_serialized_as_bytes_per_second() {
+    let mut node = test_node(443, TEST_PASSWORD);
+    node.hy2_down_mbps = Some(1);
+    let client = Hysteria2Handler::new().build_client(&node).await.unwrap();
+    let frame = auth_request_frame(TEST_PASSWORD, client.rx_bytes_per_second);
+    let mut offset = 0;
+    assert_eq!(parse_varint(&frame, &mut offset), Some(H3_FRAME_HEADERS));
+    let section_len = parse_varint(&frame, &mut offset).unwrap() as usize;
+    let section = &frame[offset..offset + section_len];
+    let fields = qpack_decode_field_section(section).unwrap();
+    assert_eq!(
+        fields
+            .iter()
+            .find(|(name, _)| name == HEADER_CC_RX)
+            .map(|(_, value)| value.as_str()),
+        Some("125000")
+    );
 }
 
 #[test]
@@ -695,6 +806,21 @@ async fn test_wrong_password_rejected() {
 }
 
 #[tokio::test]
+async fn test_udp_disabled_server_rejected() {
+    let server_addr = start_server_with_udp(TEST_PASSWORD, false).await;
+    let node = test_node(server_addr.port(), TEST_PASSWORD);
+    let target: SocketAddr = "8.8.8.8:53".parse().unwrap();
+    let error = match Hysteria2Handler::new()
+        .dial_udp_transport(&node, target, None, Duration::from_secs(5))
+        .await
+    {
+        Ok(_) => panic!("UDP-disabled server must reject packet transport"),
+        Err(error) => error,
+    };
+    assert!(error.to_string().contains("UDP disabled by server"));
+}
+
+#[tokio::test]
 async fn test_udp_transport_datagram_echo() {
     let server_addr = start_server(TEST_PASSWORD).await;
     let node = test_node(server_addr.port(), TEST_PASSWORD);
@@ -727,9 +853,8 @@ async fn test_udp_transport_fragmented_echo() {
         .dial_udp_transport(&node, target, None, Duration::from_secs(5))
         .await
         .expect("dial_udp_transport should succeed");
-    // 3000 bytes exceeds the QUIC datagram MTU: fragmented on send and
-    // reassembled on receive.
-    let payload = vec![0x5au8; 3000];
+    // Exercise the protocol's inclusive maximum across multiple fragments.
+    let payload = vec![0x5au8; MAX_UDP_SIZE];
     transport.send_packet(&payload).await.unwrap();
     let mut buf = vec![0u8; 4096];
     let (n, src) = tokio::time::timeout(Duration::from_secs(5), transport.recv_packet(&mut buf))
@@ -818,6 +943,12 @@ async fn test_salamander_wrong_obfs_password_rejected() {
 //   HONK_HY2_SERVER=host:port   (required; tests skip silently without it)
 //   HONK_HY2_PASSWORD=...       (server auth password)
 //   HONK_HY2_OBFS=...           (optional salamander obfs password)
+//   HONK_HY2_PIN=...            (optional leaf certificate SHA-256)
+//   HONK_HY2_INSECURE=1         (optional, only for self-signed fixtures)
+//   HONK_HY2_MTU=1252          (optional QUIC UDP payload cap)
+//   HONK_HY2_ECHO_TARGET=host:port / HONK_HY2_ECHO_BYTES=3000
+//   HONK_HY2_EXPECT_UDP_DISABLED=1 (run the disabled-UDP refusal check)
+//   HONK_HY2_EXPECT_CONNECT_FAILURE=auth|pin|obfs
 
 fn e2e_node() -> Option<Node> {
     let _ = tracing_subscriber::fmt()
@@ -860,10 +991,43 @@ fn e2e_node() -> Option<Node> {
             .ok()
             .and_then(|v| v.parse::<u8>().ok())
             .map(|v| v == 1),
-        // Deployed with a self-signed certificate.
-        skip_cert_verify: true,
+        quic_mtu: std::env::var("HONK_HY2_MTU")
+            .ok()
+            .and_then(|value| value.parse().ok()),
+        skip_cert_verify: std::env::var("HONK_HY2_INSECURE")
+            .ok()
+            .and_then(|v| v.parse::<u8>().ok())
+            .is_some_and(|v| v == 1),
         ..Default::default()
     })
+}
+
+#[tokio::test]
+async fn test_e2e_real_server_expected_connect_failure() {
+    let Ok(mode) = std::env::var("HONK_HY2_EXPECT_CONNECT_FAILURE") else {
+        eprintln!("HONK_HY2_EXPECT_CONNECT_FAILURE unset; skipping negative e2e");
+        return;
+    };
+    let mut node = e2e_node().expect("HONK_HY2_SERVER required for negative e2e");
+    match mode.as_str() {
+        "auth" => node.hy2_auth = Some("known-invalid-auth".to_string()),
+        "pin" => node.tls_pin_sha256 = Some("00".repeat(32)),
+        "obfs" => node.hy2_obfs = Some("known-invalid-obfs".to_string()),
+        _ => panic!("HONK_HY2_EXPECT_CONNECT_FAILURE must be auth, pin, or obfs"),
+    }
+    let target: SocketAddr = "104.18.0.204:80".parse().unwrap();
+    assert!(
+        Hysteria2Handler::new()
+            .dial(
+                &node,
+                target,
+                Some("www.gstatic.com"),
+                Duration::from_secs(10),
+            )
+            .await
+            .is_err(),
+        "{mode} failure must fail closed"
+    );
 }
 
 #[tokio::test]
@@ -904,6 +1068,56 @@ async fn test_e2e_real_server_tcp_http() {
         "expected 204 from generate_204, got: {}",
         &head[..head.len().min(200)]
     );
+}
+
+#[tokio::test]
+async fn test_e2e_real_server_udp_disabled() {
+    if std::env::var("HONK_HY2_EXPECT_UDP_DISABLED").as_deref() != Ok("1") {
+        eprintln!("HONK_HY2_EXPECT_UDP_DISABLED != 1; skipping disabled-UDP e2e");
+        return;
+    }
+    let node = e2e_node().expect("HONK_HY2_SERVER required for disabled-UDP e2e");
+    let target: SocketAddr = "8.8.8.8:53".parse().unwrap();
+    let error = match Hysteria2Handler::new()
+        .dial_udp_transport(&node, target, None, Duration::from_secs(10))
+        .await
+    {
+        Ok(_) => panic!("UDP-disabled server must reject packet transport"),
+        Err(error) => error,
+    };
+    assert!(error.to_string().contains("UDP disabled by server"));
+}
+
+#[tokio::test]
+async fn test_e2e_real_server_udp_echo() {
+    let Ok(target) = std::env::var("HONK_HY2_ECHO_TARGET").map(|value| {
+        value
+            .parse::<SocketAddr>()
+            .expect("invalid HONK_HY2_ECHO_TARGET")
+    }) else {
+        eprintln!("HONK_HY2_ECHO_TARGET unset; skipping UDP echo e2e");
+        return;
+    };
+    let node = e2e_node().expect("HONK_HY2_SERVER required for UDP echo e2e");
+    let bytes = std::env::var("HONK_HY2_ECHO_BYTES")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(3000usize);
+    assert!(bytes <= MAX_UDP_SIZE);
+    let payload: Vec<u8> = (0..bytes).map(|index| index as u8).collect();
+    let transport = Hysteria2Handler::new()
+        .dial_udp_transport(&node, target, None, Duration::from_secs(10))
+        .await
+        .expect("remote UDP echo transport should connect");
+    transport.send_packet(&payload).await.unwrap();
+    let mut response = vec![0; MAX_UDP_SIZE];
+    let (received, source) =
+        tokio::time::timeout(Duration::from_secs(5), transport.recv_packet(&mut response))
+            .await
+            .expect("remote UDP echo timed out")
+            .unwrap();
+    assert_eq!(source, target);
+    assert_eq!(&response[..received], payload);
 }
 
 #[tokio::test]
@@ -1088,29 +1302,26 @@ fn test_parse_port_hopping() {
     assert_eq!(parse_port_hopping(""), None);
     assert_eq!(parse_port_hopping("abc"), None);
     assert_eq!(parse_port_hopping("9000-8000"), None);
+    assert_eq!(parse_port_hopping("0"), None);
+    assert_eq!(parse_port_hopping("0-10"), None);
 }
 
 #[test]
 fn test_hop_state_rotation() {
-    // Empty list keeps the base port.
     let mut hop = HopState::new(vec![], Duration::from_millis(10));
     assert_eq!(hop.port(8443), 8443);
 
-    // Single port: hops to it immediately (the base port differs).
     let mut hop = HopState::new(vec![20000], Duration::from_millis(10));
-    hop.last_hop = Instant::now() - Duration::from_secs(1);
     assert_eq!(hop.port(8443), 20000);
-    // Within the interval the port stays put.
     assert_eq!(hop.port(8443), 20000);
 
-    // Multiple ports: a hop always lands in the list and off the current port.
     let mut hop = HopState::new(vec![20000, 20001, 20002], Duration::from_millis(10));
     let mut seen = std::collections::HashSet::new();
     for _ in 0..10 {
         hop.last_hop = Instant::now() - Duration::from_secs(1);
-        let p = hop.port(8443);
-        assert!((20000..=20002).contains(&p));
-        seen.insert(p);
+        let port = hop.port(8443);
+        assert!((20000..=20002).contains(&port));
+        seen.insert(port);
     }
     assert!(seen.len() > 1, "hops should visit multiple ports: {seen:?}");
 }

--- a/crates/honk-outbound/src/proxy/hysteria2/tests.rs
+++ b/crates/honk-outbound/src/proxy/hysteria2/tests.rs
@@ -782,9 +782,9 @@ async fn test_dial_tcp_domain_echo() {
         .await
         .expect("dial should succeed");
     stream.stream.write_all(b"domain").await.unwrap();
-    let mut buf = [0u8; 16];
-    let n = stream.stream.read(&mut buf).await.unwrap();
-    assert_eq!(&buf[..n], b"domain");
+    let mut buf = [0u8; 6];
+    stream.stream.read_exact(&mut buf).await.unwrap();
+    assert_eq!(&buf, b"domain");
 }
 
 #[tokio::test]

--- a/crates/honk-outbound/src/proxy/hysteria2/wire.rs
+++ b/crates/honk-outbound/src/proxy/hysteria2/wire.rs
@@ -129,6 +129,9 @@ pub(super) fn decode_udp_message(data: &[u8]) -> Option<UdpInbound> {
     let packet_id = u16::from_be_bytes(data[4..6].try_into().expect("len checked"));
     let frag_id = data[6];
     let frag_total = data[7];
+    if frag_total == 0 || frag_id >= frag_total {
+        return None;
+    }
     // Address vstring: QUIC varint length + bytes.
     let first = data[8];
     let len_len = 1usize << (first >> 6);
@@ -143,8 +146,10 @@ pub(super) fn decode_udp_message(data: &[u8]) -> Option<UdpInbound> {
         return None;
     }
     let start = 8 + len_len;
-    let end = start + addr_len as usize;
-    if data.len() < end {
+    let addr_len = usize::try_from(addr_len).ok()?;
+    let end = start.checked_add(addr_len)?;
+    // The upstream parser requires at least one payload byte after the address.
+    if data.len() <= end {
         return None;
     }
     let _addr = std::str::from_utf8(&data[start..end]).ok()?;

--- a/crates/honk-outbound/src/quic.rs
+++ b/crates/honk-outbound/src/quic.rs
@@ -420,19 +420,27 @@ pub fn client_endpoint(ipv6: bool) -> io::Result<Endpoint> {
     client_endpoint_with_mtu(ipv6, 1252)
 }
 
+fn default_gso_enabled(max_udp_payload_size: u16) -> bool {
+    max_udp_payload_size > 1252
+}
+
 /// [`client_endpoint`] with an explicit advertised `max_udp_payload_size`.
+///
+/// An explicit MTU above the conservative 1252 default opts into UDP GSO:
+/// the operator has already declared that the path carries larger datagrams.
+/// `HONK_QUIC_GSO=0|1` overrides that policy process-wide.
 pub fn client_endpoint_with_mtu(ipv6: bool, max_udp_payload_size: u16) -> io::Result<Endpoint> {
     let socket = marked_udp_socket(ipv6)?;
     let runtime = quinn::default_runtime()
         .ok_or_else(|| io::Error::other("no async runtime available for QUIC"))?;
     let io = Arc::new(tokio::net::UdpSocket::from_std(socket)?);
     let inner = quinn::udp::UdpSocketState::new((&*io).into())?;
-    static GSO: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    let gso = *GSO.get_or_init(|| {
+    static GSO_OVERRIDE: std::sync::LazyLock<Option<bool>> = std::sync::LazyLock::new(|| {
         std::env::var("HONK_QUIC_GSO")
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false)
+            .ok()
+            .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
     });
+    let gso = (*GSO_OVERRIDE).unwrap_or_else(|| default_gso_enabled(max_udp_payload_size));
     let socket = Arc::new(NoGsoUdpSocket { io, inner, gso });
     Endpoint::new_with_abstract_socket(
         endpoint_config_with_mtu(max_udp_payload_size)?,
@@ -450,16 +458,15 @@ pub(crate) fn endpoint_config_with_mtu(mtu: u16) -> io::Result<EndpointConfig> {
     Ok(config)
 }
 
-/// quinn's stock tokio socket behavior (ECN, GRO, cmsgs) with **GSO
-/// disabled** (`max_transmit_segments = 1`): every datagram goes out on its
-/// own, dodging PPPoE uplinks that drop later segments of a GSO
-/// super-packet. This is quinn's own `runtime/tokio.rs` socket with a
-/// one-line change, so nothing else (ECN signaling, GRO receives, pktinfo)
-/// diverges from the stock path.
+/// quinn's stock tokio socket behavior (ECN, GRO, cmsgs) with a conservative
+/// GSO policy. The safe 1252-byte default sends one datagram per syscall,
+/// dodging PPPoE uplinks that drop later segments of a GSO super-packet.
+/// Explicit larger MTUs enable GSO because those paths have already opted out
+/// of the black-hole-safe default. `HONK_QUIC_GSO=0|1` forces either mode.
 ///
-/// `HONK_QUIC_GSO=1` opts back into kernel UDP GSO (a 10-20% single-flow
-/// throughput win on non-PPPoE paths; keep it off where the uplink drops
-/// GSO segments).
+/// This is quinn's own `runtime/tokio.rs` socket with only
+/// [`max_transmit_segments`](quinn::AsyncUdpSocket::max_transmit_segments)
+/// made policy-driven; ECN, GRO receives, and pktinfo stay unchanged.
 #[derive(Debug)]
 struct NoGsoUdpSocket {
     io: Arc<tokio::net::UdpSocket>,
@@ -1150,6 +1157,13 @@ mod brutal_tests {
 #[cfg(test)]
 mod client_tests {
     use super::*;
+    #[test]
+    fn explicit_large_mtu_enables_gso_by_default() {
+        assert!(!default_gso_enabled(1252));
+        assert!(default_gso_enabled(1253));
+        assert!(default_gso_enabled(1452));
+    }
+
     #[tokio::test]
     async fn client_config_rejects_invalid_pin() {
         let node = honk_config::node::Node {

--- a/crates/honk-outbound/src/quic.rs
+++ b/crates/honk-outbound/src/quic.rs
@@ -203,16 +203,25 @@ pub async fn client_config(
         }
         None => None,
     };
+    let pin_sha256 = node
+        .tls_pin_sha256
+        .as_deref()
+        .map(|pin| {
+            crate::tls::parse_pin_sha256(pin).ok_or_else(|| {
+                anyhow!(
+                    "node '{}': invalid tls_pin_sha256 (expected 64 hex chars)",
+                    node.name
+                )
+            })
+        })
+        .transpose()?;
     let crypto =
         crate::quic_boring::BoringQuicClientConfig::new(crate::quic_boring::BoringQuicOptions {
             alpn_wire,
             skip_cert_verify: node.skip_cert_verify,
             chrome: crate::tls::chrome_mode(),
             ech_config_list: ech,
-            pin_sha256: node
-                .tls_pin_sha256
-                .as_deref()
-                .and_then(crate::tls::parse_pin_sha256),
+            pin_sha256,
             // Tickets belong to a specific service, not a hostname:
             // address|port|SNI|ALPN — different protocols, different
             // servers behind one certificate, and reloaded configs never
@@ -1141,6 +1150,19 @@ mod brutal_tests {
 #[cfg(test)]
 mod client_tests {
     use super::*;
+    #[tokio::test]
+    async fn client_config_rejects_invalid_pin() {
+        let node = honk_config::node::Node {
+            name: "bad-pin".to_string(),
+            tls_pin_sha256: Some("not-a-pin".to_string()),
+            ..Default::default()
+        };
+        let error = match client_config(&node, &[b"h3"], QuicClientOptions::default()).await {
+            Ok(_) => panic!("invalid pin must fail closed"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("invalid tls_pin_sha256"));
+    }
 
     async fn test_client(port: u16) -> QuicClient<()> {
         let node = honk_config::node::Node {

--- a/crates/honk-outbound/src/quic.rs
+++ b/crates/honk-outbound/src/quic.rs
@@ -423,6 +423,15 @@ pub fn client_endpoint(ipv6: bool) -> io::Result<Endpoint> {
 fn default_gso_enabled(max_udp_payload_size: u16) -> bool {
     max_udp_payload_size > 1252
 }
+const MAX_QUIC_GSO_SEGMENTS: usize = 16;
+
+fn gso_transmit_segments(enabled: bool, kernel_max: usize) -> usize {
+    if enabled {
+        kernel_max.min(MAX_QUIC_GSO_SEGMENTS)
+    } else {
+        1
+    }
+}
 
 /// [`client_endpoint`] with an explicit advertised `max_udp_payload_size`.
 ///
@@ -458,11 +467,11 @@ pub(crate) fn endpoint_config_with_mtu(mtu: u16) -> io::Result<EndpointConfig> {
     Ok(config)
 }
 
-/// quinn's stock tokio socket behavior (ECN, GRO, cmsgs) with a conservative
 /// GSO policy. The safe 1252-byte default sends one datagram per syscall,
 /// dodging PPPoE uplinks that drop later segments of a GSO super-packet.
-/// Explicit larger MTUs enable GSO because those paths have already opted out
-/// of the black-hole-safe default. `HONK_QUIC_GSO=0|1` forces either mode.
+/// Explicit larger MTUs enable batches capped at 16 segments because those
+/// paths have already opted out of the black-hole-safe default.
+/// `HONK_QUIC_GSO=0|1` forces either mode.
 ///
 /// This is quinn's own `runtime/tokio.rs` socket with only
 /// [`max_transmit_segments`](quinn::AsyncUdpSocket::max_transmit_segments)
@@ -514,11 +523,7 @@ impl quinn::AsyncUdpSocket for NoGsoUdpSocket {
     }
 
     fn max_transmit_segments(&self) -> usize {
-        if self.gso {
-            self.inner.max_gso_segments()
-        } else {
-            1
-        }
+        gso_transmit_segments(self.gso, self.inner.max_gso_segments())
     }
 
     fn max_receive_segments(&self) -> usize {
@@ -1162,6 +1167,13 @@ mod client_tests {
         assert!(!default_gso_enabled(1252));
         assert!(default_gso_enabled(1253));
         assert!(default_gso_enabled(1452));
+    }
+
+    #[test]
+    fn gso_batches_are_bounded() {
+        assert_eq!(gso_transmit_segments(false, 64), 1);
+        assert_eq!(gso_transmit_segments(true, 8), 8);
+        assert_eq!(gso_transmit_segments(true, 64), MAX_QUIC_GSO_SEGMENTS);
     }
 
     #[tokio::test]

--- a/doc/en/design/outbound.md
+++ b/doc/en/design/outbound.md
@@ -451,7 +451,7 @@ Dropping final warm ownership removes future reuse without cutting active flows.
 | --- | --- | --- | --- |
 | TUIC v5 | TLS-exporter authentication on a uni stream; one TCP bi stream per flow | QUIC datagrams, fragmentation, and uni-stream fallback when datagrams are unavailable | 10 s heartbeat; default 8 MiB stream and 8 MiB connection receive windows, with node overrides |
 | Juicity | ALPN `h3`; TLS-exporter auth; bi-stream header `[network][trojanc metadata]` | One bi stream with `[metadata][u16 length][payload]` records | BBR by default; 8 MiB stream and 8 MiB connection receive windows |
-| Hysteria2 | ALPN `h3`; minimal HTTP/3/QPACK `POST https://hysteria/auth`, success status `233` | Native Hysteria2 QUIC datagrams and fragmentation | Brutal fixed-rate sender when upload Mbps is set, otherwise BBR; receive bandwidth in `Hysteria-CC-RX`; same 8/8 MiB default receive windows |
+| Hysteria2 | ALPN `h3`; minimal HTTP/3/QPACK `POST https://hysteria/auth`, success status `233` | Native Hysteria2 QUIC datagrams and fragmentation | Upload Mbps selects the Brutal fixed-rate sender, otherwise BBR; receive bandwidth is sent in bytes/s through `Hysteria-CC-RX`; same 8/8 MiB default receive windows |
 
 Hysteria2's HTTP/3 layer is deliberately local and minimal: control/QPACK
 unidirectional streams, static-table QPACK, and enough HEADERS handling for

--- a/doc/en/reference/cli.md
+++ b/doc/en/reference/cli.md
@@ -54,7 +54,7 @@ A real-datapath process holds the lock for its lifetime. `reload` verifies that 
 | `RUST_LOG` | Both binaries | Tracing filter. It has the effective `honk-core` precedence described above; `honk-tool` otherwise defaults to `warn`. |
 | `HONK_UI_DOWNLOAD_URL` | `honk-core` with `clash-api` | Overrides the dashboard zip URL used when a configured external-UI directory needs downloading. |
 | `HONK_POOL_DISABLE=1` | `honk-core` | Bypasses both ready-stream and bare-TCP pools and performs fresh dials. The code also accepts case-insensitive `true`; the value is cached on first use. |
-| `HONK_QUIC_GSO=0|1` | QUIC outbounds | Forces UDP GSO off/on. Without an override, the conservative 1252-byte MTU keeps GSO off, while an explicit larger `mtu` enables it. |
+| `HONK_QUIC_GSO=0|1` | QUIC outbounds | Forces UDP GSO off/on. Without an override, the conservative 1252-byte MTU keeps GSO off, while an explicit larger `mtu` enables batches capped at 16 segments. |
 | `HONK_MI_COLLECT_SECS` | `honk-core` with `mimalloc` | Per-owner idle collection interval. A periodic rendezvous wakes persistently parked owners only while every other worker is idle; forced collection remains in each owner's park hook. Default `60`; `0` disables both the hook and rendezvous; an invalid value falls back to `60`. |
 | `HONK_VMLINUX_BTF` | `honk-core` with `ebpf` | Overrides the raw kernel BTF file used to resolve process-name offsets. Without it, honk checks `/sys/kernel/btf/vmlinux` and then `/usr/lib/debug/boot/vmlinux`; if runtime BTF offsets or verifier-safe kernel argv access are unavailable, pname synchronously falls back to the calling thread's `comm`. |
 | `DAE_LOCATION_ASSET` | Geo loading in both binaries | Directory checked first for `geoip.dat` and `geosite.dat`. |

--- a/doc/en/reference/cli.md
+++ b/doc/en/reference/cli.md
@@ -54,6 +54,7 @@ A real-datapath process holds the lock for its lifetime. `reload` verifies that 
 | `RUST_LOG` | Both binaries | Tracing filter. It has the effective `honk-core` precedence described above; `honk-tool` otherwise defaults to `warn`. |
 | `HONK_UI_DOWNLOAD_URL` | `honk-core` with `clash-api` | Overrides the dashboard zip URL used when a configured external-UI directory needs downloading. |
 | `HONK_POOL_DISABLE=1` | `honk-core` | Bypasses both ready-stream and bare-TCP pools and performs fresh dials. The code also accepts case-insensitive `true`; the value is cached on first use. |
+| `HONK_QUIC_GSO=0|1` | QUIC outbounds | Forces UDP GSO off/on. Without an override, the conservative 1252-byte MTU keeps GSO off, while an explicit larger `mtu` enables it. |
 | `HONK_MI_COLLECT_SECS` | `honk-core` with `mimalloc` | Per-owner idle collection interval. A periodic rendezvous wakes persistently parked owners only while every other worker is idle; forced collection remains in each owner's park hook. Default `60`; `0` disables both the hook and rendezvous; an invalid value falls back to `60`. |
 | `HONK_VMLINUX_BTF` | `honk-core` with `ebpf` | Overrides the raw kernel BTF file used to resolve process-name offsets. Without it, honk checks `/sys/kernel/btf/vmlinux` and then `/usr/lib/debug/boot/vmlinux`; if runtime BTF offsets or verifier-safe kernel argv access are unavailable, pname synchronously falls back to the calling thread's `comm`. |
 | `DAE_LOCATION_ASSET` | Geo loading in both binaries | Directory checked first for `geoip.dat` and `geosite.dat`. |

--- a/doc/en/reference/nodes.md
+++ b/doc/en/reference/nodes.md
@@ -138,8 +138,8 @@ Live interoperability has been verified for VLESS TCP+REALITY+Vision, TCP+REALIT
 | --- | --- |
 | userinfo secret | `username`, `password`, and `hy2_auth` |
 | `obfs=salamander&obfs-password=...` | Non-empty password becomes `hy2_obfs`; other/incomplete obfs input stays disabled |
-| `upmbps` / `downmbps` | `hy2_up_mbps` / `hy2_down_mbps`; a positive upload value enables brutal, otherwise BBR is used |
-| `mport` / `mhop` | Port list/ranges and hop interval in seconds; interval defaults to 30 and clamps to at least 1 |
+| `upmbps` / `downmbps` | `hy2_up_mbps` / `hy2_down_mbps`; a positive upload value enables Brutal, otherwise BBR is used; download is advertised in bytes/s |
+| `mport` / `mhop` | Port list/ranges and hop interval in seconds; interval defaults to 30 and clamps to the upstream minimum of 5 |
 | `pinSHA256` | `tls_pin_sha256`, replacing PKI/hostname verification |
 | `initStreamReceiveWindow` / `initConnReceiveWindow` | QUIC receive-window overrides |
 | `disablePathMTUDiscovery` | Disables QUIC PMTU discovery when `1`/`true` |

--- a/doc/en/reference/nodes.md
+++ b/doc/en/reference/nodes.md
@@ -66,7 +66,7 @@ The Node model exposes the fields below. Share links populate operator-facing fi
 | `hy2_port_hopping` / `hy2_hop_interval` | string? / u64? | null | Hysteria2 `mport` list and `mhop` seconds; effective interval is 30 s |
 | `hy2_init_stream_recv_window` / `hy2_init_conn_recv_window` | u64? | null | Hysteria2 QUIC receive windows; effective defaults are 8 MiB / 8 MiB (the conn window doubles as the per-connection memory budget: slow consumers buffer up to ~3× it; RSS ≈ active connections × 3 × conn window) |
 | `hy2_disable_mtu_discovery` | bool? | null | Hysteria2 `disablePathMTUDiscovery` |
-| `quic_mtu` | u16? | null | QUIC UDP payload size from `mtu`; effective default 1252, accepted link range 1200–65527 |
+| `quic_mtu` | u16? | null | QUIC UDP payload size from `mtu`; default 1252, accepted range 1200–65527; explicit values above 1252 enable GSO unless `HONK_QUIC_GSO=0` |
 | `tls_pin_sha256` | string? | null | Leaf-certificate SHA-256 pin from `pinSHA256` or `pin_sha256` |
 | `tuic_uuid` / `tuic_password` | string? | null | Dedicated TUIC credentials; handlers fall back to generic userinfo fields |
 | `tuic_congestion` / `tuic_alpn` | string? | null | TUIC `congestion_control` and comma-separated `alpn` |

--- a/doc/zh/design/outbound.md
+++ b/doc/zh/design/outbound.md
@@ -412,7 +412,7 @@ flow 可以在旧 clone 上完成。移除最后一份 warm 所有权只会移�
 | --- | --- | --- | --- |
 | TUIC v5 | uni stream 上的 TLS-exporter 认证；每个 flow 一条 TCP bi stream | QUIC datagram、分片，以及没有 datagram 时的 uni-stream fallback | 10 秒 heartbeat；默认 8 MiB stream 与 8 MiB connection 接收窗口，可由节点覆盖 |
 | Juicity | ALPN `h3`；TLS-exporter 认证；bi-stream header `[network][trojanc metadata]` | 一条含 `[metadata][u16 length][payload]` record 的 bi stream | 默认 BBR；8 MiB stream 与 8 MiB connection 接收窗口 |
-| Hysteria2 | ALPN `h3`；最小 HTTP/3/QPACK `POST https://hysteria/auth`，成功状态 `233` | Native Hysteria2 QUIC datagram 与分片 | 设置上传 Mbps 时使用 Brutal 定速发送端，否则 BBR；接收带宽写入 `Hysteria-CC-RX`；同样默认 8/8 MiB 接收窗口 |
+| Hysteria2 | ALPN `h3`；最小 HTTP/3/QPACK `POST https://hysteria/auth`，成功状态 `233` | Native Hysteria2 QUIC datagram 与分片 | 设置上传 Mbps 时使用 Brutal 定速发送端，否则 BBR；接收带宽按 bytes/s 写入 `Hysteria-CC-RX`；同样默认 8/8 MiB 接收窗口 |
 
 Hysteria2 HTTP/3 层刻意保持本地且最小：control/QPACK uni stream、静态表
 QPACK，以及认证所需的 HEADERS 处理。它不得宣告

--- a/doc/zh/reference/cli.md
+++ b/doc/zh/reference/cli.md
@@ -54,6 +54,7 @@ Clap 还提供 `-h`/`--help` 和 `-V`/`--version`。
 | `RUST_LOG` | 两个二进制 | Tracing filter。对 `honk-core` 采用上述当前有效优先级；`honk-tool` 在未设置时默认 `warn`。 |
 | `HONK_UI_DOWNLOAD_URL` | 启用 `clash-api` 的 `honk-core` | 当已配置的外部 UI 目录需要下载内容时，覆盖 dashboard zip URL。 |
 | `HONK_POOL_DISABLE=1` | `honk-core` | 绕过 Ready stream 与裸 TCP 两类池，每次全新拨号。代码也接受不区分大小写的 `true`；首次使用后缓存该值。 |
+| `HONK_QUIC_GSO=0|1` | QUIC 出站 | 强制关闭/开启 UDP GSO。未覆盖时，保守的 1252-byte MTU 保持关闭；显式设置更大的 `mtu` 时自动开启。 |
 | `HONK_MI_COLLECT_SECS` | 启用 `mimalloc` 的 `honk-core` | 每个 owner worker 的空闲回收间隔。周期性 rendezvous 仅在其余 worker 均空闲时唤醒持续 park 的 owner，强制回收仍由各 owner 的 park 钩子执行。默认 `60`；`0` 同时关闭钩子与 rendezvous；无效值回退为 `60`。 |
 | `HONK_VMLINUX_BTF` | 启用 `ebpf` 的 `honk-core` | 覆盖解析进程名字段偏移所用的原始内核 BTF 文件。未设置时，honk 依次检查 `/sys/kernel/btf/vmlinux` 与 `/usr/lib/debug/boot/vmlinux`；若运行时 BTF 偏移或内核 argv 访问无法通过 verifier，pname 同步回退到调用线程的 `comm`。 |
 | `DAE_LOCATION_ASSET` | 两个二进制的 Geo 加载 | 最先检查其中的 `geoip.dat` 与 `geosite.dat`。 |

--- a/doc/zh/reference/cli.md
+++ b/doc/zh/reference/cli.md
@@ -54,7 +54,7 @@ Clap 还提供 `-h`/`--help` 和 `-V`/`--version`。
 | `RUST_LOG` | 两个二进制 | Tracing filter。对 `honk-core` 采用上述当前有效优先级；`honk-tool` 在未设置时默认 `warn`。 |
 | `HONK_UI_DOWNLOAD_URL` | 启用 `clash-api` 的 `honk-core` | 当已配置的外部 UI 目录需要下载内容时，覆盖 dashboard zip URL。 |
 | `HONK_POOL_DISABLE=1` | `honk-core` | 绕过 Ready stream 与裸 TCP 两类池，每次全新拨号。代码也接受不区分大小写的 `true`；首次使用后缓存该值。 |
-| `HONK_QUIC_GSO=0|1` | QUIC 出站 | 强制关闭/开启 UDP GSO。未覆盖时，保守的 1252-byte MTU 保持关闭；显式设置更大的 `mtu` 时自动开启。 |
+| `HONK_QUIC_GSO=0|1` | QUIC 出站 | 强制关闭/开启 UDP GSO。未覆盖时，保守的 1252-byte MTU 保持关闭；显式设置更大的 `mtu` 时自动开启，并把批量限制为最多 16 个 segment。 |
 | `HONK_MI_COLLECT_SECS` | 启用 `mimalloc` 的 `honk-core` | 每个 owner worker 的空闲回收间隔。周期性 rendezvous 仅在其余 worker 均空闲时唤醒持续 park 的 owner，强制回收仍由各 owner 的 park 钩子执行。默认 `60`；`0` 同时关闭钩子与 rendezvous；无效值回退为 `60`。 |
 | `HONK_VMLINUX_BTF` | 启用 `ebpf` 的 `honk-core` | 覆盖解析进程名字段偏移所用的原始内核 BTF 文件。未设置时，honk 依次检查 `/sys/kernel/btf/vmlinux` 与 `/usr/lib/debug/boot/vmlinux`；若运行时 BTF 偏移或内核 argv 访问无法通过 verifier，pname 同步回退到调用线程的 `comm`。 |
 | `DAE_LOCATION_ASSET` | 两个二进制的 Geo 加载 | 最先检查其中的 `geoip.dat` 与 `geosite.dat`。 |

--- a/doc/zh/reference/nodes.md
+++ b/doc/zh/reference/nodes.md
@@ -138,8 +138,8 @@ VLESS 已完成以下 live 互通验证：TCP+REALITY+Vision、TCP+REALITY、TCP
 | --- | --- |
 | userinfo 密钥 | `username`、`password` 与 `hy2_auth` |
 | `obfs=salamander&obfs-password=...` | 非空密码成为 `hy2_obfs`；其他/不完整 obfs 输入保持关闭 |
-| `upmbps` / `downmbps` | `hy2_up_mbps` / `hy2_down_mbps`；`upmbps` 为正值时启用 brutal，否则使用 BBR |
-| `mport` / `mhop` | 端口列表/范围与以秒为单位的跳跃间隔；间隔默认 30，且最小钳制为 1 |
+| `upmbps` / `downmbps` | `hy2_up_mbps` / `hy2_down_mbps`；`upmbps` 为正值时启用 Brutal，否则使用 BBR；下载值按 bytes/s 通告 |
+| `mport` / `mhop` | 端口列表/范围与以秒为单位的跳跃间隔；间隔默认 30，并钳制到上游规定的最小值 5 |
 | `pinSHA256` | `tls_pin_sha256`，替代 PKI/主机名校验 |
 | `initStreamReceiveWindow` / `initConnReceiveWindow` | QUIC 接收窗口覆盖值 |
 | `disablePathMTUDiscovery` | 值为 `1`/`true` 时关闭 QUIC PMTU 发现 |

--- a/doc/zh/reference/nodes.md
+++ b/doc/zh/reference/nodes.md
@@ -66,7 +66,7 @@ Node 模型包含下列字段。分享链接从 scheme、userinfo、authority、
 | `hy2_port_hopping` / `hy2_hop_interval` | string? / u64? | null | Hysteria2 `mport` 列表与 `mhop` 秒数；有效间隔为 30 秒 |
 | `hy2_init_stream_recv_window` / `hy2_init_conn_recv_window` | u64? | null | Hysteria2 QUIC 接收窗口；有效默认值为 8 MiB / 8 MiB（conn 窗口同时是每连接内存预算，慢消费者最多缓冲约 3 倍该值；内存占用 ≈ 活跃连接数 × 3 × conn 窗口） |
 | `hy2_disable_mtu_discovery` | bool? | null | Hysteria2 `disablePathMTUDiscovery` |
-| `quic_mtu` | u16? | null | 来自 `mtu` 的 QUIC UDP payload 大小；有效默认值 1252，链接接受范围 1200–65527 |
+| `quic_mtu` | u16? | null | 来自 `mtu` 的 QUIC UDP payload 大小；默认 1252，接受范围 1200–65527；显式设置大于 1252 时启用 GSO，`HONK_QUIC_GSO=0` 可强制关闭 |
 | `tls_pin_sha256` | string? | null | 来自 `pinSHA256` 或 `pin_sha256` 的叶证书 SHA-256 pin |
 | `tuic_uuid` / `tuic_password` | string? | null | TUIC 专用凭据；handler 会回退到通用 userinfo 字段 |
 | `tuic_congestion` / `tuic_alpn` | string? | null | TUIC `congestion_control` 与逗号分隔的 `alpn` |


### PR DESCRIPTION
## Summary

- harden Hysteria2 interoperability with the official v2.12.2 server: encode `Hysteria-CC-RX` in bytes/s, accept quic-go's two-segment initial flight, and reject malformed UDP fragments, invalid pins, invalid hopping ranges, port 0, and undersized Salamander secrets
- remove the common Salamander hash-input allocation and reuse one sealed-packet buffer per socket while retaining the scalar socket path
- keep the official 5-second minimum hop interval, lazy TCP setup, connection reuse, MTU/PMTUD/window controls, and fail-closed authentication behavior
- enable bounded UDP GSO only for plain QUIC paths with an explicit payload MTU above the conservative 1252-byte default; cap batches at 16 segments and retain `HONK_QUIC_GSO=0|1`

## Verification

- `ci/outbound-ci.sh`: **ALL GREEN**; 540 `honk-outbound` unit tests plus config/share-link suites and clippy
- focused local interoperability: TCP/domain TCP, UDP, 4096-byte fragmented UDP, Salamander TCP/UDP, connection reuse, wrong password, wrong obfs password, UDP-disabled refusal, invalid pin, and bounded-GSO policy
- official remote Hysteria v2.12.2: ACME PKI + pin, self-signed insecure + pin, Salamander, password failures, up/down bandwidth hints, UDP-disabled refusal, MTU 1200 with PMTUD disabled, custom receive windows, 3000/4000-byte UDP, and individually reachable hopping ports
- real gateway `10.10.10.50`: HTTP 204 in 0.111 s, 20/20 UDP echoes, Clash group delay 107 ms, zero outbound errors, one retained Hysteria2 session
- reviewer pass: no P0-P3 findings

Sanitized feature evidence and full benchmark artifacts are retained on `bench`: https://github.com/daeuniverse/honk/tree/bench/bench/results/quic-gso-2026-08-25

## Benchmark reading

On x86, the same final binary measured HY2 TCP at 6479 Mbps with GSO disabled and 6713-6845 Mbps with the 16-segment cap (+3.6-5.6%); direct stayed at 9401-9406 Mbps. TUIC TCP stayed within run variance, so this PR makes no TUIC TCP or Juicity speedup claim. RSS returned to the documented 48/43 MiB HY2/TUIC baseline in the repeat arm. ARM exploratory toggles were neutral/noisy and are explicitly not treated as final cap-16 evidence.

Bilingual analysis: https://github.com/daeuniverse/honk/blob/bench/doc/benchmark.en.md and https://github.com/daeuniverse/honk/blob/bench/doc/benchmark.zh.md

## Verified limits

- the official server receives a 4096-byte UDP request but cannot return the same payload because its 4096-byte message buffer must also contain the Hysteria header; the Rust fixture completes the full 4096-byte round trip
- public-path port migration was lossy for both honk and the official client, so no hopping reliability/performance claim is made
- the throughput harness is plain HY2/TUIC; Salamander and hopping are covered by functional interoperability tests, not those throughput rows
