### PR TITLE
fix(api): expose concrete GLOBAL members

### DIFF
--- a/crates/honk-core/src/clash_api.rs
+++ b/crates/honk-core/src/clash_api.rs
@@ -469,9 +469,8 @@ fn delay_history_entry(ms: u64, at: std::time::SystemTime) -> serde_json::Value 
     })
 }
 
-/// Build the synthetic GLOBAL selector group: every group plus every node
-/// (clash semantics), with a virtual "Proxy" entry first for dashboard
-/// compatibility. `now` comes from the shared mode state.
+/// Build the synthetic GLOBAL selector from concrete configured groups and
+/// nodes. Every `all` member resolves to a top-level proxy document.
 fn build_global_proxy_info(config: &Config, global_selection: &str) -> serde_json::Value {
     let mut all: Vec<String> = Vec::new();
     let mut push_unique = |name: &str| {
@@ -485,14 +484,12 @@ fn build_global_proxy_info(config: &Config, global_selection: &str) -> serde_jso
     for node in &config.nodes {
         push_unique(&node.name);
     }
-    if !all.is_empty() {
-        all.insert(0, "Proxy".to_string());
-    }
-    let now = if global_selection.is_empty() {
-        "Proxy"
-    } else {
-        global_selection
-    };
+    let now = all
+        .iter()
+        .find(|name| name.as_str() == global_selection)
+        .or_else(|| all.first())
+        .map(String::as_str)
+        .unwrap_or("");
     serde_json::json!({
         "name": "GLOBAL",
         "type": "selector",
@@ -570,8 +567,7 @@ async fn put_proxy(
     // GLOBAL is a synthetic selector backed by the shared mode state.
     if group_name == "GLOBAL" {
         let config = s.config.read().await;
-        let valid = body.name == "Proxy"
-            || config.groups.iter().any(|g| g.name == body.name)
+        let valid = config.groups.iter().any(|g| g.name == body.name)
             || config.nodes.iter().any(|n| n.name == body.name);
         drop(config);
         if !valid {

--- a/crates/honk-core/src/lib.rs
+++ b/crates/honk-core/src/lib.rs
@@ -1152,18 +1152,26 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
         .unwrap_or_else(|| "Rule".to_string());
     #[cfg(not(feature = "clash-api"))]
     let mode = "Rule".to_string();
-    let default_selection = {
+    let (default_selection, valid_global_selections) = {
         let config = control_plane.config_handle();
         let config = config.read().await;
-        config
+        let selections = config
             .groups
-            .first()
+            .iter()
             .map(|group| group.name.clone())
-            .unwrap_or_else(|| "Proxy".to_string())
+            .chain(config.nodes.iter().map(|node| node.name.clone()))
+            .collect::<Vec<_>>();
+        let default = selections.first().cloned().unwrap_or_default();
+        (default, selections)
     };
     let global_selection = cache_db
         .as_ref()
         .and_then(|db| db.load_selector_choice("GLOBAL"))
+        .filter(|selection| {
+            valid_global_selections
+                .iter()
+                .any(|valid| valid == selection)
+        })
         .unwrap_or(default_selection);
     let mode_state: mode::SharedModeState = std::sync::Arc::new(parking_lot::RwLock::new(
         mode::ModeState::new(&mode, global_selection),

--- a/crates/honk-core/src/mode.rs
+++ b/crates/honk-core/src/mode.rs
@@ -16,8 +16,7 @@ type SharedEbpfBackend = Arc<tokio::sync::RwLock<Box<dyn crate::ebpf::EbpfBacken
 pub struct ModeState {
     /// Canonical clash mode: `"Rule"` | `"Global"` | `"Direct"`.
     pub mode: String,
-    /// Current GLOBAL selection: a group name, a node name, or the virtual
-    /// `"Proxy"` entry dashboards send for the default selection.
+    /// Current GLOBAL selection: a configured group or node name.
     pub global_selection: String,
 }
 

--- a/crates/honk-core/tests/clash_api_test.rs
+++ b/crates/honk-core/tests/clash_api_test.rs
@@ -378,6 +378,7 @@ routing {
 async fn test_proxies_structure_and_selector_switch() {
     let app = spawn_app("", "").await;
     let client = http_client();
+    app.state.mode_state.write().global_selection = "Proxy".to_string();
 
     let body: serde_json::Value = client
         .get(app.url("/proxies"))
@@ -406,13 +407,14 @@ async fn test_proxies_structure_and_selector_switch() {
     // GLOBAL synthetic group exists with the mode-state selection.
     assert_eq!(proxies["GLOBAL"]["type"], "selector");
     assert_eq!(proxies["GLOBAL"]["now"], "proxy");
-    assert_eq!(proxies["GLOBAL"]["all"][0], "Proxy");
-    // GLOBAL contains the group and both nodes, without duplicates.
+    // Every GLOBAL member is concrete, unique, and resolves to a top-level
+    // proxy document; stale virtual selections fall back to the first member.
     let global_all = proxies["GLOBAL"]["all"].as_array().unwrap();
     let unique: std::collections::HashSet<_> = global_all.iter().collect();
     assert_eq!(global_all.len(), unique.len());
-    for expected in ["Proxy", "proxy", "node-a", "node-b"] {
-        assert!(global_all.iter().any(|n| n == expected));
+    assert!(!global_all.iter().any(|name| name == "Proxy"));
+    for member in global_all {
+        assert!(proxies.get(member.as_str().unwrap()).is_some());
     }
 
     // Switch the selector to node-b.
@@ -939,14 +941,16 @@ async fn test_global_selection_and_mode_persisted() {
     assert_eq!(resp.status(), 204);
     assert_eq!(app.state.mode_state.read().global_selection, "proxy");
 
-    // Unknown GLOBAL target → 400.
-    let resp = client
-        .put(app.url("/proxies/GLOBAL"))
-        .json(&serde_json::json!({"name": "nope"}))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(resp.status(), 400);
+    // Virtual and unknown GLOBAL targets do not resolve.
+    for invalid in ["Proxy", "nope"] {
+        let resp = client
+            .put(app.url("/proxies/GLOBAL"))
+            .json(&serde_json::json!({"name": invalid}))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 400);
+    }
 
     // Switch mode to Global (case-insensitive).
     let resp = client

--- a/doc/en/reference/api.md
+++ b/doc/en/reference/api.md
@@ -75,7 +75,7 @@ The mode update goes through `DatapathFlagsHandle`, the sole serialized writer f
 
 `PUT /proxies/{name}` accepts the body regardless of `Content-Type`. For a configured Selector group, the target must be a direct member tag; a leaf reachable only through a nested group is not a direct member. An actual choice change invokes the group manager's cache callback, so an enabled `cache_file` persists the choice in `cache.db`. If that group sets `interrupt_connections`, honk removes tracked connections associated with the group, its member tags, and reachable leaves so subsequent traffic redials through the new choice. Writing the existing choice does nothing. URLTest, LoadBalance, Fallback, and Score groups reject the mutation.
 
-`GLOBAL` is synthetic. `PUT /proxies/GLOBAL` accepts `Proxy`, any configured group, or any configured node and updates it through the same `DatapathFlagsHandle`; the cache database stores it under the `GLOBAL` selector key when enabled.
+`GLOBAL` is synthetic, but every member in its `all` list is a concrete configured group or node with a matching top-level proxy document. `PUT /proxies/GLOBAL` accepts only one of those names and updates it through the same `DatapathFlagsHandle`; the cache database stores it under the `GLOBAL` selector key when enabled. Empty, removed, unknown, and legacy virtual selections fall back to the first concrete member.
 
 ## External UI hosting
 

--- a/doc/zh/reference/api.md
+++ b/doc/zh/reference/api.md
@@ -75,7 +75,7 @@ Hysteria2 还遵循 sing-box 的 lazy-handshake 规则：其目标请求与首�
 
 `PUT /proxies/{name}` 不要求特定 `Content-Type`。对已配置的 Selector 组，目标必须是直接成员 tag；只能经嵌套组到达的叶节点并非直接成员。选择确实发生变化时会调用 group manager 的 cache callback，因此启用 `cache_file` 后会把选择持久化到 `cache.db`。若该组设置了 `interrupt_connections`，honk 会移除与该组、其成员 tag 及可达叶节点关联的已跟踪连接，使后续流量通过新选择重新拨号。写入已有选择不会触发操作。URLTest、LoadBalance、Fallback 及 Score 组都会拒绝该修改。
 
-`GLOBAL` 是合成 Selector。`PUT /proxies/GLOBAL` 接受 `Proxy`、任意已配置组或任意已配置节点，并通过同一个 `DatapathFlagsHandle` 更新；启用 cache database 时，以 `GLOBAL` Selector key 保存该值。
+`GLOBAL` 是合成 Selector，但其 `all` 中每个成员都是具体的已配置组或节点，并有对应的顶层 proxy 文档。`PUT /proxies/GLOBAL` 只接受其中的名称，并通过同一个 `DatapathFlagsHandle` 更新；启用 cache database 时以 `GLOBAL` Selector key 保存。空值、已移除、未知及旧虚拟选择都会回退到第一个具体成员。
 
 ## 外部 UI hosting
 


### PR DESCRIPTION
## Summary

- remove the unresolved virtual `Proxy` value from synthetic `GLOBAL.all`; Zashboard expects every member to have a matching top-level proxy document and otherwise can fail while rendering
- make `GLOBAL.now` fall back to the first concrete member when cached state is empty, removed, unknown, or the legacy `Proxy` sentinel
- normalize restored GLOBAL state against configured groups/nodes at startup and reject future `PUT /proxies/GLOBAL {"name":"Proxy"}` mutations
- preserve the synthetic GLOBAL selector, configured groups/nodes, mode persistence, and normal Rule/Global/Direct behavior

## Verification

- complete `clash_api_test` integration suite: 30/30 passed
- `cargo clippy -p honk-core --all-targets -- -D warnings`: passed
- live VyOS `10.10.10.1` candidate `f576a331c8fb1093190625a2de8e9c5e5512be1d1c9581737f5b525947ab452e`:
  - `GLOBAL.all`: 56 concrete members, `Proxy` absent
  - every member resolves in the top-level `proxies` object
  - `GLOBAL.now=direct` and is present in `all`
  - legacy `PUT Proxy` returns 400
  - served UI identifies as `zashboard`; proxied HTTP returns 204; service journal has no warnings/errors

The previous VyOS binary is retained as `/config/vyos-scripts/podman/dae/dae.pre-zashboard-d485e82a`.