### PR TITLE
fix(subscription): reject unsupported proxy plugins

### DIFF
--- a/crates/honk-core/src/subscription.rs
+++ b/crates/honk-core/src/subscription.rs
@@ -283,6 +283,21 @@ fn parse_subscription_content(sub: &Subscription, content: &str) -> anyhow::Resu
     let nodes = nodes
         .into_iter()
         .filter(|node| {
+            if node
+                .plugin
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
+                || node
+                    .plugin_opts
+                    .as_deref()
+                    .is_some_and(|value| !value.trim().is_empty())
+            {
+                tracing::warn!(
+                    node = %node.name,
+                    "skipping subscription node with unsupported proxy plugin"
+                );
+                return false;
+            }
             if seen.insert(node.id) {
                 true
             } else {
@@ -661,6 +676,22 @@ fn parse_clash_subscription(
             continue;
         };
         let name = get_str("name").unwrap_or_else(|| format!("{proxy_type}-{server}:{port}"));
+        let plugin_configured = ["plugin", "plugin-opts"].into_iter().any(|key| {
+            get_value(key).is_some_and(|value| match value {
+                serde_yaml::Value::Null => false,
+                serde_yaml::Value::String(value) => !value.trim().is_empty(),
+                serde_yaml::Value::Sequence(value) => !value.is_empty(),
+                serde_yaml::Value::Mapping(value) => !value.is_empty(),
+                _ => true,
+            })
+        });
+        if plugin_configured {
+            tracing::warn!(
+                node = %name,
+                "skipping Clash node with unsupported proxy plugin"
+            );
+            continue;
+        }
         let address = format!("{server}:{port}");
         let mut node = Node {
             name,
@@ -682,8 +713,6 @@ fn parse_clash_subscription(
         } else {
             get_str("cipher")
         };
-        node.plugin = get_str("plugin");
-        node.plugin_opts = get_str("plugin-opts");
         if let Some(network) = get_str("network") {
             node.transport = network;
         }
@@ -907,6 +936,51 @@ mod tests {
 "#;
         let error = parse_subscription_content(&sub, yaml).unwrap_err();
         assert!(error.to_string().contains("duplicate endpoint identities"));
+    }
+
+    #[test]
+    fn test_parse_subscription_skips_proxy_plugins() {
+        let clash = Subscription {
+            sub_type: SubscriptionType::Clash,
+            ..Default::default()
+        };
+        let clash_nodes = parse_subscription_content(
+            &clash,
+            r#"proxies:
+  - name: obfs
+    type: ss
+    server: ss.example
+    port: 8388
+    cipher: aes-128-gcm
+    password: secret
+    plugin: obfs
+    plugin-opts:
+      mode: http
+      host: mask.example
+  - name: plain
+    type: socks5
+    server: 127.0.0.1
+    port: 1080
+"#,
+        )
+        .unwrap();
+        assert_eq!(clash_nodes.len(), 1);
+        assert_eq!(clash_nodes[0].name, "plain");
+
+        let simple = Subscription {
+            sub_type: SubscriptionType::Simple,
+            ..Default::default()
+        };
+        let simple_nodes = parse_subscription_content(
+            &simple,
+            concat!(
+                "ss://YWVzLTI1Ni1nY206cGFzcw@1.2.3.4:8388?plugin=obfs-local%3Bobfs%3Dhttp#obfs\n",
+                "socks5://127.0.0.1:1080#plain"
+            ),
+        )
+        .unwrap();
+        assert_eq!(simple_nodes.len(), 1);
+        assert_eq!(simple_nodes[0].name, "plain");
     }
 
     #[test]

--- a/doc/en/reference/nodes.md
+++ b/doc/en/reference/nodes.md
@@ -46,7 +46,7 @@ The Node model exposes the fields below. Share links populate operator-facing fi
 | `username` / `password` | string? | null | Authentication, UUID, or secret from userinfo |
 | `encryption` | string? | null | SS/VMess cipher or VLESS Encryption client string |
 | `vless_mode` | `WireMode` | `legacy` | `legacy`, `uot-v2`, `h2mux`, `h2mux-padded`, `xudp`, or `mux-cool` |
-| `plugin` / `plugin_opts` | string? | null | SIP002 plugin name/options (`plugin`, `plugin-opts`) |
+| `plugin` / `plugin_opts` | string? | null | Parsed SIP002 plugin metadata; subscription import rejects non-empty values because proxy plugins are unsupported |
 | `transport` | string | `"tcp"` | Stream transport; validated as empty/`tcp`, `ws`, or `grpc` |
 | `tls` | bool | `false` | Stream TLS flag; Trojan/AnyTLS links enable it, VLESS historically defaults on |
 | `sni` | string? | null | TLS server name from `sni`, or an unconsumed `host` query |

--- a/doc/en/reference/subscription.md
+++ b/doc/en/reference/subscription.md
@@ -84,7 +84,7 @@ socks5://user:password@127.0.0.1:1080#local
 vless://00000000-0000-4000-8000-000000000000@example.com:443?security=tls#edge
 ```
 
-Each non-comment line is parsed by `Node::from_share_link`. Unsupported or malformed lines are skipped. The body is rejected when it contains no supported node URI. See the [node reference](./nodes.md) for canonical share-link fields and protocols.
+Each non-comment line is parsed by `Node::from_share_link`. Unsupported or malformed lines are skipped. Share links with a non-empty proxy plugin are also skipped because honk does not execute plugins. The body is rejected when it contains no supported node URI. See the [node reference](./nodes.md) for canonical share-link fields and protocols.
 
 ### Clash YAML
 
@@ -101,7 +101,7 @@ Accepted `type` values are `socks5`, `ss`/`shadowsocks`, `trojan`, `vmess`, `vle
 | `username` | `username` | Optional string. |
 | `password` | `password` | Optional string; VLESS applies the precedence below. |
 | `cipher` | `encryption` | Optional string; VLESS applies the precedence below. |
-| `plugin`, `plugin-opts` | same names | Optional strings; mapping-valued `plugin-opts` is not imported. |
+| `plugin`, `plugin-opts` | — | Unsupported. An entry with either non-empty value is skipped before node publication; mapping-valued options are rejected too. |
 | `network` | `transport` | Optional transport string. |
 | `tls` | `tls` | Optional boolean. |
 | `servername`, `sni` | `sni` | `servername` wins; `sni` is the fallback. |

--- a/doc/zh/reference/nodes.md
+++ b/doc/zh/reference/nodes.md
@@ -46,7 +46,7 @@ Node 模型包含下列字段。分享链接从 scheme、userinfo、authority、
 | `username` / `password` | string? | null | 来自 userinfo 的认证、UUID 或密钥 |
 | `encryption` | string? | null | SS/VMess cipher 或 VLESS Encryption 客户端字符串 |
 | `vless_mode` | `WireMode` | `legacy` | `legacy`、`uot-v2`、`h2mux`、`h2mux-padded`、`xudp` 或 `mux-cool` |
-| `plugin` / `plugin_opts` | string? | null | SIP002 插件名称/参数（`plugin`、`plugin-opts`） |
+| `plugin` / `plugin_opts` | string? | null | 解析后的 SIP002 插件元数据；代理插件不受支持，订阅导入会拒绝非空值 |
 | `transport` | string | `"tcp"` | 流 transport；校验只接受空值/`tcp`、`ws` 或 `grpc` |
 | `tls` | bool | `false` | 流 TLS 标志；Trojan/AnyTLS 链接开启，VLESS 历史默认开启 |
 | `sni` | string? | null | 来自 `sni` 或未被 transport 消耗的 `host` query 的 TLS 服务端名称 |

--- a/doc/zh/reference/subscription.md
+++ b/doc/zh/reference/subscription.md
@@ -84,7 +84,7 @@ socks5://user:password@127.0.0.1:1080#local
 vless://00000000-0000-4000-8000-000000000000@example.com:443?security=tls#edge
 ```
 
-每个非注释行都由 `Node::from_share_link` 解析。不支持或格式错误的行会被跳过。若正文没有受支持的节点 URI，则拒绝整个正文。规范分享链接字段与协议见[节点参考](./nodes.md)。
+每个非注释行都由 `Node::from_share_link` 解析。不支持或格式错误的行会被跳过。honk 不执行代理插件，因此带有非空插件值的分享链接也会被跳过。若正文没有受支持的节点 URI，则拒绝整个正文。规范分享链接字段与协议见[节点参考](./nodes.md)。
 
 ### Clash YAML
 
@@ -101,7 +101,7 @@ Clash 正文必须包含顶层 `proxies` sequence。非 mapping 条目、缺少 
 | `username` | `username` | 可选 string。 |
 | `password` | `password` | 可选 string；VLESS 使用下文优先级。 |
 | `cipher` | `encryption` | 可选 string；VLESS 使用下文优先级。 |
-| `plugin`, `plugin-opts` | 同名字段 | 可选 string；mapping 类型的 `plugin-opts` 不会导入。 |
+| `plugin`, `plugin-opts` | — | 不支持；任一字段具有非空值时，条目会在发布节点前被跳过，mapping 类型的 options 也会被拒绝。 |
 | `network` | `transport` | 可选 transport string。 |
 | `tls` | `tls` | 可选 bool。 |
 | `servername`, `sni` | `sni` | `servername` 优先，`sni` 作为回退。 |


### PR DESCRIPTION
## Summary
- reject Clash nodes with non-empty `plugin` or `plugin-opts` before node publication, including mapping-valued options
- filter plugin-bearing simple, SIP008, and custom subscription nodes at the shared import boundary
- document the deliberate lack of proxy-plugin execution in both English and Chinese references

simple-obfs is deprecated and its TLS mode provides camouflage rather than TLS security. This keeps the outbound stack smaller while replacing silent plugin ignoring with an explicit warning and per-node rejection. A subscription containing no usable nodes fails as before.

## Verification
- `cargo test -p honk-core --no-default-features subscription::tests:: --lib` — 27 passed
- `cargo test -p honk-core --no-default-features --lib -- --skip test_routing_with_config_dae` — 888 passed, 1 ignored
- `cargo clippy -p honk-core --no-default-features --lib -- -D warnings`
- `cargo fmt --all --check`

Closes #83