### PR TITLE
fix(quic): patch quinn-proto receive-assembler chunk bound for lossy paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2584,8 +2584,7 @@ dependencies = [
 [[package]]
 name = "quinn-proto"
 version = "0.11.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
+source = "git+https://github.com/Glassyiris/quinn?rev=a147057a8dfbfcd583be395f5fa13adbb91ccfe5#a147057a8dfbfcd583be395f5fa13adbb91ccfe5"
 dependencies = [
  "aws-lc-rs",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,3 +169,6 @@ strip = true
 [patch.crates-io]
 # honk rprx fork: preset X25519 keyshare + ClientHello fixup hooks (REALITY)
 boring-sys = { git = "https://github.com/Glassyiris/boring-sys", rev = "630d5030ee281371231f2c8c0b7206178032f62e" }
+# honk fork: raise the receive-assembler chunk bound so large receive windows
+# survive lossy paths (upstream MAX_CHUNKS=1024 kills the whole connection).
+quinn-proto = { git = "https://github.com/Glassyiris/quinn", rev = "a147057a8dfbfcd583be395f5fa13adbb91ccfe5" }


### PR DESCRIPTION
## Problem

On high-RTT lossy paths, every QUIC-based outbound (hy2/TUIC/Juicity) dies a few seconds into a fast transfer:

```
closing connection due to transport error: ... too many gaps in stream buffer
```

quinn-proto's receive assembler aborts the whole connection once a stream accumulates more than `MAX_CHUNKS = 1024` unmergeable buffered chunks. With our 8 MiB receive window (~6500 packets in flight at 1252B), a burst of losses on a long-fat path creates more holes than retransmits can fill before the limit trips. quic-go (dae/mihomo) has no such hard cap, so those clients survive the same link.

## Fix

Patch `quinn-proto` via the honk fork (same pattern as boring-sys): `MAX_CHUNKS` 1024 → 16384. Worst-case per-stream bookkeeping grows to ~16384 × ~80B ≈ 1.3 MiB; on clean paths the chunk count stays near zero, so no regression surface. The bound still exists as DoS protection, just above anything a real lossy path produces.

Fork rev: [Glassyiris/quinn@a147057](https://github.com/Glassyiris/quinn/commit/a147057a8dfbfcd583be395f5fa13adbb91ccfe5) (one-line change on `quinn-proto-0.11.17`).

## Evidence

Same node (US, ~450ms RTT, lossy), 50 MiB download ×3 via speed.cloudflare.com on the .49 lab box:

| client | result |
|---|---|
| honk, 8 MiB window (before) | dies at ~3s, exit 56, every run |
| honk, 2 MiB window (workaround) | 4.1–5.4 MB/s, stable |
| **honk, 8 MiB window (this patch)** | **5.6–9.9 MB/s, 8/8 complete, zero gap errors** |
| dae (quic-go) | 4.6–5.5 MB/s, stable |
| mihomo (quic-go) | 2.4–3.6 MB/s, stable |

A smaller window also avoids the cap but costs ~2× throughput on this link; raising the cap keeps both.

## Gate

`cargo test --workspace --no-fail-fast` (with the known legacy routing exclude) + `clippy --all-targets -D warnings` green on the patched lockfile.
