### PR TITLE
fix(api): peek sub-group picks for delay-test member resolution

### DIFF
--- a/crates/honk-outbound/src/group/resolver.rs
+++ b/crates/honk-outbound/src/group/resolver.rs
@@ -358,6 +358,9 @@ impl GroupManager {
                 continue;
             };
             let mut visited = Vec::new();
+            // Delay tests and provider listings only display the sub-group's
+            // current pick: peek, or a dashboard poll would record phantom
+            // Score selections and flap history for unused groups.
             let leaf = self
                 .pick_in_group(
                     sub,
@@ -365,7 +368,7 @@ impl GroupManager {
                     IpVersion::V4,
                     &mut visited,
                     0,
-                    SelectionEffects::Apply,
+                    SelectionEffects::Peek,
                 )
                 .or_else(|| {
                     let mut visited = Vec::new();

--- a/crates/honk-outbound/src/group/score.rs
+++ b/crates/honk-outbound/src/group/score.rs
@@ -4700,6 +4700,32 @@ group {
     }
 
     #[test]
+    fn delay_test_members_do_not_record_score_selection() {
+        let nodes = [node("delay-peek-alpha"), node("delay-peek-beta")];
+        let sub = group("delay-peek-sub", &nodes);
+        let parent = Group {
+            id: Uuid::new_v4(),
+            name: "delay-peek-parent".into(),
+            policy: GroupPolicy::Selector,
+            nodes: vec![],
+            groups: vec!["delay-peek-sub".into()],
+            ..Default::default()
+        };
+        let manager = super::super::GroupManager::new(&[parent, sub], &nodes);
+
+        let members = manager.delay_test_members("delay-peek-parent");
+        assert_eq!(members.len(), 1);
+        assert_eq!(members[0].0, "delay-peek-sub");
+
+        let state = manager.score_state();
+        assert_eq!(
+            state.selection_reason_counts("delay-peek-sub", SelectionNetwork::Tcp),
+            SelectionReasonCounts::default()
+        );
+        assert!(state.inner.lock().selection_history.is_empty());
+    }
+
+    #[test]
     fn score_reason_snapshot_reload_policy_is_name_based() {
         let nodes = [node("private-reload-alpha"), node("private-reload-beta")];
         let score = group("persist", &nodes);


### PR DESCRIPTION
## Problem

`GET /providers/proxies` and `GET /group/{name}/delay` resolve sub-group members through `delay_test_members`, which used `SelectionEffects::Apply` for the sub-group pick. Every dashboard poll therefore recorded **phantom authoritative Score selections** for each Score sub-group (selection reasons, flap history, `selected_at` incumbent marks) — with zero real traffic behind them.

Production evidence: an unused Score group (no routing rule references it, no active connections through its leaves, zero log mentions) accumulated ~82 ranks/min and a 6–9% flap share, purely from dashboard refresh polling. Because the unused group's evidence decays (no real flows), its hysteresis margin collapses to zero and every poll-driven rank can flip the winner — a structural flap generator that no damping can fix.

## Change

`delay_test_members` now resolves sub-group picks with `SelectionEffects::Peek`, matching its documented semantics ("the leaf their policy currently selects") without mutating selection state. Real dial paths keep `Apply`.

## Evidence

- New test `delay_test_members_do_not_record_score_selection`: resolving a Selector parent over a Score sub-group leaves selection-reason counters and flap history untouched.
- `cargo test -p honk-outbound --lib group`: 132 passed; clippy + fmt clean.

## Notes

This also cleans the measurement baseline for evaluating #106 (flap damping): the group-level flap counters that motivated it were dominated by these phantom ranks. After this lands, `/stats.score` reflects real traffic only.
