### PR TITLE
refactor(logging): reclassify traffic and probe logs

### DIFF
--- a/crates/honk-core/src/control/connection/tcp.rs
+++ b/crates/honk-core/src/control/connection/tcp.rs
@@ -256,7 +256,7 @@ impl ControlPlaneHandle {
                 })
                 .unwrap_or(false);
         if ebpf_offload {
-            debug!(
+            info!(
                 network = "tcp",
                 outbound = %outbound_name,
                 ip = %original_dst,
@@ -560,7 +560,7 @@ impl ControlPlaneHandle {
             self.spawn_process_path_enrichment(conn_id, handoff.as_ref());
         }
 
-        debug!(
+        info!(
             network = "tcp",
             outbound = %outbound_name,
             dialer = %node.name,

--- a/crates/honk-core/src/control/connection/udp.rs
+++ b/crates/honk-core/src/control/connection/udp.rs
@@ -248,6 +248,17 @@ impl ControlPlaneHandle {
                         self.push_sniffed_domain_bitmap(&conn_info, domain, original_dst.ip())
                             .await;
                     }
+                    info!(
+                        network = "udp",
+                        outbound = %outbound_name,
+                        ip = %original_dst,
+                        src = %client_addr,
+                        sniffed = quic_domain.as_deref().unwrap_or(""),
+                        ebpf_offload = true,
+                        "UDP offloaded to eBPF: {} -> {}",
+                        client_addr,
+                        original_dst,
+                    );
                     return Ok(());
                 }
                 "block" => {
@@ -578,8 +589,16 @@ impl ControlPlaneHandle {
             return Err(error.into());
         }
         info!(
-            "Proxying UDP {} -> {} via {} (endpoint driver ready)",
-            client_addr, original_dst, node.name
+            network = "udp",
+            outbound = %outbound_name,
+            dialer = %node.name,
+            sniffed = quic_domain.as_deref().unwrap_or(""),
+            ip = %original_dst,
+            src = %client_addr,
+            "UDP connection: {} -> {} via {} (endpoint driver ready)",
+            client_addr,
+            original_dst,
+            node.name,
         );
         Ok(())
     }

--- a/crates/honk-core/src/control/connection/udp.rs
+++ b/crates/honk-core/src/control/connection/udp.rs
@@ -577,7 +577,7 @@ impl ControlPlaneHandle {
             self.stats.record_error(&outbound_name);
             return Err(error.into());
         }
-        debug!(
+        info!(
             "Proxying UDP {} -> {} via {} (endpoint driver ready)",
             client_addr, original_dst, node.name
         );

--- a/crates/honk-core/src/control/probers.rs
+++ b/crates/honk-core/src/control/probers.rs
@@ -702,7 +702,7 @@ pub(super) async fn resolve_udp_check_target(
         if let Some(addr) = addrs.into_iter().next() {
             return addr;
         }
-        debug!(
+        warn!(
             "Failed to resolve udp_check_dns '{}'; using {}",
             raw, fallback
         );
@@ -739,10 +739,16 @@ pub(super) async fn resolve_quic_score_target(
     resolver: Option<crate::outbound::ResolveHook>,
 ) -> Option<QuicScoreTarget> {
     if !url.trim().starts_with("https://") {
-        debug!("Score QUIC probe disabled: tcp_check_url is not HTTPS");
+        warn!("Score QUIC probe disabled: tcp_check_url is not HTTPS");
         return None;
     }
-    let (host, _) = extract_url_host_path(url)?;
+    let (host, _) = match extract_url_host_path(url) {
+        Some(parts) => parts,
+        None => {
+            warn!("Score QUIC probe disabled: invalid tcp_check_url");
+            return None;
+        }
+    };
     let host = host.to_string();
     let port = url_port(url);
     let addrs = if let Ok(ip) = host.parse::<std::net::IpAddr>() {
@@ -759,7 +765,7 @@ pub(super) async fn resolve_quic_score_target(
     let addr = match addrs.into_iter().next() {
         Some(addr) => addr,
         None => {
-            debug!("Score QUIC probe disabled: tcp_check_url host did not resolve");
+            warn!("Score QUIC probe disabled: tcp_check_url host did not resolve");
             return None;
         }
     };
@@ -791,7 +797,7 @@ pub(super) async fn resolve_quic_score_target(
     {
         Ok(config) => config,
         Err(error) => {
-            debug!("Score QUIC probe disabled: failed to build QUIC client: {error:#}");
+            warn!("Score QUIC probe disabled: failed to build QUIC client: {error:#}");
             return None;
         }
     };

--- a/crates/honk-core/src/control/probers.rs
+++ b/crates/honk-core/src/control/probers.rs
@@ -702,7 +702,7 @@ pub(super) async fn resolve_udp_check_target(
         if let Some(addr) = addrs.into_iter().next() {
             return addr;
         }
-        warn!(
+        debug!(
             "Failed to resolve udp_check_dns '{}'; using {}",
             raw, fallback
         );
@@ -739,7 +739,7 @@ pub(super) async fn resolve_quic_score_target(
     resolver: Option<crate::outbound::ResolveHook>,
 ) -> Option<QuicScoreTarget> {
     if !url.trim().starts_with("https://") {
-        warn!("Score QUIC probe disabled: tcp_check_url is not HTTPS");
+        debug!("Score QUIC probe disabled: tcp_check_url is not HTTPS");
         return None;
     }
     let (host, _) = extract_url_host_path(url)?;
@@ -759,7 +759,7 @@ pub(super) async fn resolve_quic_score_target(
     let addr = match addrs.into_iter().next() {
         Some(addr) => addr,
         None => {
-            warn!("Score QUIC probe disabled: tcp_check_url host did not resolve");
+            debug!("Score QUIC probe disabled: tcp_check_url host did not resolve");
             return None;
         }
     };
@@ -791,11 +791,11 @@ pub(super) async fn resolve_quic_score_target(
     {
         Ok(config) => config,
         Err(error) => {
-            warn!("Score QUIC probe disabled: failed to build QUIC client: {error:#}");
+            debug!("Score QUIC probe disabled: failed to build QUIC client: {error:#}");
             return None;
         }
     };
-    info!(host, %addr, "Score QUIC probe enabled");
+    debug!(host, %addr, "Score QUIC probe enabled");
     Some(QuicScoreTarget {
         addr,
         host,

--- a/crates/honk-core/src/control/runtime.rs
+++ b/crates/honk-core/src/control/runtime.rs
@@ -467,11 +467,6 @@ impl ControlPlane {
                     alive_set
                         .set_http_probe(prober, check_url, check_method)
                         .await;
-                    info!(
-                        "HTTP health check enabled (url={}, method={})",
-                        c.global.tcp_check_url.first().unwrap_or(&String::new()),
-                        c.global.tcp_check_http_method
-                    );
                 } else {
                     info!(
                         "HTTP health check disabled (no tcp_check_url configured), using TCP connect"

--- a/crates/honk-core/src/ebpf/real/events.rs
+++ b/crates/honk-core/src/ebpf/real/events.rs
@@ -86,7 +86,7 @@ pub async fn consume_dae_events(
                 } else if is_token_exhaustion {
                     warn!(target: "honk-ebpf", event = kind, "UDP decision token allocator exhausted");
                 } else {
-                    info!(target: "honk-ebpf", event = kind, pid = ev.pid, pname = %pname, l4proto = ev.l4proto, %sip, sport = ev.sport, %dip, dport = ev.dport, outbound = ev.outbound, "eBPF datapath event");
+                    debug!(target: "honk-ebpf", event = kind, pid = ev.pid, pname = %pname, l4proto = ev.l4proto, %sip, sport = ev.sport, %dip, dport = ev.dport, outbound = ev.outbound, "eBPF datapath event");
                 }
             }
         }

--- a/crates/honk-outbound/src/alive/mod.rs
+++ b/crates/honk-outbound/src/alive/mod.rs
@@ -464,10 +464,10 @@ impl AliveDialerSet {
         if let Some(hostname) = Self::parse_url_host(&check_url) {
             let addrs = self.resolve_host(&hostname, port).await;
             if addrs.is_empty() {
-                tracing::warn!("Failed to resolve health check URL '{}'", hostname);
+                tracing::debug!("Failed to resolve health check URL '{}'", hostname);
             }
             let ips = Self::merge_check_addrs(addrs, &check_url, port);
-            tracing::info!(
+            tracing::debug!(
                 "Health check DNS resolved '{}' → {} IPs",
                 hostname,
                 ips.len()
@@ -1443,7 +1443,7 @@ impl AliveDialerSet {
                 .cloned()
                 .unwrap_or_default();
             if !members.is_empty() {
-                tracing::info!(
+                tracing::debug!(
                     "URLTest group '{}' active again — resuming member probes",
                     group
                 );

--- a/crates/honk-outbound/src/alive/mod.rs
+++ b/crates/honk-outbound/src/alive/mod.rs
@@ -454,31 +454,39 @@ impl AliveDialerSet {
         check_method: String,
     ) {
         *self.http_prober.write() = Some(prober);
+        *self.check_method.write() = check_method.clone();
+
+        let port = Self::parse_url_port(&check_url);
+        let Some(hostname) = Self::parse_url_host(&check_url) else {
+            tracing::warn!(
+                "Invalid health check URL '{}'; falling back to TCP probe",
+                check_url
+            );
+            *self.check_url.write() = String::new();
+            self.check_url_ips.write().clear();
+            return;
+        };
         *self.check_url.write() = check_url.clone();
-        *self.check_method.write() = check_method;
 
         // Resolve the check URL hostname once at startup; dae-format literal
         // fallback IPs (comma-separated) are merged in so probes still have
         // targets even when DNS resolution fails.
-        let port = Self::parse_url_port(&check_url);
-        if let Some(hostname) = Self::parse_url_host(&check_url) {
-            let addrs = self.resolve_host(&hostname, port).await;
-            if addrs.is_empty() {
-                tracing::debug!("Failed to resolve health check URL '{}'", hostname);
-            }
-            let ips = Self::merge_check_addrs(addrs, &check_url, port);
-            tracing::debug!(
-                "Health check DNS resolved '{}' → {} IPs",
-                hostname,
-                ips.len()
-            );
-            *self.check_url_ips.write() = ips;
-        } else {
-            let ips = Self::merge_check_addrs(Vec::new(), &check_url, port);
-            if !ips.is_empty() {
-                *self.check_url_ips.write() = ips;
-            }
+        let addrs = self.resolve_host(&hostname, port).await;
+        if addrs.is_empty() {
+            tracing::warn!("Failed to resolve health check URL '{}'[39m", hostname);
         }
+        let ips = Self::merge_check_addrs(addrs, &check_url, port);
+        tracing::debug!(
+            "Health check DNS resolved '{}' → {} IPs",
+            hostname,
+            ips.len()
+        );
+        *self.check_url_ips.write() = ips;
+        tracing::info!(
+            "HTTP health check enabled (url={}, method={})",
+            check_url,
+            check_method
+        );
     }
 
     /// Install the UDP health check prober (Go: UdpCheckOption).

--- a/crates/honk-outbound/src/alive/probe.rs
+++ b/crates/honk-outbound/src/alive/probe.rs
@@ -81,7 +81,7 @@ impl AliveDialerSet {
         let hostname = match Self::parse_url_host(&check_url) {
             Some(h) => h,
             None => {
-                tracing::warn!(
+                tracing::debug!(
                     "Invalid check URL '{}', falling back to TCP probe",
                     check_url
                 );
@@ -110,7 +110,7 @@ impl AliveDialerSet {
         };
 
         if addrs.is_empty() {
-            tracing::warn!(
+            tracing::debug!(
                 "Health check found no addresses for '{}' (node '{}')",
                 hostname,
                 node_name
@@ -183,9 +183,9 @@ impl AliveDialerSet {
         }
 
         if any_ok {
-            tracing::info!("Node '{}' is alive after HTTP health check", node_name);
+            tracing::debug!("Node '{}' is alive after HTTP health check", node_name);
         } else {
-            tracing::warn!(
+            tracing::debug!(
                 "Node '{}' failed HTTP health check for '{}' through proxy endpoint {}",
                 node_name,
                 check_url,
@@ -230,7 +230,7 @@ impl AliveDialerSet {
         }
         let addrs = self.check_ips_for_url(url).await;
         if addrs.is_empty() {
-            tracing::warn!(
+            tracing::debug!(
                 "Health check found no addresses for '{}' (member '{}')",
                 url,
                 tag
@@ -278,7 +278,7 @@ impl AliveDialerSet {
             }
         }
         if !any_ok {
-            tracing::warn!(
+            tracing::debug!(
                 "Member '{}' (leaf '{}') failed HTTP health check against custom URL '{}'",
                 tag,
                 leaf,
@@ -310,7 +310,7 @@ impl AliveDialerSet {
             if !out.is_empty() {
                 out
             } else {
-                tracing::warn!(
+                tracing::debug!(
                     "Health check DNS resolution failed for node '{}' ({}): system lookup failed",
                     node_name,
                     addr
@@ -322,7 +322,7 @@ impl AliveDialerSet {
         };
 
         if addrs.is_empty() {
-            tracing::warn!(
+            tracing::debug!(
                 "Health check found no addresses for node '{}' ({})",
                 node_name,
                 addr
@@ -418,9 +418,9 @@ impl AliveDialerSet {
         // nothing about the other family's reachability through the tunnel —
         // leave it untouched rather than dead-marking it without evidence.
         if any_ok {
-            tracing::info!("Node '{}' is alive after TCP health check", node_name);
+            tracing::debug!("Node '{}' is alive after TCP health check", node_name);
         } else {
-            tracing::warn!(
+            tracing::debug!(
                 "Node '{}' failed TCP health check against all addresses ({})",
                 node_name,
                 addr

--- a/crates/honk-outbound/src/alive/probe.rs
+++ b/crates/honk-outbound/src/alive/probe.rs
@@ -78,17 +78,10 @@ impl AliveDialerSet {
                 .await;
         }
 
-        let hostname = match Self::parse_url_host(&check_url) {
-            Some(h) => h,
-            None => {
-                tracing::debug!(
-                    "Invalid check URL '{}', falling back to TCP probe",
-                    check_url
-                );
-                return self
-                    .probe_node_tcp(node_id, node_name, &registered.address, timeout)
-                    .await;
-            }
+        let Some(hostname) = Self::parse_url_host(&check_url) else {
+            return self
+                .probe_node_tcp(node_id, node_name, &registered.address, timeout)
+                .await;
         };
 
         // Use cached IPs from startup (Go: TcpCheckOption.Ip46).

--- a/crates/honk-outbound/src/alive/tests.rs
+++ b/crates/honk-outbound/src/alive/tests.rs
@@ -445,6 +445,22 @@ impl HttpProber for MockHttpProber {
 }
 
 #[tokio::test]
+async fn invalid_http_check_url_falls_back_before_probe_cycles() {
+    let set = AliveDialerSet::new();
+    set.set_http_probe(
+        Arc::new(MockHttpProber {
+            result: HttpProbeResult::WarmSuccess(Duration::from_millis(1)),
+        }),
+        "http://".into(),
+        "HEAD".into(),
+    )
+    .await;
+
+    assert!(set.check_url.read().is_empty());
+    assert!(set.check_url_ips.read().is_empty());
+}
+
+#[tokio::test]
 async fn warm_http_probe_is_the_only_result_recorded_as_latency() {
     let set = AliveDialerSet::new();
     set.register_node(id(1), "n1".into(), "127.0.0.1:1".into());


### PR DESCRIPTION
## Summary
- Promote established TCP/UDP connection and TCP eBPF offload logs to `info`.
- Move health-check, URLTest, and Score probe diagnostics to `debug`.
- Keep non-probe fault and traffic-recovery logs at their existing levels.

## Verification
- `cargo fmt --all -- --check`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY cargo check -p honk-core -p honk-outbound`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY cargo test -p honk-outbound alive --lib`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY cargo test -p honk-core control::connection --lib`