### PR TITLE
fix(anytls): bound TLS handshake time

### DIFF
--- a/crates/honk-outbound/src/proxy/anytls/mod.rs
+++ b/crates/honk-outbound/src/proxy/anytls/mod.rs
@@ -1686,7 +1686,11 @@ async fn connect_transport(
         None => Arc::new(crate::tls::build_connector(node)?),
     };
     let server_name = node.sni.clone().unwrap_or_else(|| node.host().to_string());
-    let tls = connector.connect(&server_name, tcp).await?;
+    let tls = tokio::time::timeout(connect_timeout, connector.connect(&server_name, tcp))
+        .await
+        .map_err(|_| {
+            anyhow::anyhow!("AnyTLS TLS handshake timed out after {connect_timeout:?}")
+        })??;
     debug!("AnyTLS: TLS handshake completed with {}", addr);
     let (read, write) = tokio::io::split(crate::tls::BatchRead::new(tls));
 

--- a/crates/honk-outbound/src/proxy/anytls/tests.rs
+++ b/crates/honk-outbound/src/proxy/anytls/tests.rs
@@ -324,11 +324,11 @@ async fn stalled_tls_session_dial_respects_its_own_deadline() {
     .await;
     server.abort();
 
-    // Then: the dial itself expires instead of relying on caller cancellation.
+    // Then: the handshake expires instead of relying on caller cancellation.
     let outcome = result.expect("the AnyTLS dial must enforce an internal deadline");
     let error = outcome.err().expect("the stalled TLS dial must fail");
     assert!(
-        error.to_string().contains("AnyTLS session dial timed out"),
+        error.to_string().contains("AnyTLS TLS handshake timed out"),
         "unexpected error: {error:#}"
     );
 }


### PR DESCRIPTION
## Summary
- bound AnyTLS TLS setup with the existing per-connect timeout
- fail a stalled handshake before the outer three-times dial deadline
- make the stalled-ServerHello regression assert the handshake-specific error

## Verification
- `cargo test -p honk-outbound stalled_tls_session_dial_respects_its_own_deadline`
- `just outbound-ci`
- x86_64 lab: sing-box and Go AnyTLS loaded runs reached 9.37/9.40 Gbps with 0/200 request failures; a stalled ServerHello failed repeatedly after about 3.002s