### PR TITLE
perf(juicity): avoid framed UDP payload copies

### DIFF
--- a/crates/honk-outbound/src/proxy/juicity.rs
+++ b/crates/honk-outbound/src/proxy/juicity.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 
 use anyhow::{Context as _, anyhow};
 use async_trait::async_trait;
+use bytes::Bytes;
 use honk_config::node::Node;
 use tracing::debug;
 
@@ -32,16 +33,32 @@ const CONN_IDLE_TIMEOUT: Duration = Duration::from_secs(120);
 /// credentials fail the first stream open an RTT later instead.
 const AUTH_GRACE: Duration = Duration::ZERO;
 
-/// Read one inbound UDP frame (`[metadata][len u16][payload]`); the address
-/// is returned alongside the payload for completeness but relayed sessions
-/// are keyed by target, so callers currently ignore it.
-async fn read_udp_frame(recv: &mut quinn::RecvStream) -> io::Result<(JuiceAddr, Vec<u8>)> {
+/// Read one inbound UDP frame (`[metadata][len u16][payload]`) into the
+/// caller's buffer. Oversized payloads are consumed before returning the
+/// same buffer-size error as the previous allocating path.
+async fn read_udp_frame(
+    recv: &mut quinn::RecvStream,
+    payload: &mut [u8],
+) -> io::Result<(JuiceAddr, usize)> {
     let addr = JuiceAddr::read_from_stream(recv).await?;
     let mut len = [0u8; 2];
     read_exact(recv, &mut len).await?;
-    let mut payload = vec![0u8; u16::from_be_bytes(len) as usize];
-    read_exact(recv, &mut payload).await?;
-    Ok((addr, payload))
+    let payload_len = u16::from_be_bytes(len) as usize;
+    if payload_len > payload.len() {
+        let mut discard = [0u8; 512];
+        let mut remaining = payload_len;
+        while remaining != 0 {
+            let chunk = remaining.min(discard.len());
+            read_exact(recv, &mut discard[..chunk]).await?;
+            remaining -= chunk;
+        }
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "juicity datagram exceeds buffer",
+        ));
+    }
+    read_exact(recv, &mut payload[..payload_len]).await?;
+    Ok((addr, payload_len))
 }
 
 /// Per-QUIC-connection protocol state.
@@ -425,21 +442,14 @@ impl PacketTransport for JuicityUdpTransport {
         self.send
             .lock()
             .await
-            .write_all(&frame)
+            .write_chunk(Bytes::from(frame))
             .await
             .map_err(io::Error::other)
     }
 
     async fn recv_packet(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
-        let (_addr, payload) = read_udp_frame(&mut *self.recv.lock().await).await?;
-        if payload.len() > buf.len() {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "juicity datagram exceeds buffer",
-            ));
-        }
-        buf[..payload.len()].copy_from_slice(&payload);
-        Ok((payload.len(), self.target))
+        let (_addr, payload_len) = read_udp_frame(&mut *self.recv.lock().await, buf).await?;
+        Ok((payload_len, self.target))
     }
 }
 
@@ -556,15 +566,18 @@ mod tests {
                         if JuiceAddr::read_from_stream(&mut recv).await.is_err() {
                             return;
                         }
+                        let mut payload = vec![0u8; u16::MAX as usize];
                         loop {
-                            let Ok((addr, payload)) = read_udp_frame(&mut recv).await else {
+                            let Ok((addr, payload_len)) =
+                                read_udp_frame(&mut recv, &mut payload).await
+                            else {
                                 return;
                             };
                             let mut frame =
-                                Vec::with_capacity(addr.encoded_len() + 2 + payload.len());
+                                Vec::with_capacity(addr.encoded_len() + 2 + payload_len);
                             addr.encode(&mut frame);
-                            frame.extend_from_slice(&(payload.len() as u16).to_be_bytes());
-                            frame.extend_from_slice(&payload);
+                            frame.extend_from_slice(&(payload_len as u16).to_be_bytes());
+                            frame.extend_from_slice(&payload[..payload_len]);
                             if send.write_all(&frame).await.is_err() {
                                 return;
                             }
@@ -622,7 +635,12 @@ mod tests {
             .expect("dial_udp_transport should succeed");
         assert_eq!(transport.relay_addr(), target);
         transport.send_packet(b"dns-query").await.unwrap();
+        let mut small = [0u8; 4];
+        let error = transport.recv_packet(&mut small).await.unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+
         let mut buf = [0u8; 256];
+        transport.send_packet(b"dns-query").await.unwrap();
         let (n, src) =
             tokio::time::timeout(Duration::from_secs(5), transport.recv_packet(&mut buf))
                 .await


### PR DESCRIPTION
## Summary

- pass encoded Juicity UDP frames to Quinn as owned `Bytes`
- read the declared inbound payload directly into the caller buffer
- preserve oversized-frame draining and `InvalidData` behavior

## Verification

- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY ./ci/outbound-ci.sh`
- 546 `honk-outbound` tests passed; fmt and clippy passed
- focused Juicity tests: 4 passed
- controlled local allocation counts across three complete paired runs were approximately 4,828 vs 5,839 allocation calls per 500-packet run (candidate vs baseline), with about 15% fewer allocated bytes

The local endpoint was too noisy for a defensible end-to-end throughput claim, so this PR does not claim a proxy throughput improvement. The change is limited to ownership/copy reduction and keeps the existing wire and error contract.