### PR TITLE
perf(quic): add path telemetry and bounded recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2584,7 +2584,7 @@ dependencies = [
 [[package]]
 name = "quinn-proto"
 version = "0.11.17"
-source = "git+https://github.com/Glassyiris/quinn?rev=a147057a8dfbfcd583be395f5fa13adbb91ccfe5#a147057a8dfbfcd583be395f5fa13adbb91ccfe5"
+source = "git+https://github.com/Glassyiris/quinn?rev=b0acb533#b0acb53397902059fb2fa4ce5a2081734dd4d69e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -3367,7 +3367,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,6 +169,6 @@ strip = true
 [patch.crates-io]
 # honk rprx fork: preset X25519 keyshare + ClientHello fixup hooks (REALITY)
 boring-sys = { git = "https://github.com/Glassyiris/boring-sys", rev = "630d5030ee281371231f2c8c0b7206178032f62e" }
-# honk fork: raise the receive-assembler chunk bound so large receive windows
-# survive lossy paths (upstream MAX_CHUNKS=1024 kills the whole connection).
-quinn-proto = { git = "https://github.com/Glassyiris/quinn", rev = "a147057a8dfbfcd583be395f5fa13adbb91ccfe5" }
+# honk fork: raise the receive-assembler chunk bound and expose ACK-eliciting
+# delivery counters for path-stall detection and QUIC telemetry.
+quinn-proto = { git = "https://github.com/Glassyiris/quinn", rev = "b0acb533" }

--- a/crates/honk-core/src/clash_api.rs
+++ b/crates/honk-core/src/clash_api.rs
@@ -905,6 +905,7 @@ async fn get_outbound_stats(State(s): State<Arc<ClashState>>) -> Json<serde_json
     let warm = s
         .stats
         .warm_snapshot(&s.runtime_registry.read().clone(), &s.connection_pool);
+    let quic = honk_outbound::quic::quic_stats_snapshot();
     Json(serde_json::json!({
         "outbounds": per_outbound,
         "score": {
@@ -920,6 +921,32 @@ async fn get_outbound_stats(State(s): State<Arc<ClashState>>) -> Json<serde_json
             "readyHits": pool.hits,
             "readyMisses": pool.misses,
             "entries": pool.entries,
+        },
+        "quic": {
+            "activeConnections": quic.active_connections,
+            "srttUs": quic.srtt_us,
+            "cwndBytes": quic.cwnd_bytes,
+            "lossRatePpm": quic.loss_rate_ppm,
+            "sentPackets": quic.sent_packets,
+            "ackFrames": quic.ack_frames,
+            "lostPackets": quic.lost_packets,
+            "sentPlpmtudProbes": quic.sent_plpmtud_probes,
+            "lostPlpmtudProbes": quic.lost_plpmtud_probes,
+            "currentMtu": quic.current_mtu,
+            "blackHoles": quic.black_holes,
+            "congestionEvents": quic.congestion_events,
+            "txBytes": quic.tx_bytes,
+            "rxBytes": quic.rx_bytes,
+            "txDatagrams": quic.tx_datagrams,
+            "rxDatagrams": quic.rx_datagrams,
+            "txIos": quic.tx_ios,
+            "rxIos": quic.rx_ios,
+            "transportTxWouldBlock": quic.transport_tx_would_block,
+            "transportTxDrops": quic.transport_tx_drops,
+            "transportRxDrops": quic.transport_rx_drops,
+            "sessionRxDrops": quic.session_rx_drops,
+            "sendTimeouts": quic.send_timeouts,
+            "pathStalls": quic.path_stalls,
         },
         "warm": {
             "nodes": {

--- a/crates/honk-core/src/control/nfqueue/ingest.rs
+++ b/crates/honk-core/src/control/nfqueue/ingest.rs
@@ -200,13 +200,14 @@ impl PendingUdpVerdicts {
                     self.drop_one(held, DropOutcome::Cancel);
                     return NfqueueIngest::Dropped;
                 };
-                let result = self.endpoints.reserve_owned_or_enqueue(
+                let result = self.endpoints.reserve_owned_or_enqueue_at(
                     cell.identity.client(),
                     cell.identity.destination(),
                     payload,
                     decision_token,
                     Some(cell.identity.endpoint_generation),
                     slow_permit,
+                    held.received_at,
                     &self.stats,
                 );
                 match result {
@@ -249,13 +250,14 @@ impl PendingUdpVerdicts {
                     self.drop_one(held, DropOutcome::Other);
                     return NfqueueIngest::Dropped;
                 };
-                let result = self.endpoints.reserve_owned_or_enqueue(
+                let result = self.endpoints.reserve_owned_or_enqueue_at(
                     cell.identity.client(),
                     cell.identity.destination(),
                     payload,
                     decision_token,
                     Some(cell.identity.endpoint_generation),
                     slow_permit,
+                    held.received_at,
                     &self.stats,
                 );
                 drop(state);
@@ -350,13 +352,14 @@ impl PendingUdpVerdicts {
                     self.drop_one(held, DropOutcome::Cancel);
                     return NfqueueIngest::Dropped;
                 };
-                match self.endpoints.reserve_owned_or_enqueue(
+                match self.endpoints.reserve_owned_or_enqueue_at(
                     key.client,
                     key.destination,
                     payload,
                     decision_token,
                     None,
                     slow_permit,
+                    held.received_at,
                     &self.stats,
                 ) {
                     EndpointReservation::Initializing(lease) => {
@@ -421,11 +424,12 @@ impl PendingUdpVerdicts {
             }
             RetainedState::Proxy => {
                 drop(slow_permit);
-                match self.endpoints.enqueue_owned_by_token(
+                match self.endpoints.enqueue_owned_by_token_at(
                     key.client,
                     key.destination,
                     payload,
                     decision_token,
+                    held.received_at,
                     &self.stats,
                 ) {
                     Ok(generation) => {

--- a/crates/honk-core/src/control/runtime.rs
+++ b/crates/honk-core/src/control/runtime.rs
@@ -922,6 +922,7 @@ pub(super) enum UdpSlowPathWork {
         permit: tokio::sync::OwnedSemaphorePermit,
         data: Bytes,
         validated: ValidatedDnsQuery,
+        enqueued_at: u32,
     },
     /// Fully handled in the receive loop (enqueued / rejected / dropped).
     Done,
@@ -933,6 +934,7 @@ pub(super) enum UdpSlowPathWork {
 /// Only strict DNS queries whose authoritative destination is port 53 return
 /// [`UdpSlowPathWork::DnsThenMaybeInitialize`]; DNS-shaped non-53 UDP stays
 /// on ordinary forwarding.
+#[cfg(test)]
 pub(super) fn begin_udp_slow_path(
     pool: &Arc<UdpEndpointPool>,
     stats: &StatsManager,
@@ -941,6 +943,29 @@ pub(super) fn begin_udp_slow_path(
     original_dst: SocketAddr,
     data: &[u8],
     validated_dns: Option<ValidatedDnsQuery>,
+) -> UdpSlowPathWork {
+    begin_udp_slow_path_at(
+        pool,
+        stats,
+        concurrency_limit,
+        src_addr,
+        original_dst,
+        data,
+        validated_dns,
+        udp_endpoint::queue_now(),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn begin_udp_slow_path_at(
+    pool: &Arc<UdpEndpointPool>,
+    stats: &StatsManager,
+    concurrency_limit: &Arc<tokio::sync::Semaphore>,
+    src_addr: SocketAddr,
+    original_dst: SocketAddr,
+    data: &[u8],
+    validated_dns: Option<ValidatedDnsQuery>,
+    enqueued_at: u32,
 ) -> UdpSlowPathWork {
     let Some(permit) = try_admit_udp_slow_path(stats, concurrency_limit) else {
         return UdpSlowPathWork::Done;
@@ -954,9 +979,10 @@ pub(super) fn begin_udp_slow_path(
             permit,
             data: Bytes::copy_from_slice(data),
             validated,
+            enqueued_at,
         };
     }
-    match pool.reserve_or_enqueue(src_addr, original_dst, data, permit, stats) {
+    match pool.reserve_or_enqueue_at(src_addr, original_dst, data, permit, enqueued_at, stats) {
         EndpointReservation::Initializing(lease) => UdpSlowPathWork::Initialize(lease),
         EndpointReservation::Enqueued
         | EndpointReservation::CapacityRejected
@@ -982,6 +1008,7 @@ pub(super) async fn complete_udp_dns_slow_path(
     context: UdpDnsSlowPathContext<'_>,
     permit: tokio::sync::OwnedSemaphorePermit,
     data: &[u8],
+    enqueued_at: u32,
     validated: ValidatedDnsQuery,
 ) -> Option<UdpInitLease> {
     let UdpDnsSlowPathContext {
@@ -1007,7 +1034,7 @@ pub(super) async fn complete_udp_dns_slow_path(
             );
         }
     }
-    match pool.reserve_or_enqueue(src_addr, original_dst, data, permit, stats) {
+    match pool.reserve_or_enqueue_at(src_addr, original_dst, data, permit, enqueued_at, stats) {
         EndpointReservation::Initializing(mut lease) => {
             // The controller was invoked exactly once for this packet. Carry
             // that fact into initialize_udp_connection so an Ok(false) or
@@ -1062,6 +1089,7 @@ async fn udp_listener_loop(state: UdpLoopState, socket: Arc<UdpSocket>, family: 
             error!("{} UDP recv error: {}", family, error);
             continue;
         }
+        let batch_received_at = udp_endpoint::queue_now();
         for index in 0..batch.len() {
             let (data, src_addr, recv_meta) = match batch.packet(index) {
                 Ok(packet) => packet,
@@ -1086,23 +1114,32 @@ async fn udp_listener_loop(state: UdpLoopState, socket: Arc<UdpSocket>, family: 
                 state.stats.record_udp_slow_permit_closed();
                 continue;
             }
-            if udp_fast_path(
+            if udp_fast_path_at(
                 &state.udp_pool,
                 &state.stats,
                 data,
                 src_addr,
                 original_dst,
                 validated_dns,
+                batch_received_at,
             )
             .await
             {
                 continue;
             }
-            dispatch_udp_slow_path(&state, src_addr, original_dst, data, validated_dns);
+            dispatch_udp_slow_path_at(
+                &state,
+                src_addr,
+                original_dst,
+                data,
+                validated_dns,
+                batch_received_at,
+            );
         }
     }
 }
 
+#[cfg(test)]
 pub(super) fn dispatch_udp_slow_path(
     state: &UdpLoopState,
     src_addr: SocketAddr,
@@ -1110,12 +1147,30 @@ pub(super) fn dispatch_udp_slow_path(
     data: &[u8],
     validated_dns: Option<ValidatedDnsQuery>,
 ) {
+    dispatch_udp_slow_path_at(
+        state,
+        src_addr,
+        original_dst,
+        data,
+        validated_dns,
+        udp_endpoint::queue_now(),
+    );
+}
+
+fn dispatch_udp_slow_path_at(
+    state: &UdpLoopState,
+    src_addr: SocketAddr,
+    original_dst: SocketAddr,
+    data: &[u8],
+    validated_dns: Option<ValidatedDnsQuery>,
+    enqueued_at: u32,
+) {
     let concurrency_limit = if original_dst.port() == 53 && validated_dns.is_some() {
         &state.dns_concurrency_limit
     } else {
         &state.udp_concurrency_limit
     };
-    match begin_udp_slow_path(
+    match begin_udp_slow_path_at(
         &state.udp_pool,
         &state.stats,
         concurrency_limit,
@@ -1123,6 +1178,7 @@ pub(super) fn dispatch_udp_slow_path(
         original_dst,
         data,
         validated_dns,
+        enqueued_at,
     ) {
         UdpSlowPathWork::Done => {}
         UdpSlowPathWork::Initialize(lease) => {
@@ -1142,6 +1198,7 @@ pub(super) fn dispatch_udp_slow_path(
             permit,
             data,
             validated,
+            enqueued_at,
         } => {
             let handle = state.handle.clone();
             let guard = ConnectionGuard::new(Arc::clone(&state.drain));
@@ -1163,6 +1220,7 @@ pub(super) fn dispatch_udp_slow_path(
                     },
                     permit,
                     &data,
+                    enqueued_at,
                     validated,
                 )
                 .await
@@ -1201,8 +1259,20 @@ pub(super) fn reserve_udp_slow_path(
         None,
     ) {
         UdpSlowPathWork::Initialize(lease) => Some(lease),
-        UdpSlowPathWork::DnsThenMaybeInitialize { permit, data, .. } => {
-            match pool.reserve_or_enqueue(src_addr, original_dst, &data, permit, stats) {
+        UdpSlowPathWork::DnsThenMaybeInitialize {
+            permit,
+            data,
+            enqueued_at,
+            ..
+        } => {
+            match pool.reserve_or_enqueue_at(
+                src_addr,
+                original_dst,
+                &data,
+                permit,
+                enqueued_at,
+                stats,
+            ) {
                 EndpointReservation::Initializing(lease) => Some(lease),
                 _ => None,
             }

--- a/crates/honk-core/src/control/sockets.rs
+++ b/crates/honk-core/src/control/sockets.rs
@@ -1176,6 +1176,7 @@ pub(super) fn get_original_dst(stream: &TcpStream) -> anyhow::Result<SocketAddr>
 /// accounting. Skipping the QUIC sniffer on Ready hits is safe because
 /// routing for this flow was already decided when its first packet took the
 /// slow path.
+#[cfg(test)]
 pub(super) async fn udp_fast_path(
     udp_pool: &UdpEndpointPool,
     stats: &StatsManager,
@@ -1183,6 +1184,27 @@ pub(super) async fn udp_fast_path(
     client_addr: SocketAddr,
     original_dst: SocketAddr,
     validated_dns: Option<ValidatedDnsQuery>,
+) -> bool {
+    udp_fast_path_at(
+        udp_pool,
+        stats,
+        data,
+        client_addr,
+        original_dst,
+        validated_dns,
+        udp_endpoint::queue_now(),
+    )
+    .await
+}
+
+pub(super) async fn udp_fast_path_at(
+    udp_pool: &UdpEndpointPool,
+    stats: &StatsManager,
+    data: &[u8],
+    client_addr: SocketAddr,
+    original_dst: SocketAddr,
+    validated_dns: Option<ValidatedDnsQuery>,
+    enqueued_at: u32,
 ) -> bool {
     // Same drop pre-checks as serve_udp_connection: honk-internal subnet and
     // broadcast/multicast traffic must never be proxied.
@@ -1209,7 +1231,9 @@ pub(super) async fn udp_fast_path(
     // The receive loop only performs a synchronous bounded enqueue. Transport
     // I/O belongs exclusively to the per-endpoint driver, so a blocked send
     // on one flow cannot delay classification of another datagram.
-    let Some(result) = udp_pool.fast_path_enqueue(client_addr, original_dst, data, stats) else {
+    let Some(result) =
+        udp_pool.fast_path_enqueue_at(client_addr, original_dst, data, enqueued_at, stats)
+    else {
         stats.record_udp_endpoint_miss();
         return false;
     };

--- a/crates/honk-core/src/control/tests.rs
+++ b/crates/honk-core/src/control/tests.rs
@@ -3723,12 +3723,24 @@ async fn udp_dns_with_ready_endpoint_uses_controller_not_queue() {
     // Fast path must force DNS-shaped traffic slow even with Ready present.
     assert!(!udp_fast_path(&pool, &stats, &query, client, dst, Some(validated)).await);
 
-    match super::begin_udp_slow_path(&pool, &stats, &slow, client, dst, &query, Some(validated)) {
+    let received_at = crate::control::udp_endpoint::queue_now().wrapping_sub(1_234);
+    match super::runtime::begin_udp_slow_path_at(
+        &pool,
+        &stats,
+        &slow,
+        client,
+        dst,
+        &query,
+        Some(validated),
+        received_at,
+    ) {
         super::UdpSlowPathWork::DnsThenMaybeInitialize {
             permit,
             data,
             validated,
+            enqueued_at,
         } => {
+            assert_eq!(enqueued_at, received_at);
             let lease = super::complete_udp_dns_slow_path(
                 super::UdpDnsSlowPathContext {
                     pool: &pool,
@@ -3739,6 +3751,7 @@ async fn udp_dns_with_ready_endpoint_uses_controller_not_queue() {
                 },
                 permit,
                 &data,
+                enqueued_at,
                 validated,
             )
             .await;
@@ -3795,6 +3808,7 @@ async fn udp_dns_with_initializing_endpoint_uses_controller_not_queue() {
             permit,
             data,
             validated,
+            enqueued_at,
         } => {
             let maybe_lease = super::complete_udp_dns_slow_path(
                 super::UdpDnsSlowPathContext {
@@ -3806,6 +3820,7 @@ async fn udp_dns_with_initializing_endpoint_uses_controller_not_queue() {
                 },
                 permit,
                 &data,
+                enqueued_at,
                 validated,
             )
             .await;

--- a/crates/honk-core/src/control/udp_endpoint/admission.rs
+++ b/crates/honk-core/src/control/udp_endpoint/admission.rs
@@ -69,14 +69,50 @@ impl EndpointKey {
 /// after the same bounded admission succeeds.
 pub(in crate::control) struct QueuedDatagram {
     pub(super) data: Bytes,
-    pub(super) _flow_permit: OwnedSemaphorePermit,
-    pub(super) _global_byte_permit: Option<OwnedSemaphorePermit>,
+    accounting: DatagramAccounting,
+}
+
+struct DatagramAccounting {
+    _flow_permit: OwnedSemaphorePermit,
+    global_payload_bytes: Arc<Semaphore>,
+    payload_bytes: u32,
+    enqueued_at: u32,
+}
+
+impl Drop for DatagramAccounting {
+    fn drop(&mut self) {
+        self.global_payload_bytes
+            .add_permits(self.payload_bytes as usize);
+    }
 }
 
 impl QueuedDatagram {
     pub(in crate::control) fn payload(&self) -> &[u8] {
         &self.data
     }
+
+    pub(super) fn expired(&self, max_age: Duration) -> bool {
+        queue_now().wrapping_sub(self.accounting.enqueued_at) >= duration_millis(max_age)
+    }
+
+    #[cfg(test)]
+    pub(super) fn age_for_test(&mut self, age: Duration) {
+        self.accounting.enqueued_at = queue_now().wrapping_sub(duration_millis(age));
+    }
+}
+
+fn duration_millis(duration: Duration) -> u32 {
+    u32::try_from(duration.as_millis()).unwrap_or(u32::MAX)
+}
+
+pub(in crate::control) fn queue_now() -> u32 {
+    // ponytail: u32 milliseconds wrap every 49 days; queued packets live for seconds.
+    (monotonic_nanos() / 1_000_000) as u32
+}
+
+#[cfg(any(feature = "ebpf", test))]
+fn queue_timestamp(received_at: Instant) -> u32 {
+    queue_now().wrapping_sub(duration_millis(received_at.elapsed()))
 }
 
 enum DatagramPayload<'a> {
@@ -346,6 +382,7 @@ impl UdpInitLease {
     /// setup. Returns false when a newer generation or death/cancel path
     /// retired this entry.
     pub(in crate::control) fn bind_selected_node(&self, node_id: uuid::Uuid) -> bool {
+        let _binding_gate = self.pool.node_binding_gate.lock();
         let Some(entry) = self.pool.endpoints.get(&self.key) else {
             return false;
         };
@@ -521,6 +558,28 @@ pub(super) struct ReservationPublicationHook {
     pub(super) published: Arc<std::sync::Barrier>,
     pub(super) resume: Arc<std::sync::Barrier>,
 }
+#[cfg(test)]
+#[derive(Debug)]
+pub(super) struct ReservationGateHook {
+    pub(super) entered: Arc<std::sync::Barrier>,
+    pub(super) resume: Arc<std::sync::Barrier>,
+}
+
+impl UdpEndpointPool {
+    #[cfg(test)]
+    fn pause_before_reservation_gate(&self) {
+        let hook = self.reservation_gate_hook.lock().clone();
+        if let Some(hook) = hook {
+            hook.entered.wait();
+            hook.resume.wait();
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn set_reservation_gate_hook(&self, hook: Option<Arc<ReservationGateHook>>) {
+        *self.reservation_gate_hook.lock() = hook;
+    }
+}
 
 impl UdpInitializerGuard {
     fn new(pool: Arc<UdpEndpointPool>) -> Self {
@@ -555,55 +614,59 @@ impl UdpEndpointPool {
         }
     }
 
-    fn packet_permits(
+    fn packet_accounting(
         &self,
         len: usize,
         flow_slots: &Arc<Semaphore>,
-    ) -> Result<(OwnedSemaphorePermit, Option<OwnedSemaphorePermit>), PacketAdmissionError> {
+        enqueued_at: u32,
+    ) -> Result<DatagramAccounting, PacketAdmissionError> {
         let flow_permit = flow_slots
             .clone()
             .try_acquire_owned()
             .map_err(|_| PacketAdmissionError::FlowQueueFull)?;
-        let global_byte_permit = if len == 0 {
-            None
-        } else {
-            let byte_count =
-                u32::try_from(len).map_err(|_| PacketAdmissionError::GlobalPayloadFull)?;
-            Some(
-                self.global_payload_bytes
-                    .clone()
-                    .try_acquire_many_owned(byte_count)
-                    .map_err(|_| PacketAdmissionError::GlobalPayloadFull)?,
-            )
-        };
-        Ok((flow_permit, global_byte_permit))
-    }
-
-    fn make_packet(
-        &self,
-        data: DatagramPayload<'_>,
-        flow_slots: &Arc<Semaphore>,
-    ) -> Result<QueuedDatagram, PacketAdmissionError> {
-        let (flow_permit, global_byte_permit) = self.packet_permits(data.len(), flow_slots)?;
-        Ok(QueuedDatagram {
-            data: data.into_bytes(),
+        let payload_bytes =
+            u32::try_from(len).map_err(|_| PacketAdmissionError::GlobalPayloadFull)?;
+        let global_payload_bytes = Arc::clone(&self.global_payload_bytes);
+        if payload_bytes != 0 {
+            let permit = global_payload_bytes
+                .try_acquire_many(payload_bytes)
+                .map_err(|_| PacketAdmissionError::GlobalPayloadFull)?;
+            permit.forget();
+        }
+        Ok(DatagramAccounting {
             _flow_permit: flow_permit,
-            _global_byte_permit: global_byte_permit,
+            global_payload_bytes,
+            payload_bytes,
+            enqueued_at,
         })
     }
 
-    fn enqueue(
+    fn make_packet_at(
+        &self,
+        data: DatagramPayload<'_>,
+        flow_slots: &Arc<Semaphore>,
+        enqueued_at: u32,
+    ) -> Result<QueuedDatagram, PacketAdmissionError> {
+        let accounting = self.packet_accounting(data.len(), flow_slots, enqueued_at)?;
+        Ok(QueuedDatagram {
+            data: data.into_bytes(),
+            accounting,
+        })
+    }
+
+    fn enqueue_at(
         &self,
         sender: &mpsc::Sender<QueuedDatagram>,
         flow_slots: &Arc<Semaphore>,
         data: DatagramPayload<'_>,
+        enqueued_at: u32,
         stats: &StatsManager,
     ) -> EndpointReservation {
         if sender.is_closed() {
             stats.record_udp_queue_closed();
             return EndpointReservation::QueueClosed;
         }
-        let packet = match self.make_packet(data, flow_slots) {
+        let packet = match self.make_packet_at(data, flow_slots, enqueued_at) {
             Ok(packet) => packet,
             Err(PacketAdmissionError::FlowQueueFull) => {
                 stats.record_udp_flow_queue_full();
@@ -630,14 +693,26 @@ impl UdpEndpointPool {
         }
     }
 
-    fn reserve_new(
+    fn reserve_new_at(
         self: &Arc<Self>,
         vacant: dashmap::mapref::entry::VacantEntry<'_, EndpointKey, EndpointEntry>,
         data: DatagramPayload<'_>,
         decision_token: u32,
         slow_permit: OwnedSemaphorePermit,
+        enqueued_at: u32,
         stats: &StatsManager,
     ) -> EndpointReservation {
+        let reservation_epoch = *self.initialization_epoch.lock();
+        #[cfg(test)]
+        self.pause_before_reservation_gate();
+        let epoch_gate = self.initialization_epoch.lock();
+        if self.terminal.load(Ordering::Acquire) || reservation_epoch != *epoch_gate {
+            stats.record_udp_queue_closed();
+            return EndpointReservation::QueueClosed;
+        }
+        let cancellation = self.cancel_epoch.subscribe();
+        let initializer_guard = UdpInitializerGuard::new(Arc::clone(self));
+        drop(epoch_gate);
         let endpoint_permit = match self.endpoint_slots.clone().try_acquire_owned() {
             Ok(permit) => permit,
             Err(_) => {
@@ -646,7 +721,7 @@ impl UdpEndpointPool {
             }
         };
         let flow_slots = Arc::new(Semaphore::new(FLOW_QUEUE_CAPACITY));
-        let first = match self.make_packet(data, &flow_slots) {
+        let first = match self.make_packet_at(data, &flow_slots, enqueued_at) {
             Ok(packet) => packet,
             Err(PacketAdmissionError::FlowQueueFull) => {
                 stats.record_udp_flow_queue_full();
@@ -660,13 +735,11 @@ impl UdpEndpointPool {
         let (queue_tx, queue_rx) = mpsc::channel(FLOW_QUEUE_CAPACITY);
         let generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
         let epoch_gate = self.initialization_epoch.lock();
-        if self.terminal.load(Ordering::Acquire) {
+        if self.terminal.load(Ordering::Acquire) || reservation_epoch != *epoch_gate {
             stats.record_udp_queue_closed();
             return EndpointReservation::QueueClosed;
         }
         let epoch = *epoch_gate;
-        let cancellation = self.cancel_epoch.subscribe();
-        let initializer_guard = UdpInitializerGuard::new(Arc::clone(self));
         let initializer = Arc::new(InitializingEndpoint {
             decision_token,
             generation,
@@ -700,6 +773,7 @@ impl UdpEndpointPool {
             committed: false,
         })
     }
+    #[cfg(test)]
     /// Atomically reserve a cold tuple or synchronously enqueue onto its
     /// existing Initializing/Ready incarnation. No map or std-mutex guard is
     /// held across await because this entire operation is synchronous.
@@ -709,6 +783,19 @@ impl UdpEndpointPool {
         dst: SocketAddr,
         data: &[u8],
         slow_permit: OwnedSemaphorePermit,
+        stats: &StatsManager,
+    ) -> EndpointReservation {
+        self.reserve_or_enqueue_at(client, dst, data, slow_permit, queue_now(), stats)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(in crate::control) fn reserve_or_enqueue_at(
+        self: &Arc<Self>,
+        client: SocketAddr,
+        dst: SocketAddr,
+        data: &[u8],
+        slow_permit: OwnedSemaphorePermit,
+        enqueued_at: u32,
         stats: &StatsManager,
     ) -> EndpointReservation {
         let key = EndpointKey::new(client, dst);
@@ -721,10 +808,11 @@ impl UdpEndpointPool {
                 dashmap::mapref::entry::Entry::Occupied(occupied) => {
                     let (stale_token, stale_generation) = match occupied.get() {
                         EndpointEntry::Initializing(initializing) => {
-                            match self.enqueue(
+                            match self.enqueue_at(
                                 &initializing.queue_tx,
                                 &initializing.flow_slots,
                                 DatagramPayload::Borrowed(data),
+                                enqueued_at,
                                 stats,
                             ) {
                                 EndpointReservation::QueueClosed => {
@@ -737,10 +825,11 @@ impl UdpEndpointPool {
                             if ready.alive.load(Ordering::Acquire)
                                 && !ready.endpoint.dead.load(Ordering::Acquire) =>
                         {
-                            match self.enqueue(
+                            match self.enqueue_at(
                                 &ready.queue_tx,
                                 &ready.flow_slots,
                                 DatagramPayload::Borrowed(data),
+                                enqueued_at,
                                 stats,
                             ) {
                                 EndpointReservation::QueueClosed => {
@@ -759,11 +848,12 @@ impl UdpEndpointPool {
                     self.retire_if_same(key, stale_token, stale_generation);
                 }
                 dashmap::mapref::entry::Entry::Vacant(vacant) => {
-                    return self.reserve_new(
+                    return self.reserve_new_at(
                         vacant,
                         DatagramPayload::Borrowed(data),
                         0,
                         slow_permit,
+                        enqueued_at,
                         stats,
                     );
                 }
@@ -785,6 +875,32 @@ impl UdpEndpointPool {
         slow_permit: OwnedSemaphorePermit,
         stats: &StatsManager,
     ) -> EndpointReservation {
+        self.reserve_owned_or_enqueue_at(
+            client,
+            dst,
+            data,
+            decision_token,
+            expected_generation,
+            slow_permit,
+            std::time::Instant::now(),
+            stats,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    #[cfg(any(feature = "ebpf", test))]
+    pub(in crate::control) fn reserve_owned_or_enqueue_at(
+        self: &Arc<Self>,
+        client: SocketAddr,
+        dst: SocketAddr,
+        data: Bytes,
+        decision_token: u32,
+        expected_generation: Option<u64>,
+        slow_permit: OwnedSemaphorePermit,
+        enqueued_at: std::time::Instant,
+        stats: &StatsManager,
+    ) -> EndpointReservation {
+        let enqueued_at = queue_timestamp(enqueued_at);
         if self.terminal.load(Ordering::Acquire) {
             stats.record_udp_queue_closed();
             return EndpointReservation::QueueClosed;
@@ -807,20 +923,22 @@ impl UdpEndpointPool {
                     return EndpointReservation::IdentityMismatch;
                 }
                 match occupied.get() {
-                    EndpointEntry::Initializing(initializing) => self.enqueue(
+                    EndpointEntry::Initializing(initializing) => self.enqueue_at(
                         &initializing.queue_tx,
                         &initializing.flow_slots,
                         DatagramPayload::Owned(data),
+                        enqueued_at,
                         stats,
                     ),
                     EndpointEntry::Ready(ready)
                         if ready.alive.load(Ordering::Acquire)
                             && !ready.endpoint.dead.load(Ordering::Acquire) =>
                     {
-                        self.enqueue(
+                        self.enqueue_at(
                             &ready.queue_tx,
                             &ready.flow_slots,
                             DatagramPayload::Owned(data),
+                            enqueued_at,
                             stats,
                         )
                     }
@@ -834,11 +952,12 @@ impl UdpEndpointPool {
                 if expected_generation.is_some() {
                     return EndpointReservation::IdentityMismatch;
                 }
-                self.reserve_new(
+                self.reserve_new_at(
                     vacant,
                     DatagramPayload::Owned(data),
                     decision_token,
                     slow_permit,
+                    enqueued_at,
                     stats,
                 )
             }
@@ -856,6 +975,28 @@ impl UdpEndpointPool {
         decision_token: u32,
         stats: &StatsManager,
     ) -> Result<u64, OwnedEnqueueError> {
+        self.enqueue_owned_by_token_at(
+            client,
+            dst,
+            data,
+            decision_token,
+            std::time::Instant::now(),
+            stats,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    #[cfg(any(feature = "ebpf", test))]
+    pub(in crate::control) fn enqueue_owned_by_token_at(
+        &self,
+        client: SocketAddr,
+        dst: SocketAddr,
+        data: Bytes,
+        decision_token: u32,
+        enqueued_at: std::time::Instant,
+        stats: &StatsManager,
+    ) -> Result<u64, OwnedEnqueueError> {
+        let enqueued_at = queue_timestamp(enqueued_at);
         if decision_token == 0 {
             return Err(OwnedEnqueueError::IdentityMismatch);
         }
@@ -872,10 +1013,11 @@ impl UdpEndpointPool {
             {
                 (
                     initializing.generation,
-                    self.enqueue(
+                    self.enqueue_at(
                         &initializing.queue_tx,
                         &initializing.flow_slots,
                         DatagramPayload::Owned(data),
+                        enqueued_at,
                         stats,
                     ),
                 )
@@ -887,10 +1029,11 @@ impl UdpEndpointPool {
             {
                 (
                     ready.generation,
-                    self.enqueue(
+                    self.enqueue_at(
                         &ready.queue_tx,
                         &ready.flow_slots,
                         DatagramPayload::Owned(data),
+                        enqueued_at,
                         stats,
                     ),
                 )
@@ -920,11 +1063,23 @@ impl UdpEndpointPool {
     /// the tuple remains fenced until the removal worker acknowledges cleanup.
     /// Terminal shutdown returns `QueueClosed` directly
     /// so the listener drops the datagram instead of attempting slow admission.
+    #[cfg(test)]
     pub(in crate::control) fn fast_path_enqueue(
         &self,
         client: SocketAddr,
         dst: SocketAddr,
         data: &[u8],
+        stats: &StatsManager,
+    ) -> Option<EndpointReservation> {
+        self.fast_path_enqueue_at(client, dst, data, queue_now(), stats)
+    }
+
+    pub(in crate::control) fn fast_path_enqueue_at(
+        &self,
+        client: SocketAddr,
+        dst: SocketAddr,
+        data: &[u8],
+        enqueued_at: u32,
         stats: &StatsManager,
     ) -> Option<EndpointReservation> {
         if self.terminal.load(Ordering::Acquire) {
@@ -940,10 +1095,11 @@ impl UdpEndpointPool {
                     && !ready.endpoint.dead.load(Ordering::Acquire) =>
             {
                 (
-                    self.enqueue(
+                    self.enqueue_at(
                         &ready.queue_tx,
                         &ready.flow_slots,
                         DatagramPayload::Borrowed(data),
+                        enqueued_at,
                         stats,
                     ),
                     (ready.decision_token, ready.generation),

--- a/crates/honk-core/src/control/udp_endpoint/bench_support.rs
+++ b/crates/honk-core/src/control/udp_endpoint/bench_support.rs
@@ -84,6 +84,7 @@ struct QueuedBatch {
     client: SocketAddr,
     destination: SocketAddr,
     receiver: mpsc::Receiver<super::QueuedDatagram>,
+    enqueued_at: u32,
     _lease: super::UdpInitLease,
 }
 
@@ -93,11 +94,13 @@ impl QueuedBatch {
         let stats = StatsManager::new();
         let slow_slots = Arc::new(Semaphore::new(slow_capacity));
         let (client, destination) = bench_addresses();
-        let lease = match pool.reserve_or_enqueue(
+        let enqueued_at = super::queue_now();
+        let lease = match pool.reserve_or_enqueue_at(
             client,
             destination,
             first,
             acquire_slow_permit(&slow_slots),
+            enqueued_at,
             &stats,
         ) {
             EndpointReservation::Initializing(lease) => lease,
@@ -114,16 +117,18 @@ impl QueuedBatch {
             client,
             destination,
             receiver,
+            enqueued_at,
             _lease: lease,
         }
     }
 
     fn enqueue(&mut self, payload: &[u8]) -> EndpointReservation {
-        self.pool.reserve_or_enqueue(
+        self.pool.reserve_or_enqueue_at(
             self.client,
             self.destination,
             payload,
             acquire_slow_permit(&self.slow_slots),
+            self.enqueued_at,
             &self.stats,
         )
     }
@@ -137,6 +142,7 @@ struct ReadyBatch {
     client: SocketAddr,
     destination: SocketAddr,
     receiver: mpsc::Receiver<super::QueuedDatagram>,
+    enqueued_at: u32,
 }
 
 impl ReadyBatch {
@@ -149,6 +155,7 @@ impl ReadyBatch {
             client,
             destination,
             receiver,
+            enqueued_at,
             _lease: mut lease,
         } = QueuedBatch::new(1, first);
         drop(
@@ -173,13 +180,20 @@ impl ReadyBatch {
             slow_capacity,
             client,
             destination,
+            enqueued_at,
             receiver,
         }
     }
 
     fn enqueue(&self, payload: &[u8]) -> EndpointReservation {
         self.pool
-            .fast_path_enqueue(self.client, self.destination, payload, &self.stats)
+            .fast_path_enqueue_at(
+                self.client,
+                self.destination,
+                payload,
+                self.enqueued_at,
+                &self.stats,
+            )
             .unwrap_or_else(|| panic!("benchmark Ready mapping must hit the UDP fast path"))
     }
 
@@ -237,13 +251,15 @@ pub fn reserve_rollback_batch(iterations: usize) {
     let (client, destination) = bench_addresses();
     let (remove_tx, mut remove_rx) = mpsc::channel(1);
     pool.set_remove_sink(remove_tx);
+    let enqueued_at = super::queue_now();
 
     for _ in 0..iterations {
-        let lease = match pool.reserve_or_enqueue(
+        let lease = match pool.reserve_or_enqueue_at(
             client,
             destination,
             b"rollback",
             acquire_slow_permit(&slow_slots),
+            enqueued_at,
             &stats,
         ) {
             EndpointReservation::Initializing(lease) => lease,

--- a/crates/honk-core/src/control/udp_endpoint/driver.rs
+++ b/crates/honk-core/src/control/udp_endpoint/driver.rs
@@ -1,9 +1,12 @@
 use super::*;
+use honk_outbound::proxy::QuicSendAttempt;
 
 /// How long the endpoint driver waits for proxy data before giving up.
 pub(super) const REPLY_IDLE_TIMEOUT: Duration = Duration::from_secs(120);
 
 pub(super) const TRANSPORT_SEND_TIMEOUT: Duration = Duration::from_secs(5);
+/// Setup may consume the dynamic send deadline; queue retention still has one fixed bound.
+const QUEUED_PACKET_MAX_AGE: Duration = Duration::from_secs(5);
 pub(super) const TRAFFIC_ALIVE_REPORT_INTERVAL: Duration = Duration::from_millis(200);
 pub(super) const DRIVER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(6);
 pub(super) const DRIVER_ABORT_TIMEOUT: Duration = Duration::from_secs(1);
@@ -15,6 +18,9 @@ enum PacketSendFailure {
     Congestion(io::Error),
     Transport(io::Error),
 }
+
+const QUEUED_PACKET_EXPIRED: &str = "UDP packet expired in endpoint queue";
+
 /// Marker separating receiver-idle expiry from a transport send timeout.
 #[derive(Debug)]
 pub(super) struct ReplyIdleTimeout;
@@ -256,6 +262,9 @@ pub(super) fn score_driver_outcome(
         } else {
             ScoreOutcome::Cancelled
         };
+    }
+    if endpoint.proxy_socket.quic_path_stalled() {
+        return ScoreOutcome::Timeout;
     }
     match result {
         Ok(()) => ScoreOutcome::Success,
@@ -531,26 +540,32 @@ async fn send_one(
     packet: QueuedDatagram,
     first: bool,
 ) -> Result<(), PacketSendFailure> {
-    // This is the application-send linearization point. Node death that wins
-    // before it prevents any transport call; congestion or a post-send error
-    // never causes this packet to be replayed.
+    let started = first.then(Instant::now);
+    if packet.expired(QUEUED_PACKET_MAX_AGE) {
+        if first {
+            stats.record_udp_first_send_failure();
+        }
+        return Err(PacketSendFailure::Congestion(io::Error::new(
+            io::ErrorKind::TimedOut,
+            QUEUED_PACKET_EXPIRED,
+        )));
+    }
     endpoint
         .begin_send_attempt()
         .map_err(PacketSendFailure::Transport)?;
-    let started = first.then(Instant::now);
+    let transport = endpoint.proxy_socket.as_ref();
+    let attempt = QuicSendAttempt::new(transport);
+    let timeout = transport.send_timeout().max(Duration::from_millis(1));
     send_timeout
         .as_mut()
-        .reset(tokio::time::Instant::now() + TRANSPORT_SEND_TIMEOUT);
+        .reset(tokio::time::Instant::now() + timeout);
     let sent = tokio::select! {
         biased;
         result = async {
             if first {
-                endpoint
-                    .proxy_socket
-                    .send_packet_confirmed(&packet.data)
-                    .await
+                transport.send_packet_confirmed(&packet.data).await
             } else {
-                endpoint.proxy_socket.send_packet(&packet.data).await
+                transport.send_packet(&packet.data).await
             }
         } => Ok(result),
         _ = send_timeout.as_mut() => Err(io::Error::new(
@@ -558,10 +573,29 @@ async fn send_one(
             "UDP PacketTransport send timed out",
         )),
     };
-    let result = match sent {
-        Ok(Ok(())) => Ok(()),
-        Ok(Err(error)) => Err(classify_send_error(endpoint.proxy_socket.as_ref(), error)),
-        Err(error) => Err(classify_send_error(endpoint.proxy_socket.as_ref(), error)),
+    let timed_out = match &sent {
+        Ok(Ok(())) => false,
+        Ok(Err(error)) | Err(error) => error.kind() == io::ErrorKind::TimedOut,
+    };
+    let endpoint_retired = endpoint.dead.load(Ordering::Acquire);
+    match &sent {
+        Ok(Ok(())) if endpoint_retired => attempt.failure(),
+        Ok(Ok(())) => attempt.success(),
+        Ok(Err(_)) | Err(_) if endpoint_retired => attempt.failure(),
+        Ok(Err(_)) | Err(_) if timed_out => attempt.timeout(),
+        Ok(Err(_)) | Err(_) => attempt.failure(),
+    };
+    let result = if endpoint_retired {
+        Err(PacketSendFailure::Transport(io::Error::new(
+            io::ErrorKind::ConnectionAborted,
+            "UDP endpoint retired while sending",
+        )))
+    } else {
+        match sent {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(error)) => Err(classify_send_error(transport, error)),
+            Err(error) => Err(classify_send_error(transport, error)),
+        }
     };
     if let Some(started) = started {
         stats.record_udp_first_send_latency(started.elapsed());
@@ -606,13 +640,13 @@ async fn receive_loop(
             .reset(tokio::time::Instant::now() + REPLY_IDLE_TIMEOUT);
         let received = tokio::select! {
             biased;
-            packet = endpoint.proxy_socket.recv_packet(&mut buf) => Ok(packet),
-            _ = reply_idle_timeout.as_mut() => Err(()),
+            packet = endpoint.proxy_socket.recv_packet(&mut buf) => Some(packet),
+            _ = reply_idle_timeout.as_mut() => None,
         };
         let (n, source) = match received {
-            Ok(Ok(packet)) => packet,
-            Ok(Err(error)) => return Err(error),
-            Err(()) => {
+            Some(Ok(packet)) => packet,
+            Some(Err(error)) => return Err(error),
+            None => {
                 return Err(io::Error::new(io::ErrorKind::TimedOut, ReplyIdleTimeout));
             }
         };
@@ -675,9 +709,28 @@ async fn receive_loop(
     }
 }
 
+#[cfg(target_os = "linux")]
 pub(super) fn monotonic_nanos() -> i64 {
-    // Use std Instant as monotonic clock (handles suspend correctly).
-    // We only need relative comparisons, so offset from a fixed epoch is fine.
+    // Queue expiry is second-scale; the coarse clock keeps receive-batch stamping cheap.
+    let mut ts = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    if unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC_COARSE, &mut ts) } == 0 {
+        ts.tv_sec
+            .saturating_mul(1_000_000_000)
+            .saturating_add(ts.tv_nsec)
+    } else {
+        fallback_monotonic_nanos()
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub(super) fn monotonic_nanos() -> i64 {
+    fallback_monotonic_nanos()
+}
+
+fn fallback_monotonic_nanos() -> i64 {
     static EPOCH: std::sync::OnceLock<Instant> = std::sync::OnceLock::new();
     let epoch = EPOCH.get_or_init(Instant::now);
     epoch.elapsed().as_nanos() as i64

--- a/crates/honk-core/src/control/udp_endpoint/mod.rs
+++ b/crates/honk-core/src/control/udp_endpoint/mod.rs
@@ -29,10 +29,12 @@ pub(crate) use retirement::{EndpointRemoval, RemovalReason};
 pub mod bench_support;
 #[cfg(feature = "ebpf")]
 pub(in crate::control) use admission::OwnedEnqueueError;
-#[cfg(test)]
-use admission::ReservationPublicationHook;
 use admission::{EndpointEntry, EndpointKey, FLOW_QUEUE_CAPACITY, GLOBAL_PAYLOAD_CAPACITY};
-pub(in crate::control) use admission::{EndpointReservation, QueuedDatagram, UdpInitLease};
+pub(in crate::control) use admission::{
+    EndpointReservation, QueuedDatagram, UdpInitLease, queue_now,
+};
+#[cfg(test)]
+use admission::{ReservationGateHook, ReservationPublicationHook};
 
 const DEFAULT_NAT_TIMEOUT: Duration = Duration::from_secs(30);
 /// Hard cap on pooled endpoints. A unique-tuple UDP flood must not be able
@@ -62,7 +64,7 @@ pub struct UdpEndpoint {
     created_at: Instant,
     /// Reference count for active operations.
     ref_count: AtomicI64,
-    /// Set when the endpoint is being destroyed.
+    /// Set when node retirement wins before a packet send starts.
     dead: AtomicBool,
     /// Serializes node-death retirement with the linearization point for an
     /// application send attempt. This lock is held only synchronously; no
@@ -107,6 +109,7 @@ impl UdpEndpoint {
     ) -> Self {
         let now = monotonic_nanos();
         Self {
+            dead: AtomicBool::new(false),
             proxy_socket,
             relay_addr,
             node_id,
@@ -116,7 +119,6 @@ impl UdpEndpoint {
             next_alive_report_at: AtomicI64::new(0),
             created_at: Instant::now(),
             ref_count: AtomicI64::new(1),
-            dead: AtomicBool::new(false),
             send_gate: Mutex::new(()),
             pending_reply_peers: Mutex::new(
                 [(
@@ -282,6 +284,10 @@ pub struct UdpEndpointPool {
     endpoints: DashMap<EndpointKey, EndpointEntry>,
     endpoint_slots: Arc<Semaphore>,
     global_payload_bytes: Arc<Semaphore>,
+    /// Linearizes finalized-node binding against node-death scans. Without
+    /// this gate a scan can observe an unbound initializer, then binding can
+    /// publish a dead winner after the scan has passed.
+    node_binding_gate: Mutex<()>,
     /// Monotonic per-reservation incarnation; used only for map ownership.
     next_generation: AtomicU64,
     /// Serializes initializer publication, cancellation bumps, and Ready
@@ -307,6 +313,8 @@ pub struct UdpEndpointPool {
     /// without introducing an await into reservation.
     #[cfg(test)]
     reservation_publication_hook: Mutex<Option<Arc<ReservationPublicationHook>>>,
+    #[cfg(test)]
+    reservation_gate_hook: Mutex<Option<Arc<ReservationGateHook>>>,
 }
 
 impl UdpEndpointPool {
@@ -335,6 +343,7 @@ impl UdpEndpointPool {
             endpoints: DashMap::new(),
             endpoint_slots: Arc::new(Semaphore::new(capacity_limit)),
             global_payload_bytes: Arc::new(Semaphore::new(GLOBAL_PAYLOAD_CAPACITY)),
+            node_binding_gate: Mutex::new(()),
             next_generation: AtomicU64::new(1),
             initialization_epoch: Mutex::new(0),
             cancel_epoch,
@@ -350,6 +359,8 @@ impl UdpEndpointPool {
             retirements_empty: Notify::new(),
             #[cfg(test)]
             reservation_publication_hook: Mutex::new(None),
+            #[cfg(test)]
+            reservation_gate_hook: Mutex::new(None),
         }
     }
 

--- a/crates/honk-core/src/control/udp_endpoint/retirement.rs
+++ b/crates/honk-core/src/control/udp_endpoint/retirement.rs
@@ -174,6 +174,7 @@ impl UdpEndpointPool {
     /// removed; an unbound reservation is still awaiting a winner. Removal is
     /// generation-safe.
     pub fn remove_by_node(&self, node_id: uuid::Uuid) {
+        let _binding_gate = self.node_binding_gate.lock();
         let stale: Vec<(EndpointKey, u32, u64)> = self
             .endpoints
             .iter()

--- a/crates/honk-core/src/control/udp_endpoint/tests.rs
+++ b/crates/honk-core/src/control/udp_endpoint/tests.rs
@@ -841,6 +841,49 @@ fn udp_fast_path_queue_closed_entry_retires_and_allows_recreation() {
 }
 
 #[tokio::test]
+async fn udp_init_started_before_cancellation_cannot_publish_after_fence() {
+    let pool = Arc::new(UdpEndpointPool::new());
+    let stats = Arc::new(StatsManager::new());
+    let client = make_addr("10.0.0.1", 12345);
+    let dst = make_addr("8.8.8.8", 53);
+    let hook = Arc::new(ReservationGateHook {
+        entered: Arc::new(std::sync::Barrier::new(2)),
+        resume: Arc::new(std::sync::Barrier::new(2)),
+    });
+    pool.set_reservation_gate_hook(Some(Arc::clone(&hook)));
+
+    let (result_tx, result_rx) = std::sync::mpsc::sync_channel(1);
+    let reserving_pool = Arc::clone(&pool);
+    let reserving_stats = Arc::clone(&stats);
+    let reserver = std::thread::spawn(move || {
+        let slow_permit = Arc::new(Semaphore::new(1)).try_acquire_owned().unwrap();
+        let result =
+            reserving_pool.reserve_or_enqueue(client, dst, b"first", slow_permit, &reserving_stats);
+        result_tx.send(result).unwrap();
+    });
+
+    hook.entered.wait();
+    let mut cancellation_sent = pool.cancel_epoch.subscribe();
+    let cancelling_pool = Arc::clone(&pool);
+    let cancelling =
+        tokio::spawn(async move { cancelling_pool.cancel_initializers_and_wait().await });
+    cancellation_sent
+        .changed()
+        .await
+        .expect("cancellation sender must remain live");
+
+    hook.resume.wait();
+    let result = tokio::task::spawn_blocking(move || result_rx.recv().unwrap())
+        .await
+        .unwrap();
+    assert!(matches!(result, EndpointReservation::QueueClosed));
+    assert!(cancelling.await.unwrap());
+    reserver.join().unwrap();
+    pool.set_reservation_gate_hook(None);
+    assert!(pool.is_empty());
+}
+
+#[tokio::test]
 async fn udp_init_lease_registers_cancellation_before_publishing() {
     let pool = Arc::new(UdpEndpointPool::new());
     let stats = Arc::new(StatsManager::new());
@@ -1274,6 +1317,38 @@ async fn udp_endpoint_worker_sends_first_then_fifo_followers() {
     worker.abort();
 }
 
+#[tokio::test]
+async fn udp_endpoint_worker_rejects_stale_first_packet() {
+    let pool = Arc::new(UdpEndpointPool::new());
+    let stats = Arc::new(StatsManager::new());
+    let client = make_addr("10.0.0.1", 12345);
+    let dst = make_addr("8.8.8.8", 53);
+    let relay = make_addr("192.168.1.1", 1080);
+    let (mut first, queue_rx) = reserve_driver_packets(&pool, &stats, client, dst, b"first", &[]);
+    first.age_for_test(Duration::from_secs(6));
+    let transport = Arc::new(ScriptedPacketTransport::new(relay, []));
+    let endpoint = driver_test_endpoint(Arc::clone(&transport), relay);
+    let (first_ack_tx, first_ack_rx) = oneshot::channel();
+    let worker = tokio::spawn(run_endpoint_driver(
+        endpoint,
+        queue_rx,
+        test_reply_socket().await,
+        client,
+        dst,
+        Arc::new(honk_outbound::alive::AliveDialerSet::new()),
+        Arc::clone(&stats),
+        "test-node".to_owned(),
+        first,
+        first_ack_tx,
+    ));
+
+    assert!(first_ack_rx.await.unwrap().is_err());
+    assert!(transport.sent_packets().is_empty());
+    assert_eq!(transport.confirmed_send_count(), 0);
+    assert_eq!(stats.udp_snapshot().first_send_failures, 1);
+    worker.await.unwrap().unwrap_err();
+}
+
 #[tokio::test(start_paused = true)]
 async fn udp_endpoint_worker_treats_stream_send_timeout_as_connection_dead() {
     let pool = Arc::new(UdpEndpointPool::new());
@@ -1454,7 +1529,10 @@ async fn udp_endpoint_node_death_stops_after_blocked_first_send() {
     transport.wait_for_send_count(1).await;
     endpoint.kill();
     release.notify_waiters();
-    first_ack_rx.await.unwrap().unwrap();
+    assert_eq!(
+        first_ack_rx.await.unwrap().unwrap_err().kind(),
+        io::ErrorKind::ConnectionAborted
+    );
     assert_eq!(
         worker.await.unwrap().unwrap_err().kind(),
         io::ErrorKind::ConnectionAborted

--- a/crates/honk-core/src/dns/transport/doh3.rs
+++ b/crates/honk-core/src/dns/transport/doh3.rs
@@ -5,6 +5,7 @@
 
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
+use std::time::Duration;
 
 use bytes::{Buf, Bytes};
 use h3::client::SendRequest;
@@ -28,7 +29,17 @@ struct H3Session {
     sender: Mutex<Option<H3Sender>>,
     connection: quinn::Connection,
     endpoint: Option<honk_outbound::quic::PacketTransportEndpoint>,
+    _metrics: honk_outbound::quic::QuicConnectionMonitor,
     driver: OwnedTask,
+}
+async fn close_failed_connection(
+    connection: &quinn::Connection,
+    endpoint: &Option<honk_outbound::quic::PacketTransportEndpoint>,
+) {
+    connection.close(0_u32.into(), b"DoH3 setup failed");
+    if let Some(endpoint) = endpoint {
+        endpoint.close(Duration::ZERO).await;
+    }
 }
 
 /// DoH3 client for one upstream.
@@ -168,10 +179,21 @@ impl Doh3Client {
         )
         .await?;
         let quinn_conn = H3QuinnConnection::new(conn.clone());
-        let (mut driver, sender) = tokio::time::timeout_at(deadline, h3::client::new(quinn_conn))
-            .await
-            .map_err(|_| anyhow::anyhow!("DoH3 dial timed out after {:?}", self.dial.dial_timeout))?
-            .map_err(|e| anyhow::anyhow!("DoH3 h3::client::new: {e}"))?;
+        let h3 = tokio::time::timeout_at(deadline, h3::client::new(quinn_conn)).await;
+        let (mut driver, sender) = match h3 {
+            Ok(Ok(result)) => result,
+            Ok(Err(error)) => {
+                close_failed_connection(&conn, &endpoint).await;
+                return Err(anyhow::anyhow!("DoH3 h3::client::new: {error}"));
+            }
+            Err(_) => {
+                close_failed_connection(&conn, &endpoint).await;
+                return Err(anyhow::anyhow!(
+                    "DoH3 dial timed out after {:?}",
+                    self.dial.dial_timeout
+                ));
+            }
+        };
 
         let driver = OwnedTask::spawn(
             async move {
@@ -186,8 +208,9 @@ impl Doh3Client {
         );
         Ok(H3Session {
             sender: Mutex::new(Some(sender)),
-            connection: conn,
+            connection: conn.clone(),
             endpoint,
+            _metrics: honk_outbound::quic::monitor_quic_connection(&conn),
             driver,
         })
     }

--- a/crates/honk-core/src/dns/transport/doq.rs
+++ b/crates/honk-core/src/dns/transport/doq.rs
@@ -21,6 +21,7 @@ use super::{
 struct DoqConnection {
     connection: Connection,
     endpoint: Option<honk_outbound::quic::PacketTransportEndpoint>,
+    _metrics: honk_outbound::quic::QuicConnectionMonitor,
 }
 
 /// DoQ client for one upstream.
@@ -109,7 +110,6 @@ impl DoqClient {
         }
         Ok(connection.connection.clone())
     }
-
     async fn dial(&self) -> anyhow::Result<DoqConnection> {
         let (connection, endpoint) = quic_connect_endpoint(
             &self.dial,
@@ -120,9 +120,11 @@ impl DoqClient {
             "DoQ",
         )
         .await?;
+        let metrics = honk_outbound::quic::monitor_quic_connection(&connection);
         Ok(DoqConnection {
             connection,
             endpoint,
+            _metrics: metrics,
         })
     }
 

--- a/crates/honk-core/src/dns/transport/quic.rs
+++ b/crates/honk-core/src/dns/transport/quic.rs
@@ -71,8 +71,9 @@ async fn quic_connect(
     let deadline = tokio::time::Instant::now() + budget;
     let (connecting, owner) = if dial.proxy.is_some() {
         let transport = dial.dial_packet_transport_until(addr, deadline).await?;
-        let owner = honk_outbound::quic::packet_transport_endpoint(transport, addr)
-            .map_err(|error| anyhow::anyhow!("{label} packet endpoint: {error}"))?;
+        let owner =
+            honk_outbound::quic::packet_transport_endpoint_with_metrics(transport, addr, true)
+                .map_err(|error| anyhow::anyhow!("{label} packet endpoint: {error}"))?;
         let connecting = owner
             .endpoint()
             .connect_with(config.clone(), addr, sni)

--- a/crates/honk-core/src/stats.rs
+++ b/crates/honk-core/src/stats.rs
@@ -695,7 +695,7 @@ impl StatsManager {
         self.udp.reply_ready_latency.record(elapsed);
     }
 
-    /// Record the fixed five-second first-send attempt latency.
+    /// Record latency for a first-send transport attempt.
     pub fn record_udp_first_send_latency(&self, elapsed: std::time::Duration) {
         self.udp.first_send_latency.record(elapsed);
     }

--- a/crates/honk-core/tests/clash_api_test.rs
+++ b/crates/honk-core/tests/clash_api_test.rs
@@ -2003,6 +2003,35 @@ async fn stats_exposes_udp_metrics() {
     // UDP is additive: existing dashboard keys retain their shapes.
     assert!(body["outbounds"].is_array());
     assert!(body["pool"].is_object());
+    assert!(body["quic"].is_object());
+    assert!(body["quic"]["activeConnections"].is_u64());
+    for key in [
+        "srttUs",
+        "cwndBytes",
+        "lossRatePpm",
+        "sentPackets",
+        "ackFrames",
+        "lostPackets",
+        "sentPlpmtudProbes",
+        "lostPlpmtudProbes",
+        "currentMtu",
+        "blackHoles",
+        "congestionEvents",
+        "txBytes",
+        "rxBytes",
+        "txDatagrams",
+        "rxDatagrams",
+        "txIos",
+        "rxIos",
+        "transportTxWouldBlock",
+        "transportTxDrops",
+        "transportRxDrops",
+        "sessionRxDrops",
+        "sendTimeouts",
+        "pathStalls",
+    ] {
+        assert!(body["quic"][key].is_u64(), "missing QUIC stat {key}");
+    }
 
     let tcp = &body["tcp"];
     assert!(tcp["activeFlows"].is_u64());

--- a/crates/honk-outbound/src/proxy/hysteria2/mod.rs
+++ b/crates/honk-outbound/src/proxy/hysteria2/mod.rs
@@ -46,8 +46,8 @@ use std::collections::HashMap;
 use std::io::{self, IoSliceMut};
 use std::net::SocketAddr;
 use std::pin::Pin;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU16, AtomicU32, AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, OnceLock};
 use std::task::{Context, Poll};
 use std::time::Duration;
 
@@ -64,7 +64,8 @@ use crate::quic::defrag::Defragmenter;
 use crate::quic::{QuicClient, QuicConnState, now_secs};
 
 use super::{
-    PacketOutbound, PacketTransport, ProbeableOutbound, ProxyStream, TcpOutbound, WarmableOutbound,
+    PacketOutbound, PacketTransport, ProbeableOutbound, ProxyStream, QuicSendToken, TcpOutbound,
+    WarmableOutbound,
 };
 
 /// QUIC keep-alive (`hysteria/protocol.go:21`).
@@ -121,6 +122,8 @@ struct Hy2ConnState {
     open: Arc<AtomicUsize>,
     /// Last activity (unix seconds) for the idle-connection reaper.
     last_activity: Arc<AtomicU64>,
+    path_health: Arc<crate::quic::QuicPathHealth>,
+    metrics: OnceLock<crate::quic::QuicConnectionMonitor>,
     /// H3 client preface streams (control + QPACK encoder/decoder). Held
     /// open for the life of the connection: dropping the send half finishes
     /// the stream, and closing a critical H3 stream is a connection error.
@@ -135,6 +138,11 @@ impl QuicConnState for Hy2ConnState {
     fn open_counter(&self) -> &Arc<AtomicUsize> {
         &self.open
     }
+    fn install_metrics_monitor(&self, conn: quinn::Connection) {
+        self.path_health.enable_telemetry();
+        self.metrics
+            .get_or_init(|| crate::quic::monitor_quic_connection(&conn));
+    }
 }
 
 impl Hy2ConnState {
@@ -143,6 +151,7 @@ impl Hy2ConnState {
         udp_disabled: bool,
         preface: (quinn::SendStream, quinn::SendStream, quinn::SendStream),
     ) -> Self {
+        let path_health = crate::quic::QuicPathHealth::new(&conn);
         let sessions: SessionMap = Arc::new(parking_lot::Mutex::new(HashMap::new()));
         let state = Self {
             conn: conn.clone(),
@@ -151,22 +160,31 @@ impl Hy2ConnState {
             next_session: AtomicU32::new(0),
             open: Arc::new(AtomicUsize::new(0)),
             last_activity: Arc::new(AtomicU64::new(now_secs())),
+            path_health: Arc::clone(&path_health),
+            metrics: OnceLock::new(),
             _preface: preface,
         };
         if !udp_disabled {
             // Inbound QUIC datagrams demultiplexed by session id
             // (`client_packet.go:5-19`).
+            let recv_conn = conn.clone();
+            let recv_sessions = Arc::clone(&sessions);
+            let recv_health = Arc::clone(&path_health);
             tokio::spawn(async move {
                 loop {
-                    let Ok(data) = conn.read_datagram().await else {
+                    let Ok(data) = recv_conn.read_datagram().await else {
                         break;
                     };
                     let Some(msg) = decode_udp_message(&data) else {
                         continue;
                     };
-                    let tx = sessions.lock().get(&msg.session_id).cloned();
+                    let tx = recv_sessions.lock().get(&msg.session_id).cloned();
                     if let Some(tx) = tx {
-                        let _ = tx.try_send(msg); // drop on a full queue (UDP semantics)
+                        if let Err(tokio::sync::mpsc::error::TrySendError::Full(_)) =
+                            tx.try_send(msg)
+                        {
+                            recv_health.record_session_rx_drop();
+                        }
                     } else {
                         debug!(
                             session_id = msg.session_id,
@@ -175,8 +193,11 @@ impl Hy2ConnState {
                     }
                 }
                 // Connection died: drop all session senders so bridges end.
-                sessions.lock().clear();
+                recv_sessions.lock().clear();
             });
+        }
+        if !udp_disabled {
+            crate::quic::spawn_quic_path_watchdog(conn, path_health);
         }
         crate::quic::spawn_conn_reaper(
             state.conn.clone(),
@@ -397,6 +418,10 @@ impl crate::runtime::QuicRuntimeClient for Hy2Client {
         self
     }
 
+    async fn enable_metrics(&self) {
+        self.quic.enable_metrics().await;
+    }
+
     async fn force_close(&self) {
         self.quic.force_close().await;
     }
@@ -414,7 +439,7 @@ impl Hy2Client {
         let password = self.password.clone();
         let rx_bytes_per_second = self.rx_bytes_per_second;
         self.quic
-            .connection_with(connect_timeout, move |conn| async move {
+            .connection_with_metrics(connect_timeout, move |conn| async move {
                 authenticate(&conn, &password, rx_bytes_per_second, connect_timeout).await
             })
             .await
@@ -687,7 +712,7 @@ impl Hysteria2Handler {
             session_id,
             packet_id: AtomicU16::new(0),
             rx: tokio::sync::Mutex::new(rx),
-            defrag: tokio::sync::Mutex::new(Defragmenter::new()),
+            defrag: tokio::sync::Mutex::new(Defragmenter::new(MAX_UDP_SIZE)),
             addr,
             max_datagram,
             target,
@@ -825,6 +850,33 @@ impl Drop for Hy2UdpTransport {
 impl PacketTransport for Hy2UdpTransport {
     fn relay_addr(&self) -> SocketAddr {
         self.target
+    }
+    fn send_timeout(&self) -> Duration {
+        self.state.path_health.send_timeout()
+    }
+    fn record_quic_send_started(&self) -> QuicSendToken {
+        self.state.path_health.record_send_started(&self.state.conn)
+    }
+    fn record_quic_send_success(&self, token: QuicSendToken) {
+        self.state
+            .path_health
+            .record_send_success(token, &self.state.conn);
+    }
+    fn record_quic_send_timeout(&self, token: QuicSendToken) {
+        if self
+            .state
+            .path_health
+            .record_send_timeout(token, &self.state.conn)
+        {
+            crate::quic::record_quic_send_timeout();
+        }
+    }
+    fn record_quic_send_failure(&self, token: QuicSendToken) {
+        self.state.path_health.record_send_failure(token);
+    }
+
+    fn quic_path_stalled(&self) -> bool {
+        self.state.path_health.is_stalled()
     }
     fn send_timeout_is_congestion(&self) -> bool {
         true

--- a/crates/honk-outbound/src/proxy/hysteria2/tests.rs
+++ b/crates/honk-outbound/src/proxy/hysteria2/tests.rs
@@ -604,7 +604,7 @@ fn test_fragmentation_and_defrag() {
     assert_eq!(frags.len(), 3);
     assert!(frags.iter().all(|f| f.len() <= 1200));
     // Every fragment repeats the full header (sing parity).
-    let mut defrag = Defragmenter::new();
+    let mut defrag = Defragmenter::new(MAX_UDP_SIZE);
     let mut out = None;
     for pkt in frags.iter().rev() {
         let msg = decode_udp_message(pkt).unwrap();

--- a/crates/honk-outbound/src/proxy/juicity.rs
+++ b/crates/honk-outbound/src/proxy/juicity.rs
@@ -2,8 +2,8 @@
 
 use std::io;
 use std::net::SocketAddr;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use anyhow::{Context as _, anyhow};
@@ -72,6 +72,8 @@ struct JuicityConnState {
     open: Arc<AtomicUsize>,
     /// Last activity (unix seconds) for the idle-connection reaper.
     last_activity: Arc<AtomicU64>,
+    path_health: Arc<crate::quic::QuicPathHealth>,
+    metrics: OnceLock<crate::quic::QuicConnectionMonitor>,
 }
 
 impl QuicConnState for JuicityConnState {
@@ -82,16 +84,25 @@ impl QuicConnState for JuicityConnState {
     fn open_counter(&self) -> &Arc<AtomicUsize> {
         &self.open
     }
+    fn install_metrics_monitor(&self, conn: quinn::Connection) {
+        self.path_health.enable_telemetry();
+        self.metrics
+            .get_or_init(|| crate::quic::monitor_quic_connection(&conn));
+    }
 }
 
 impl JuicityConnState {
     fn new(conn: quinn::Connection, auth_stream: quinn::SendStream) -> Self {
+        let path_health = crate::quic::QuicPathHealth::new(&conn);
         let state = Self {
             _conn: conn.clone(),
             _auth_stream: auth_stream,
             open: Arc::new(AtomicUsize::new(0)),
             last_activity: Arc::new(AtomicU64::new(now_secs())),
+            path_health: Arc::clone(&path_health),
+            metrics: OnceLock::new(),
         };
+        crate::quic::spawn_quic_path_watchdog(conn.clone(), path_health);
         crate::quic::spawn_conn_reaper(
             conn,
             Arc::downgrade(&state.open),
@@ -116,6 +127,10 @@ impl crate::runtime::QuicRuntimeClient for JuicityClient {
         self
     }
 
+    async fn enable_metrics(&self) {
+        self.quic.enable_metrics().await;
+    }
+
     async fn force_close(&self) {
         self.quic.force_close().await;
     }
@@ -133,7 +148,7 @@ impl JuicityClient {
         let uuid = self.uuid;
         let password = self.password.clone();
         self.quic
-            .connection_with(connect_timeout, move |conn| async move {
+            .connection_with_metrics(connect_timeout, move |conn| async move {
                 let auth_stream = crate::quic::exporter_auth(
                     &conn,
                     &uuid,
@@ -263,30 +278,37 @@ impl JuicityHandler {
         connect_timeout: Duration,
     ) -> anyhow::Result<Arc<dyn PacketTransport>> {
         let stream_addr = JuiceAddr::new(target, target_domain);
-        let addr = stream_addr.clone();
-        let stream = crate::quic::dial_quic_stream(
-            &client.quic,
-            |timeout| {
-                let client = Arc::clone(&client);
-                async move { client.connection(timeout).await }
-            },
-            connect_timeout,
-            move |conn| {
-                let addr = addr.clone();
-                async move { Self::open_stream(&conn, NETWORK_UDP, &addr).await }
-            },
-            |_| true,
-            "Juicity",
-        )
-        .await?;
-        let (send, recv, guard) = stream.into_parts();
-        Ok(Arc::new(JuicityUdpTransport {
-            send: tokio::sync::Mutex::new(send),
-            recv: tokio::sync::Mutex::new(recv),
-            _guard: guard,
-            target_addr: stream_addr,
-            target,
-        }))
+        let mut last_error = None;
+        for _ in 0..2 {
+            let (conn, state) = client.connection(connect_timeout).await?;
+            state.touch();
+            match Self::open_stream(&conn, NETWORK_UDP, &stream_addr).await {
+                Ok((send, recv)) => {
+                    state.open.fetch_add(1, Ordering::Relaxed);
+                    let open = Arc::clone(&state.open);
+                    let stream_state = Arc::clone(&state);
+                    let stream =
+                        crate::quic::QuicBiStream::new(send, recv).with_on_drop(move || {
+                            open.fetch_sub(1, Ordering::Relaxed);
+                            let _state_kept_alive_under_this_stream = &stream_state;
+                        });
+                    let (send, recv, guard) = stream.into_parts();
+                    return Ok(Arc::new(JuicityUdpTransport {
+                        state,
+                        send: tokio::sync::Mutex::new(send),
+                        recv: tokio::sync::Mutex::new(recv),
+                        _guard: guard,
+                        target_addr: stream_addr,
+                        target,
+                    }));
+                }
+                Err(error) => {
+                    client.quic.invalidate(&conn).await;
+                    last_error = Some(error);
+                }
+            }
+        }
+        Err(last_error.expect("Juicity UDP stream attempts are non-empty"))
     }
 }
 
@@ -403,6 +425,7 @@ impl ProbeableOutbound for JuicityHandler {
 /// Framed UDP transport over a Juicity UDP bi stream: datagrams are framed
 /// as `[metadata][len u16][payload]` directly on the QUIC stream.
 struct JuicityUdpTransport {
+    state: Arc<JuicityConnState>,
     send: tokio::sync::Mutex<quinn::SendStream>,
     recv: tokio::sync::Mutex<quinn::RecvStream>,
     /// Keeps the connection's open-stream accounting alive for the
@@ -425,6 +448,45 @@ impl PacketTransport for JuicityUdpTransport {
     fn relay_addr(&self) -> SocketAddr {
         self.target
     }
+    fn send_timeout(&self) -> Duration {
+        self.state.path_health.send_timeout()
+    }
+
+    fn record_quic_send_started(&self) -> super::QuicSendToken {
+        self.state
+            .path_health
+            .record_send_started(&self.state._conn)
+    }
+
+    fn record_quic_send_success(&self, token: super::QuicSendToken) {
+        self.state
+            .path_health
+            .record_send_success(token, &self.state._conn);
+    }
+
+    fn record_quic_send_timeout(&self, token: super::QuicSendToken) {
+        if self
+            .state
+            .path_health
+            .record_send_timeout(token, &self.state._conn)
+        {
+            crate::quic::record_quic_send_timeout();
+        }
+    }
+
+    fn record_quic_send_failure(&self, token: super::QuicSendToken) {
+        self.state.path_health.record_send_failure(token);
+    }
+
+    fn quic_path_stalled(&self) -> bool {
+        self.state.path_health.is_stalled()
+    }
+
+    fn send_timeout_is_congestion(&self) -> bool {
+        // write_chunk is not cancellation-safe; a timed-out write can leave a
+        // partial frame on this long-lived stream, so retire the endpoint.
+        false
+    }
 
     async fn send_packet(&self, data: &[u8]) -> io::Result<()> {
         if data.len() > u16::MAX as usize {
@@ -433,6 +495,7 @@ impl PacketTransport for JuicityUdpTransport {
                 "juicity datagram too large",
             ));
         }
+        self.state.touch();
         // SealUDP: `[metadata][len u16][payload]`
         // (`stream_packet_conn.go:83-90`).
         let mut frame = Vec::with_capacity(self.target_addr.encoded_len() + 2 + data.len());

--- a/crates/honk-outbound/src/proxy/mod.rs
+++ b/crates/honk-outbound/src/proxy/mod.rs
@@ -237,10 +237,91 @@ pub fn packet_error_class(error: &std::io::Error) -> PacketErrorClass {
     }
 }
 
+/// Snapshot identifying one asynchronous QUIC packet send.
+///
+/// The token binds completion to the ACK epoch and packet counts observed
+/// before the send. A cancelled send is completed as a failure by
+/// [`QuicSendAttempt`] so it cannot leave a phantom path wait.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct QuicSendToken {
+    pub(crate) ack_epoch: u64,
+    pub(crate) ack_baseline: u64,
+    pub(crate) sent_baseline: u64,
+    pub(crate) started_at: u64,
+}
+
+impl QuicSendToken {
+    pub(crate) const INACTIVE: Self = Self {
+        ack_epoch: 0,
+        ack_baseline: 0,
+        sent_baseline: 0,
+        started_at: 0,
+    };
+
+    pub(crate) fn new(
+        ack_epoch: u64,
+        ack_baseline: u64,
+        sent_baseline: u64,
+        started_at: u64,
+    ) -> Self {
+        Self {
+            ack_epoch,
+            ack_baseline,
+            sent_baseline,
+            started_at,
+        }
+    }
+
+    pub(crate) fn is_active(self) -> bool {
+        self.started_at != 0
+    }
+}
+
+/// Completes one asynchronous QUIC packet send exactly once.
+#[must_use]
+pub struct QuicSendAttempt<'a> {
+    transport: &'a dyn PacketTransport,
+    token: QuicSendToken,
+    completed: bool,
+}
+
+impl<'a> QuicSendAttempt<'a> {
+    pub fn new(transport: &'a dyn PacketTransport) -> Self {
+        Self {
+            token: transport.record_quic_send_started(),
+            transport,
+            completed: false,
+        }
+    }
+
+    pub fn success(mut self) {
+        self.completed = true;
+        self.transport.record_quic_send_success(self.token);
+    }
+
+    pub fn timeout(mut self) {
+        self.completed = true;
+        self.transport.record_quic_send_timeout(self.token);
+    }
+
+    pub fn failure(mut self) {
+        self.completed = true;
+        self.transport.record_quic_send_failure(self.token);
+    }
+}
+
+impl Drop for QuicSendAttempt<'_> {
+    fn drop(&mut self) {
+        if !self.completed && self.token.is_active() {
+            self.transport.record_quic_send_failure(self.token);
+        }
+    }
+}
+
 /// Framed UDP packet transport — the production UDP contract. Native UDP
 /// protocols wrap a real `UdpSocket`; tunnel protocols implement their
 /// framing directly on the tunnel instead of bouncing datagrams through a
-/// loopback socket pair (extra FD + bridge task + 1–2 copies per packet).
+/// loopback socket pair (extra FD + 1–2 copies per packet).
 #[async_trait]
 pub trait PacketTransport: Send + Sync + Debug {
     /// The relay target a flow reports as its destination.
@@ -248,6 +329,26 @@ pub trait PacketTransport: Send + Sync + Debug {
     /// Whether server-carried metadata may authoritatively name a logical
     /// reply source before the endpoint has observed its first response.
     fn allows_full_cone_replies(&self) -> bool {
+        false
+    }
+    /// Per-packet send deadline. QUIC transports derive this from SRTT;
+    /// non-QUIC transports retain the five-second driver default.
+    fn send_timeout(&self) -> std::time::Duration {
+        std::time::Duration::from_secs(5)
+    }
+    /// Capture the ACK baseline before an asynchronous QUIC send begins.
+    fn record_quic_send_started(&self) -> QuicSendToken {
+        QuicSendToken::INACTIVE
+    }
+    /// Record a packet accepted by the QUIC transport; the path watchdog
+    /// waits for its ACK before declaring a black hole.
+    fn record_quic_send_success(&self, _token: QuicSendToken) {}
+    /// Record a QUIC packet wait that reached its deadline.
+    fn record_quic_send_timeout(&self, _token: QuicSendToken) {}
+    /// Record a non-timeout send failure so a failed send cannot arm a path wait.
+    fn record_quic_send_failure(&self, _token: QuicSendToken) {}
+    /// Whether this transport's shared QUIC path was retired by the watchdog.
+    fn quic_path_stalled(&self) -> bool {
         false
     }
     /// Whether a driver send deadline is packet-local congestion rather than
@@ -324,6 +425,24 @@ impl<T: Send + Sync> PacketTransport for RuntimeOwnedPacketTransport<T> {
     fn allows_full_cone_replies(&self) -> bool {
         self.inner.allows_full_cone_replies()
     }
+    fn send_timeout(&self) -> std::time::Duration {
+        self.inner.send_timeout()
+    }
+    fn record_quic_send_started(&self) -> QuicSendToken {
+        self.inner.record_quic_send_started()
+    }
+    fn record_quic_send_success(&self, token: QuicSendToken) {
+        self.inner.record_quic_send_success(token);
+    }
+    fn record_quic_send_timeout(&self, token: QuicSendToken) {
+        self.inner.record_quic_send_timeout(token);
+    }
+    fn record_quic_send_failure(&self, token: QuicSendToken) {
+        self.inner.record_quic_send_failure(token);
+    }
+    fn quic_path_stalled(&self) -> bool {
+        self.inner.quic_path_stalled()
+    }
     fn send_timeout_is_congestion(&self) -> bool {
         self.inner.send_timeout_is_congestion()
     }
@@ -385,7 +504,6 @@ impl PreparedUdpTransport {
             commit: Box::new(move || Box::pin(commit())),
         }
     }
-
     /// Wrap an already-authoritative ordinary transport. This deliberately
     /// preserves `dial_udp_transport` semantics for protocols with no
     /// speculative ownership to promote.

--- a/crates/honk-outbound/src/proxy/tuic.rs
+++ b/crates/honk-outbound/src/proxy/tuic.rs
@@ -3,8 +3,8 @@
 use std::collections::HashMap;
 use std::io;
 use std::net::SocketAddr;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU16, AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use anyhow::{Context as _, anyhow};
@@ -18,7 +18,8 @@ use crate::quic::{QuicClient, QuicConnState, now_secs, recv_read_exact as read_e
 
 use super::addr::{self, SocksAddr};
 use super::{
-    PacketOutbound, PacketTransport, ProbeableOutbound, ProxyStream, TcpOutbound, WarmableOutbound,
+    PacketOutbound, PacketTransport, ProbeableOutbound, ProxyStream, QuicSendToken, TcpOutbound,
+    WarmableOutbound,
 };
 
 const TUIC_VERSION: u8 = 0x05;
@@ -247,6 +248,8 @@ struct TuicConnState {
     open: Arc<AtomicUsize>,
     /// Last activity (unix seconds) for the idle-connection reaper.
     last_activity: Arc<AtomicU64>,
+    path_health: Arc<crate::quic::QuicPathHealth>,
+    metrics: OnceLock<crate::quic::QuicConnectionMonitor>,
 }
 
 impl QuicConnState for TuicConnState {
@@ -257,11 +260,17 @@ impl QuicConnState for TuicConnState {
     fn open_counter(&self) -> &Arc<AtomicUsize> {
         &self.open
     }
+    fn install_metrics_monitor(&self, conn: quinn::Connection) {
+        self.path_health.enable_telemetry();
+        self.metrics
+            .get_or_init(|| crate::quic::monitor_quic_connection(&conn));
+    }
 }
 
 impl TuicConnState {
     fn new(conn: quinn::Connection) -> Self {
         let sessions: SessionMap = Arc::new(parking_lot::Mutex::new(HashMap::new()));
+        let path_health = crate::quic::QuicPathHealth::new(&conn);
         let state = Self {
             udp_over_stream: conn.max_datagram_size().is_none(),
             conn: conn.clone(),
@@ -269,36 +278,42 @@ impl TuicConnState {
             next_session: AtomicU16::new(0),
             open: Arc::new(AtomicUsize::new(0)),
             last_activity: Arc::new(AtomicU64::new(now_secs())),
+            path_health: Arc::clone(&path_health),
+            metrics: OnceLock::new(),
         };
-        tokio::spawn(Self::datagram_loop(conn.clone(), Arc::clone(&sessions)));
-        tokio::spawn(Self::uni_stream_loop(conn.clone(), Arc::clone(&sessions)));
+        tokio::spawn(Self::datagram_loop(
+            conn.clone(),
+            Arc::clone(&sessions),
+            Arc::clone(&path_health),
+        ));
+        tokio::spawn(Self::uni_stream_loop(
+            conn.clone(),
+            Arc::clone(&sessions),
+            Arc::clone(&path_health),
+        ));
+        crate::quic::spawn_quic_path_watchdog(conn.clone(), Arc::clone(&path_health));
         let open = Arc::downgrade(&state.open);
         let last_activity = Arc::downgrade(&state.last_activity);
-        if state.udp_over_stream {
-            // No heartbeat frames without datagram support; idle reaping only.
-            crate::quic::spawn_conn_reaper(
-                conn,
-                open,
-                last_activity,
-                HEARTBEAT_INTERVAL,
-                CONN_IDLE_TIMEOUT,
-                None,
-            );
-        } else {
-            // Heartbeat datagrams every 10s while the connection is in use
-            // (`client.go:216-230`); ends the loop when the send fails.
-            crate::quic::spawn_conn_reaper(
-                conn,
-                open,
-                last_activity,
-                HEARTBEAT_INTERVAL,
-                CONN_IDLE_TIMEOUT,
+        crate::quic::spawn_conn_reaper(
+            conn,
+            open,
+            last_activity,
+            HEARTBEAT_INTERVAL,
+            CONN_IDLE_TIMEOUT,
+            if state.udp_over_stream {
+                None
+            } else {
                 Some(Box::new(|conn: &quinn::Connection| {
-                    conn.send_datagram(bytes::Bytes::from_static(&[TUIC_VERSION, CMD_HEARTBEAT]))
-                        .is_ok()
-                })),
-            );
-        }
+                    !matches!(
+                        conn.send_datagram(bytes::Bytes::from_static(&[
+                            TUIC_VERSION,
+                            CMD_HEARTBEAT,
+                        ])),
+                        Err(quinn::SendDatagramError::ConnectionLost(_))
+                    )
+                }))
+            },
+        );
         state
     }
 
@@ -308,7 +323,11 @@ impl TuicConnState {
 
     /// Inbound QUIC datagrams: PACKET frames are demultiplexed by session id
     /// (sing `loopMessages`, `client_packet.go:12-50`).
-    async fn datagram_loop(conn: quinn::Connection, sessions: SessionMap) {
+    async fn datagram_loop(
+        conn: quinn::Connection,
+        sessions: SessionMap,
+        path_health: Arc<crate::quic::QuicPathHealth>,
+    ) {
         loop {
             let data = match conn.read_datagram().await {
                 Ok(data) => data,
@@ -321,8 +340,11 @@ impl TuicConnState {
                 CMD_PACKET => {
                     if let Ok(msg) = decode_udp_message(&data[2..]) {
                         let tx = sessions.lock().get(&msg.session_id).cloned();
-                        if let Some(tx) = tx {
-                            let _ = tx.try_send(msg); // drop on a full queue (UDP semantics)
+                        if let Some(tx) = tx
+                            && let Err(tokio::sync::mpsc::error::TrySendError::Full(_)) =
+                                tx.try_send(msg)
+                        {
+                            path_health.record_session_rx_drop();
                         }
                     }
                 }
@@ -336,13 +358,18 @@ impl TuicConnState {
 
     /// Inbound uni streams carry one PACKET frame each in UDP-over-stream
     /// mode (sing `loopUniStreams`, `client_packet.go:52-93`).
-    async fn uni_stream_loop(conn: quinn::Connection, sessions: SessionMap) {
+    async fn uni_stream_loop(
+        conn: quinn::Connection,
+        sessions: SessionMap,
+        path_health: Arc<crate::quic::QuicPathHealth>,
+    ) {
         loop {
             let mut recv = match conn.accept_uni().await {
                 Ok(recv) => recv,
                 Err(_) => break,
             };
             let sessions = Arc::clone(&sessions);
+            let path_health = Arc::clone(&path_health);
             tokio::spawn(async move {
                 let mut head = [0u8; 2];
                 if read_exact(&mut recv, &mut head).await.is_err() {
@@ -353,8 +380,11 @@ impl TuicConnState {
                 }
                 if let Ok(msg) = read_udp_message_stream(&mut recv).await {
                     let tx = sessions.lock().get(&msg.session_id).cloned();
-                    if let Some(tx) = tx {
-                        let _ = tx.try_send(msg); // drop on a full queue (UDP semantics)
+                    if let Some(tx) = tx
+                        && let Err(tokio::sync::mpsc::error::TrySendError::Full(_)) =
+                            tx.try_send(msg)
+                    {
+                        path_health.record_session_rx_drop();
                     }
                 }
             });
@@ -374,6 +404,10 @@ impl crate::runtime::QuicRuntimeClient for TuicClient {
         self
     }
 
+    async fn enable_metrics(&self) {
+        self.quic.enable_metrics().await;
+    }
+
     async fn force_close(&self) {
         self.quic.force_close().await;
     }
@@ -391,7 +425,7 @@ impl TuicClient {
         let uuid = self.uuid;
         let password = self.password.clone();
         self.quic
-            .connection_with(connect_timeout, move |conn| async move {
+            .connection_with_metrics(connect_timeout, move |conn| async move {
                 crate::quic::exporter_auth(&conn, &uuid, &password, TUIC_VERSION, true, AUTH_GRACE)
                     .await?;
                 Ok(TuicConnState::new(conn))
@@ -440,12 +474,10 @@ impl TuicHandler {
             })
             .filter(|v| !v.is_empty())
             .unwrap_or_else(|| vec![b"tuic".to_vec()]);
-        // quinn's default stream window (1.25MB) caps a single stream at
-        // ~12.5MB/s per 100ms of RTT — unusable on long-fat links. Default
-        // to 8MB stream / 8MB conn (conn window = memory budget, see hy2).
-        // Explicit node fields override.
         let options = crate::quic::QuicClientOptions {
             congestion: Some(crate::quic::congestion_factory(tuic.congestion.as_deref())),
+            // Keep both protocol and QUIC PING liveness in fallback mode.
+            keep_alive: Some(HEARTBEAT_INTERVAL),
             stream_receive_window: Some(tuic.init_stream_recv_window.unwrap_or(8 << 20)),
             conn_receive_window: Some(tuic.init_conn_recv_window.unwrap_or(8 << 20)),
             max_udp_payload_size: tuic.quic.mtu,
@@ -528,7 +560,7 @@ impl TuicHandler {
             session_id,
             packet_id: AtomicU16::new(0),
             rx: tokio::sync::Mutex::new(rx),
-            defrag: tokio::sync::Mutex::new(Defragmenter::new()),
+            defrag: tokio::sync::Mutex::new(Defragmenter::new(u16::MAX as usize)),
             target_addr: TuicAddr::new(target, target_domain),
             target,
         }))
@@ -725,6 +757,33 @@ impl Drop for TuicUdpTransport {
 impl PacketTransport for TuicUdpTransport {
     fn relay_addr(&self) -> SocketAddr {
         self.target
+    }
+    fn send_timeout(&self) -> Duration {
+        self.state.path_health.send_timeout()
+    }
+    fn record_quic_send_started(&self) -> QuicSendToken {
+        self.state.path_health.record_send_started(&self.state.conn)
+    }
+    fn record_quic_send_success(&self, token: QuicSendToken) {
+        self.state
+            .path_health
+            .record_send_success(token, &self.state.conn);
+    }
+    fn record_quic_send_timeout(&self, token: QuicSendToken) {
+        if self
+            .state
+            .path_health
+            .record_send_timeout(token, &self.state.conn)
+        {
+            crate::quic::record_quic_send_timeout();
+        }
+    }
+    fn record_quic_send_failure(&self, token: QuicSendToken) {
+        self.state.path_health.record_send_failure(token);
+    }
+
+    fn quic_path_stalled(&self) -> bool {
+        self.state.path_health.is_stalled()
     }
     fn send_timeout_is_congestion(&self) -> bool {
         !self.state.udp_over_stream
@@ -1132,7 +1191,7 @@ mod tests {
         assert_eq!(frags.len(), 3);
         assert!(frags.iter().all(|f| f.len() <= max));
 
-        let mut defrag = Defragmenter::new();
+        let mut defrag = Defragmenter::new(u16::MAX as usize);
         let mut out = None;
         // Feed out of order; only the last missing fragment completes it.
         for pkt in frags.iter().rev() {

--- a/crates/honk-outbound/src/quic.rs
+++ b/crates/honk-outbound/src/quic.rs
@@ -2,12 +2,13 @@
 //!
 //! Used by the TUIC v5, Juicity, and Hysteria2 outbounds.
 
+use std::collections::HashMap;
 use std::future::Future;
 use std::io;
 use std::net::SocketAddr;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
-use std::sync::{Arc, Weak};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, LazyLock, Weak};
 use std::task::{Context, Poll, Waker};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -73,7 +74,6 @@ impl congestion::ControllerFactory for BrutalConfig {
         })
     }
 }
-
 struct Brutal {
     /// Target send rate, bytes per second.
     rate: u64,
@@ -84,8 +84,8 @@ struct Brutal {
 
 impl Brutal {
     fn bdp(&self) -> u64 {
-        let bdp = self.rate as u128 * self.rtt.as_micros() / 1_000_000;
-        bdp as u64
+        (u128::from(self.rate).saturating_mul(self.rtt.as_micros()) / 1_000_000)
+            .min(u128::from(u64::MAX)) as u64
     }
 }
 
@@ -124,7 +124,7 @@ impl congestion::Controller for Brutal {
         // the crate, mutate a default value instead.
         let mut metrics = congestion::ControllerMetrics::default();
         metrics.congestion_window = self.window();
-        metrics.pacing_rate = Some(self.rate * 8);
+        metrics.pacing_rate = Some(self.rate.saturating_mul(8));
         metrics
     }
 
@@ -145,6 +145,785 @@ impl congestion::Controller for Brutal {
     }
 }
 
+const QUIC_SAMPLE_INTERVAL: Duration = Duration::from_secs(1);
+const PATH_TIMEOUT_STREAK: u8 = 3;
+const PATH_MIN_UNACKED_SENDS: u64 = 3;
+const PATH_WATCH_INTERVAL: Duration = Duration::from_secs(1);
+static PATH_CLOCK: LazyLock<Instant> = LazyLock::new(Instant::now);
+
+fn path_now_millis() -> u64 {
+    PATH_CLOCK
+        .elapsed()
+        .as_millis()
+        .min(u128::from(u64::MAX - 1)) as u64
+        + 1
+}
+
+const PATH_EPOCH_MASK: u64 = (1_u64 << 62) - 1;
+const PATH_WAITING: u64 = 1_u64 << 62;
+const PATH_MUTATING: u64 = 1_u64 << 63;
+const PATH_TIMEOUT_BITS: u32 = 2;
+const PATH_TIMEOUT_MASK: u64 = (1_u64 << PATH_TIMEOUT_BITS) - 1;
+
+fn path_epoch(state: u64) -> u64 {
+    state & PATH_EPOCH_MASK
+}
+
+fn path_state(epoch: u64, waiting: bool) -> u64 {
+    (epoch & PATH_EPOCH_MASK) | if waiting { PATH_WAITING } else { 0 }
+}
+
+fn timeout_state(epoch: u64, streak: u8) -> u64 {
+    (epoch << PATH_TIMEOUT_BITS) | u64::from(streak.min(PATH_TIMEOUT_STREAK))
+}
+
+fn timeout_state_epoch(state: u64) -> u64 {
+    state >> PATH_TIMEOUT_BITS
+}
+
+fn timeout_state_streak(state: u64) -> u8 {
+    (state & PATH_TIMEOUT_MASK) as u8
+}
+
+/// Connection-wide QUIC delivery progress. Packet sends only read atomics;
+/// Quinn statistics are sampled at most once per second, plus on a send
+/// deadline and the watchdog's one-second tick.
+#[derive(Debug)]
+pub(crate) struct QuicPathHealth {
+    ack_state: AtomicU64,
+    last_acked_packets: AtomicU64,
+    sampled_acked_packets: AtomicU64,
+    sampled_sent_ack_eliciting_packets: AtomicU64,
+    waiting_sent_baseline: AtomicU64,
+    waiting_acked_baseline: AtomicU64,
+    unacked_since_ms: AtomicU64,
+    last_sample_ms: AtomicU64,
+    timeout_state: AtomicU64,
+    waiting_since_ms: AtomicU64,
+    send_timeout_ms: AtomicU64,
+    path_stall_timeout_ms: AtomicU64,
+    path_stalled: AtomicBool,
+    telemetry_enabled: AtomicBool,
+}
+
+enum SendCompletion {
+    Success,
+    Timeout,
+    Failure,
+}
+
+impl QuicPathHealth {
+    pub(crate) fn new(conn: &Connection) -> Arc<Self> {
+        let stats = conn.stats();
+        let now = path_now_millis();
+        let rtt = stats.path.rtt;
+        Arc::new(Self {
+            ack_state: AtomicU64::new(0),
+            last_acked_packets: AtomicU64::new(stats.path.acked_ack_eliciting_packets),
+            sampled_acked_packets: AtomicU64::new(stats.path.acked_ack_eliciting_packets),
+            sampled_sent_ack_eliciting_packets: AtomicU64::new(
+                stats.path.sent_ack_eliciting_packets,
+            ),
+            waiting_sent_baseline: AtomicU64::new(stats.path.sent_ack_eliciting_packets),
+            waiting_acked_baseline: AtomicU64::new(stats.path.acked_ack_eliciting_packets),
+            unacked_since_ms: AtomicU64::new(0),
+            last_sample_ms: AtomicU64::new(now),
+            timeout_state: AtomicU64::new(timeout_state(0, 0)),
+            waiting_since_ms: AtomicU64::new(0),
+            send_timeout_ms: AtomicU64::new(duration_millis(bounded_quic_send_timeout(rtt))),
+            path_stall_timeout_ms: AtomicU64::new(duration_millis(
+                quic_path_stall_timeout_from_rtt(rtt),
+            )),
+            path_stalled: AtomicBool::new(false),
+            telemetry_enabled: AtomicBool::new(false),
+        })
+    }
+
+    pub(crate) fn send_timeout(&self) -> Duration {
+        Duration::from_millis(self.send_timeout_ms.load(Ordering::Acquire).max(1))
+    }
+
+    pub(crate) fn enable_telemetry(&self) {
+        self.telemetry_enabled.store(true, Ordering::Release);
+    }
+
+    pub(crate) fn telemetry_enabled(&self) -> bool {
+        self.telemetry_enabled.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn record_session_rx_drop(&self) {
+        if self.telemetry_enabled() {
+            record_quic_session_rx_drop();
+        }
+    }
+
+    fn refresh_timing_from_rtt(&self, rtt: Duration) {
+        self.send_timeout_ms.store(
+            duration_millis(bounded_quic_send_timeout(rtt)),
+            Ordering::Release,
+        );
+        self.path_stall_timeout_ms.store(
+            duration_millis(quic_path_stall_timeout_from_rtt(rtt)),
+            Ordering::Release,
+        );
+    }
+    fn unacked_sends_since_wait(&self) -> u64 {
+        let sent = self
+            .sampled_sent_ack_eliciting_packets
+            .load(Ordering::Acquire)
+            .saturating_sub(self.waiting_sent_baseline.load(Ordering::Acquire));
+        let acked = self
+            .last_acked_packets
+            .load(Ordering::Acquire)
+            .saturating_sub(self.waiting_acked_baseline.load(Ordering::Acquire));
+        sent.saturating_sub(acked)
+    }
+
+    fn refresh_unacked_since(&self, now: u64) {
+        let state = self.ack_state.load(Ordering::Acquire);
+        if state & (PATH_WAITING | PATH_MUTATING) != PATH_WAITING {
+            self.unacked_since_ms.store(0, Ordering::Release);
+            return;
+        }
+        if self.unacked_sends_since_wait() != 0 {
+            let _ =
+                self.unacked_since_ms
+                    .compare_exchange(0, now, Ordering::AcqRel, Ordering::Acquire);
+        } else {
+            self.unacked_since_ms.store(0, Ordering::Release);
+        }
+    }
+
+    fn note_ack_progress(&self, current: u64) -> bool {
+        if self.path_stalled.load(Ordering::Acquire)
+            || current <= self.last_acked_packets.load(Ordering::Acquire)
+        {
+            return false;
+        }
+        loop {
+            if self.path_stalled.load(Ordering::Acquire) {
+                return false;
+            }
+            let state = self.ack_state.load(Ordering::Acquire);
+            if state & PATH_MUTATING != 0 {
+                std::hint::spin_loop();
+                continue;
+            }
+            if current <= self.last_acked_packets.load(Ordering::Acquire) {
+                return false;
+            }
+            if self
+                .ack_state
+                .compare_exchange(
+                    state,
+                    state | PATH_MUTATING,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                )
+                .is_err()
+            {
+                continue;
+            }
+            if current <= self.last_acked_packets.load(Ordering::Acquire) {
+                self.ack_state.store(state, Ordering::Release);
+                return false;
+            }
+            let epoch = path_epoch(state).wrapping_add(1) & PATH_EPOCH_MASK;
+            self.last_acked_packets.store(current, Ordering::Release);
+            self.waiting_sent_baseline.store(
+                self.sampled_sent_ack_eliciting_packets
+                    .load(Ordering::Acquire),
+                Ordering::Release,
+            );
+            self.waiting_acked_baseline
+                .store(current, Ordering::Release);
+            self.timeout_state
+                .store(timeout_state(epoch, 0), Ordering::Release);
+            self.waiting_since_ms.store(0, Ordering::Release);
+            self.unacked_since_ms.store(0, Ordering::Release);
+            self.ack_state
+                .store(path_state(epoch, false), Ordering::Release);
+            return true;
+        }
+    }
+
+    fn apply_sample(&self, stats: quinn::ConnectionStats, now: u64) -> u64 {
+        // A newer sampler may have claimed the next interval while this
+        // snapshot was waiting for Quinn's state lock; never publish its
+        // older RTT after that sampler.
+        if self.last_sample_ms.load(Ordering::Acquire) <= now {
+            self.refresh_timing_from_rtt(stats.path.rtt);
+        }
+        self.last_sample_ms.fetch_max(now, Ordering::Release);
+        self.sampled_acked_packets
+            .fetch_max(stats.path.acked_ack_eliciting_packets, Ordering::Release);
+        self.sampled_sent_ack_eliciting_packets
+            .fetch_max(stats.path.sent_ack_eliciting_packets, Ordering::Release);
+        let current = self.sampled_acked_packets.load(Ordering::Acquire);
+        self.note_ack_progress(current);
+        self.refresh_unacked_since(now);
+        current
+    }
+    /// Refresh Quinn statistics at most once per second on packet send paths.
+    fn refresh_sample(&self, conn: &Connection) -> u64 {
+        let now = path_now_millis();
+        let last = self.last_sample_ms.load(Ordering::Acquire);
+        if now.saturating_sub(last) >= QUIC_SAMPLE_INTERVAL.as_millis() as u64
+            && self
+                .last_sample_ms
+                .compare_exchange(last, now, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+        {
+            return self.apply_sample(conn.stats(), now);
+        }
+        self.sampled_acked_packets.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn record_send_started(&self, conn: &Connection) -> crate::proxy::QuicSendToken {
+        self.refresh_sample(conn);
+        loop {
+            if self.path_stalled.load(Ordering::Acquire) {
+                return crate::proxy::QuicSendToken::INACTIVE;
+            }
+            let state = self.ack_state.load(Ordering::Acquire);
+            if state & PATH_MUTATING != 0 {
+                if self.path_stalled.load(Ordering::Acquire) {
+                    return crate::proxy::QuicSendToken::INACTIVE;
+                }
+                std::hint::spin_loop();
+                continue;
+            }
+            let ack_baseline = self.last_acked_packets.load(Ordering::Acquire);
+            let sent_baseline = self
+                .sampled_sent_ack_eliciting_packets
+                .load(Ordering::Acquire);
+            if state == self.ack_state.load(Ordering::Acquire) {
+                return crate::proxy::QuicSendToken::new(
+                    path_epoch(state),
+                    ack_baseline,
+                    sent_baseline,
+                    path_now_millis(),
+                );
+            }
+        }
+    }
+    fn complete_send(
+        &self,
+        token: crate::proxy::QuicSendToken,
+        completion: SendCompletion,
+        observed_acks: u64,
+    ) -> bool {
+        if !token.is_active() {
+            return false;
+        }
+        self.note_ack_progress(observed_acks);
+        if matches!(completion, SendCompletion::Failure) {
+            return false;
+        }
+        loop {
+            if self.path_stalled.load(Ordering::Acquire) {
+                return false;
+            }
+            let state = self.ack_state.load(Ordering::Acquire);
+            if state & PATH_MUTATING != 0 {
+                if self.path_stalled.load(Ordering::Acquire) {
+                    return false;
+                }
+                std::hint::spin_loop();
+                continue;
+            }
+            if path_epoch(state) != token.ack_epoch
+                || self.last_acked_packets.load(Ordering::Acquire) > token.ack_baseline
+            {
+                return false;
+            }
+            if self
+                .ack_state
+                .compare_exchange(
+                    state,
+                    state | PATH_MUTATING,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                )
+                .is_err()
+            {
+                continue;
+            }
+            if self.last_acked_packets.load(Ordering::Acquire) > token.ack_baseline {
+                self.ack_state.store(state, Ordering::Release);
+                return false;
+            }
+            let epoch = path_epoch(state);
+            let timeout = self.timeout_state.load(Ordering::Acquire);
+            let previous_streak = if timeout_state_epoch(timeout) == epoch {
+                timeout_state_streak(timeout)
+            } else {
+                0
+            };
+            let streak = if matches!(completion, SendCompletion::Timeout) {
+                previous_streak.saturating_add(1).min(PATH_TIMEOUT_STREAK)
+            } else {
+                0
+            };
+            self.timeout_state
+                .store(timeout_state(epoch, streak), Ordering::Release);
+            if state & PATH_WAITING == 0 {
+                self.waiting_sent_baseline
+                    .store(token.sent_baseline, Ordering::Release);
+                self.waiting_acked_baseline
+                    .store(token.ack_baseline, Ordering::Release);
+                self.waiting_since_ms
+                    .store(token.started_at, Ordering::Release);
+                self.unacked_since_ms.store(0, Ordering::Release);
+            } else {
+                // Concurrent sends can complete out of order. Keep the
+                // earliest accepted packet in the watchdog's accounting.
+                self.waiting_sent_baseline
+                    .fetch_min(token.sent_baseline, Ordering::AcqRel);
+                self.waiting_since_ms
+                    .fetch_min(token.started_at, Ordering::AcqRel);
+            }
+            self.ack_state
+                .store(path_state(epoch, true), Ordering::Release);
+            self.refresh_unacked_since(path_now_millis());
+            return true;
+        }
+    }
+
+    pub(crate) fn record_send_success(
+        &self,
+        token: crate::proxy::QuicSendToken,
+        conn: &Connection,
+    ) {
+        let observed = self.refresh_sample(conn);
+        self.complete_send(token, SendCompletion::Success, observed);
+    }
+
+    pub(crate) fn record_send_timeout(
+        &self,
+        token: crate::proxy::QuicSendToken,
+        conn: &Connection,
+    ) -> bool {
+        let observed = self.refresh_sample(conn);
+        self.complete_send(token, SendCompletion::Timeout, observed) && self.telemetry_enabled()
+    }
+
+    pub(crate) fn record_send_failure(&self, token: crate::proxy::QuicSendToken) {
+        self.complete_send(
+            token,
+            SendCompletion::Failure,
+            self.sampled_acked_packets.load(Ordering::Acquire),
+        );
+    }
+
+    fn check_stalled(&self, conn: &Connection) -> bool {
+        if conn.close_reason().is_some() {
+            return false;
+        }
+        let state = self.ack_state.load(Ordering::Acquire);
+        if state & PATH_WAITING == 0 || state & PATH_MUTATING != 0 {
+            return false;
+        }
+        self.refresh_sample(conn);
+        let state = self.ack_state.load(Ordering::Acquire);
+        if state & PATH_WAITING == 0 || state & PATH_MUTATING != 0 {
+            return false;
+        }
+        let epoch = path_epoch(state);
+        let unacked_sends = self.unacked_sends_since_wait();
+        let timeout = self.timeout_state.load(Ordering::Acquire);
+        let streak = if timeout_state_epoch(timeout) == epoch {
+            timeout_state_streak(timeout)
+        } else {
+            0
+        };
+        let now = path_now_millis();
+        let timeout_elapsed = Duration::from_millis(
+            now.saturating_sub(self.waiting_since_ms.load(Ordering::Acquire)),
+        );
+        let no_ack_elapsed =
+            elapsed_since_millis(now, self.unacked_since_ms.load(Ordering::Acquire));
+        if !should_retire_path(
+            timeout_elapsed,
+            no_ack_elapsed,
+            streak,
+            unacked_sends,
+            self.send_timeout(),
+            self.path_stall_timeout(),
+        ) {
+            return false;
+        }
+        if self
+            .ack_state
+            .compare_exchange(
+                state,
+                state | PATH_MUTATING,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_err()
+        {
+            return false;
+        }
+        if conn.close_reason().is_some() {
+            self.ack_state.store(state, Ordering::Release);
+            return false;
+        }
+        // An ACK may arrive between the last sample and the claim. Recheck
+        // while the mutation bit blocks send completions and ACK samplers.
+        let latest = conn.stats();
+        if latest.path.acked_ack_eliciting_packets > self.last_acked_packets.load(Ordering::Acquire)
+        {
+            self.sampled_acked_packets
+                .fetch_max(latest.path.acked_ack_eliciting_packets, Ordering::Release);
+            self.sampled_sent_ack_eliciting_packets
+                .fetch_max(latest.path.sent_ack_eliciting_packets, Ordering::Release);
+            self.last_acked_packets
+                .store(latest.path.acked_ack_eliciting_packets, Ordering::Release);
+            self.waiting_sent_baseline.store(
+                self.sampled_sent_ack_eliciting_packets
+                    .load(Ordering::Acquire),
+                Ordering::Release,
+            );
+            self.waiting_acked_baseline
+                .store(latest.path.acked_ack_eliciting_packets, Ordering::Release);
+            self.unacked_since_ms.store(0, Ordering::Release);
+            let next_epoch = path_epoch(state).wrapping_add(1) & PATH_EPOCH_MASK;
+            self.timeout_state
+                .store(timeout_state(next_epoch, 0), Ordering::Release);
+            self.waiting_since_ms.store(0, Ordering::Release);
+            self.ack_state
+                .store(path_state(next_epoch, false), Ordering::Release);
+            return false;
+        }
+        self.path_stalled.store(true, Ordering::Release);
+        conn.close(VarInt::from_u32(0), b"QUIC path stalled");
+        true
+    }
+
+    fn path_stall_timeout(&self) -> Duration {
+        Duration::from_millis(self.path_stall_timeout_ms.load(Ordering::Acquire).max(1))
+    }
+
+    pub(crate) fn is_stalled(&self) -> bool {
+        self.path_stalled.load(Ordering::Acquire)
+    }
+}
+
+fn duration_millis(duration: Duration) -> u64 {
+    duration.as_millis().min(u128::from(u64::MAX - 1)).max(1) as u64
+}
+
+fn elapsed_since_millis(now: u64, since: u64) -> Duration {
+    if since == 0 {
+        Duration::ZERO
+    } else {
+        Duration::from_millis(now.saturating_sub(since))
+    }
+}
+fn bounded_quic_send_timeout(rtt: Duration) -> Duration {
+    rtt.checked_mul(4)
+        .unwrap_or(Duration::MAX)
+        .clamp(Duration::from_secs(1), Duration::from_secs(5))
+}
+
+fn should_retire_path(
+    timeout_elapsed: Duration,
+    no_ack_elapsed: Duration,
+    timeout_streak: u8,
+    unacked_sends: u64,
+    send_timeout: Duration,
+    no_ack_timeout: Duration,
+) -> bool {
+    (no_ack_elapsed >= no_ack_timeout && unacked_sends >= PATH_MIN_UNACKED_SENDS)
+        || (timeout_streak >= PATH_TIMEOUT_STREAK && timeout_elapsed >= send_timeout)
+}
+
+fn quic_path_stall_timeout_from_rtt(rtt: Duration) -> Duration {
+    rtt.checked_mul(8)
+        .unwrap_or(Duration::MAX)
+        .max(Duration::from_secs(10))
+}
+
+/// Close a shared QUIC path only after repeated send deadlines or a full
+/// no-ACK grace period. Any new packet acknowledgement clears both clocks.
+pub(crate) fn spawn_quic_path_watchdog(conn: Connection, health: Arc<QuicPathHealth>) {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval_at(
+            tokio::time::Instant::now() + PATH_WATCH_INTERVAL,
+            PATH_WATCH_INTERVAL,
+        );
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            tokio::select! {
+                _ = conn.closed() => break,
+                _ = ticker.tick() => {
+                    if health.check_stalled(&conn) {
+                        if health.telemetry_enabled() {
+                            record_quic_path_stall();
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+    });
+}
+
+/// Process-wide QUIC path telemetry. Connection labels are intentionally not
+/// retained; the snapshot is suitable for the aggregate `/stats` surface.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct QuicStatsSnapshot {
+    pub active_connections: u64,
+    pub srtt_us: u64,
+    pub cwnd_bytes: u64,
+    pub loss_rate_ppm: u64,
+    pub sent_packets: u64,
+    pub ack_frames: u64,
+    pub lost_packets: u64,
+    pub sent_plpmtud_probes: u64,
+    pub lost_plpmtud_probes: u64,
+    pub current_mtu: u64,
+    pub black_holes: u64,
+    pub congestion_events: u64,
+    pub tx_bytes: u64,
+    pub rx_bytes: u64,
+    pub tx_datagrams: u64,
+    pub rx_datagrams: u64,
+    pub tx_ios: u64,
+    pub rx_ios: u64,
+    pub transport_tx_would_block: u64,
+    pub transport_rx_drops: u64,
+    pub transport_tx_drops: u64,
+    pub session_rx_drops: u64,
+    pub send_timeouts: u64,
+    pub path_stalls: u64,
+}
+
+#[derive(Debug, Default)]
+struct QuicMetricTotals {
+    sent_packets: AtomicU64,
+    ack_frames: AtomicU64,
+    lost_packets: AtomicU64,
+    sent_plpmtud_probes: AtomicU64,
+    lost_plpmtud_probes: AtomicU64,
+    black_holes: AtomicU64,
+    congestion_events: AtomicU64,
+    tx_bytes: AtomicU64,
+    rx_bytes: AtomicU64,
+    tx_datagrams: AtomicU64,
+    rx_datagrams: AtomicU64,
+    tx_ios: AtomicU64,
+    rx_ios: AtomicU64,
+    transport_tx_would_block: AtomicU64,
+    transport_rx_drops: AtomicU64,
+    transport_tx_drops: AtomicU64,
+    session_rx_drops: AtomicU64,
+    send_timeouts: AtomicU64,
+    path_stalls: AtomicU64,
+}
+
+impl QuicMetricTotals {
+    fn add_stats(&self, stats: &quinn::ConnectionStats) {
+        self.sent_packets
+            .fetch_add(stats.path.sent_packets, Ordering::Relaxed);
+        self.ack_frames
+            .fetch_add(stats.frame_rx.acks, Ordering::Relaxed);
+        self.lost_packets
+            .fetch_add(stats.path.lost_packets, Ordering::Relaxed);
+        self.sent_plpmtud_probes
+            .fetch_add(stats.path.sent_plpmtud_probes, Ordering::Relaxed);
+        self.lost_plpmtud_probes
+            .fetch_add(stats.path.lost_plpmtud_probes, Ordering::Relaxed);
+        self.black_holes
+            .fetch_add(stats.path.black_holes_detected, Ordering::Relaxed);
+        self.congestion_events
+            .fetch_add(stats.path.congestion_events, Ordering::Relaxed);
+        self.tx_bytes
+            .fetch_add(stats.udp_tx.bytes, Ordering::Relaxed);
+        self.rx_bytes
+            .fetch_add(stats.udp_rx.bytes, Ordering::Relaxed);
+        self.tx_datagrams
+            .fetch_add(stats.udp_tx.datagrams, Ordering::Relaxed);
+        self.rx_datagrams
+            .fetch_add(stats.udp_rx.datagrams, Ordering::Relaxed);
+        self.tx_ios.fetch_add(stats.udp_tx.ios, Ordering::Relaxed);
+        self.rx_ios.fetch_add(stats.udp_rx.ios, Ordering::Relaxed);
+    }
+}
+
+#[derive(Debug)]
+struct QuicMetricEntry {
+    stats: quinn::ConnectionStats,
+}
+
+#[derive(Debug, Default)]
+struct QuicMetrics {
+    entries: SyncMutex<HashMap<u64, QuicMetricEntry>>,
+    next_id: AtomicU64,
+    totals: QuicMetricTotals,
+}
+
+static QUIC_METRICS: LazyLock<QuicMetrics> = LazyLock::new(QuicMetrics::default);
+
+fn quic_metrics() -> &'static QuicMetrics {
+    &QUIC_METRICS
+}
+
+fn register_quic_connection(stats: quinn::ConnectionStats) -> u64 {
+    let metrics = quic_metrics();
+    let id = metrics
+        .next_id
+        .fetch_add(1, Ordering::Relaxed)
+        .wrapping_add(1);
+    metrics.entries.lock().insert(id, QuicMetricEntry { stats });
+    id
+}
+
+fn update_quic_connection(id: u64, stats: quinn::ConnectionStats) {
+    let metrics = quic_metrics();
+    if let Some(entry) = metrics.entries.lock().get_mut(&id) {
+        entry.stats = stats;
+    }
+}
+
+fn finish_quic_connection(id: u64, stats: quinn::ConnectionStats) {
+    let metrics = quic_metrics();
+    let mut entries = metrics.entries.lock();
+    if entries.remove(&id).is_some() {
+        metrics.totals.add_stats(&stats);
+    }
+}
+
+fn add_active_stats(snapshot: &mut QuicStatsSnapshot, stats: &quinn::ConnectionStats) {
+    snapshot.sent_packets = snapshot
+        .sent_packets
+        .saturating_add(stats.path.sent_packets);
+    snapshot.ack_frames = snapshot.ack_frames.saturating_add(stats.frame_rx.acks);
+    snapshot.lost_packets = snapshot
+        .lost_packets
+        .saturating_add(stats.path.lost_packets);
+    snapshot.sent_plpmtud_probes = snapshot
+        .sent_plpmtud_probes
+        .saturating_add(stats.path.sent_plpmtud_probes);
+    snapshot.lost_plpmtud_probes = snapshot
+        .lost_plpmtud_probes
+        .saturating_add(stats.path.lost_plpmtud_probes);
+    snapshot.black_holes = snapshot
+        .black_holes
+        .saturating_add(stats.path.black_holes_detected);
+    snapshot.congestion_events = snapshot
+        .congestion_events
+        .saturating_add(stats.path.congestion_events);
+    snapshot.tx_bytes = snapshot.tx_bytes.saturating_add(stats.udp_tx.bytes);
+    snapshot.rx_bytes = snapshot.rx_bytes.saturating_add(stats.udp_rx.bytes);
+    snapshot.tx_datagrams = snapshot.tx_datagrams.saturating_add(stats.udp_tx.datagrams);
+    snapshot.rx_datagrams = snapshot.rx_datagrams.saturating_add(stats.udp_rx.datagrams);
+    snapshot.tx_ios = snapshot.tx_ios.saturating_add(stats.udp_tx.ios);
+    snapshot.rx_ios = snapshot.rx_ios.saturating_add(stats.udp_rx.ios);
+}
+
+/// Return aggregate QUIC counters and averages for active paths.
+pub fn quic_stats_snapshot() -> QuicStatsSnapshot {
+    let metrics = quic_metrics();
+    let entries = metrics.entries.lock();
+    let active = entries.len() as u64;
+    let mut snapshot = QuicStatsSnapshot {
+        sent_packets: metrics.totals.sent_packets.load(Ordering::Relaxed),
+        ack_frames: metrics.totals.ack_frames.load(Ordering::Relaxed),
+        lost_packets: metrics.totals.lost_packets.load(Ordering::Relaxed),
+        sent_plpmtud_probes: metrics.totals.sent_plpmtud_probes.load(Ordering::Relaxed),
+        lost_plpmtud_probes: metrics.totals.lost_plpmtud_probes.load(Ordering::Relaxed),
+        black_holes: metrics.totals.black_holes.load(Ordering::Relaxed),
+        congestion_events: metrics.totals.congestion_events.load(Ordering::Relaxed),
+        tx_bytes: metrics.totals.tx_bytes.load(Ordering::Relaxed),
+        rx_bytes: metrics.totals.rx_bytes.load(Ordering::Relaxed),
+        tx_datagrams: metrics.totals.tx_datagrams.load(Ordering::Relaxed),
+        rx_datagrams: metrics.totals.rx_datagrams.load(Ordering::Relaxed),
+        tx_ios: metrics.totals.tx_ios.load(Ordering::Relaxed),
+        rx_ios: metrics.totals.rx_ios.load(Ordering::Relaxed),
+        transport_tx_would_block: metrics
+            .totals
+            .transport_tx_would_block
+            .load(Ordering::Relaxed),
+        transport_rx_drops: metrics.totals.transport_rx_drops.load(Ordering::Relaxed),
+        transport_tx_drops: metrics.totals.transport_tx_drops.load(Ordering::Relaxed),
+        session_rx_drops: metrics.totals.session_rx_drops.load(Ordering::Relaxed),
+        send_timeouts: metrics.totals.send_timeouts.load(Ordering::Relaxed),
+        path_stalls: metrics.totals.path_stalls.load(Ordering::Relaxed),
+        active_connections: active,
+        ..Default::default()
+    };
+    let mut rtt_us = 0u128;
+    let mut cwnd_bytes = 0u128;
+    let mut mtu = 0u128;
+    for entry in entries.values() {
+        add_active_stats(&mut snapshot, &entry.stats);
+        rtt_us += entry.stats.path.rtt.as_micros();
+        cwnd_bytes += entry.stats.path.cwnd as u128;
+        mtu += entry.stats.path.current_mtu as u128;
+    }
+    let data_sent = snapshot
+        .sent_packets
+        .saturating_sub(snapshot.sent_plpmtud_probes);
+    snapshot.loss_rate_ppm = if data_sent == 0 {
+        0
+    } else {
+        (u128::from(snapshot.lost_packets) * 1_000_000 / u128::from(data_sent)).min(1_000_000)
+            as u64
+    };
+    if active != 0 {
+        let active = u128::from(active);
+        snapshot.srtt_us = (rtt_us / active).min(u128::from(u64::MAX)) as u64;
+        snapshot.cwnd_bytes = (cwnd_bytes / active).min(u128::from(u64::MAX)) as u64;
+        snapshot.current_mtu = (mtu / active).min(u128::from(u64::MAX)) as u64;
+    }
+    snapshot
+}
+
+/// Count a QUIC packet-send timeout observed by the core driver.
+pub fn record_quic_send_timeout() {
+    quic_metrics()
+        .totals
+        .send_timeouts
+        .fetch_add(1, Ordering::Relaxed);
+}
+
+/// Count a QUIC path retired by the core driver watchdog.
+pub fn record_quic_path_stall() {
+    quic_metrics()
+        .totals
+        .path_stalls
+        .fetch_add(1, Ordering::Relaxed);
+}
+
+fn record_transport_tx_would_block() {
+    quic_metrics()
+        .totals
+        .transport_tx_would_block
+        .fetch_add(1, Ordering::Relaxed);
+}
+
+fn record_transport_rx_drop() {
+    quic_metrics()
+        .totals
+        .transport_rx_drops
+        .fetch_add(1, Ordering::Relaxed);
+}
+fn record_transport_tx_drop() {
+    quic_metrics()
+        .totals
+        .transport_tx_drops
+        .fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_quic_session_rx_drop() {
+    quic_metrics()
+        .totals
+        .session_rx_drops
+        .fetch_add(1, Ordering::Relaxed);
+}
+
 /// Caller-tunable options for [`client_config`]. Everything defaults to the
 /// quinn/cubic behavior; protocol handlers override only what they need.
 #[derive(Clone, Default)]
@@ -152,8 +931,7 @@ pub struct QuicClientOptions {
     /// Congestion controller; `None` = cubic. Use [`congestion_factory`] for
     /// named algorithms or [`BrutalConfig`] for hysteria2's fixed-rate sender.
     pub congestion: Option<Arc<dyn congestion::ControllerFactory + Send + Sync>>,
-    /// QUIC keep-alive interval (Juicity uses 5s per the daeuniverse
-    /// reference client; TUIC relies on its own heartbeat datagrams instead).
+    /// QUIC keep-alive interval.
     pub keep_alive: Option<Duration>,
     /// Initial per-stream receive window, bytes.
     pub stream_receive_window: Option<u64>,
@@ -231,10 +1009,6 @@ pub async fn client_config(
             chrome: crate::tls::chrome_mode(),
             ech_config_list: ech,
             pin_sha256,
-            // Tickets belong to a specific service, not a hostname:
-            // address|port|SNI|ALPN — different protocols, different
-            // servers behind one certificate, and reloaded configs never
-            // cross-resume into each other.
             ticket_key: Some(format!(
                 "{}|{}|{}|{}",
                 node.host(),
@@ -247,7 +1021,6 @@ pub async fn client_config(
             )),
         })?;
     let mut cfg = ClientConfig::new(Arc::new(crypto));
-
     let mut transport = TransportConfig::default();
     transport
         .congestion_controller_factory(
@@ -255,9 +1028,6 @@ pub async fn client_config(
                 .congestion
                 .unwrap_or_else(|| congestion_factory(None)),
         )
-        // Protocols like TUIC deliver inbound UDP packets on server-initiated
-        // uni streams (one stream per packet) — allow a generous number
-        // (sing-quic sets MaxIncomingUniStreams to 1<<60).
         .max_concurrent_uni_streams(VarInt::from_u32(4096));
     if let Some(w) = options.stream_receive_window {
         transport.stream_receive_window(VarInt::from_u64(w)?);
@@ -266,10 +1036,7 @@ pub async fn client_config(
         transport.receive_window(VarInt::from_u64(w)?);
     }
     if let Some(mtu) = options.max_udp_payload_size {
-        // UDP payload size, not link MTU. Valid range per RFC 9000 (initial
-        // packets must carry 1200) and quinn's cap; invalid values are
-        // clamped rather than failing the first dial later.
-        let mtu = mtu.clamp(1200, 65527);
+        let mtu = clamp_quic_payload_size(mtu);
         transport.initial_mtu(mtu);
         if !options.disable_mtu_discovery {
             let mut mtud = quinn::MtuDiscoveryConfig::default();
@@ -287,8 +1054,6 @@ pub async fn client_config(
     Ok(cfg)
 }
 
-/// Current unix time in seconds (0 on clock skew); used for the idle
-/// accounting of shared connections.
 pub(crate) fn now_secs() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -296,16 +1061,12 @@ pub(crate) fn now_secs() -> u64 {
         .unwrap_or(0)
 }
 
-/// `RecvStream::read_exact` with quinn's error mapped to
-/// `io::ErrorKind::UnexpectedEof` (protocol framing helpers return
-/// `io::Result`).
 pub(crate) async fn recv_read_exact(recv: &mut RecvStream, buf: &mut [u8]) -> io::Result<()> {
     recv.read_exact(buf)
         .await
         .map_err(|e| io::Error::new(io::ErrorKind::UnexpectedEof, e))
 }
-/// Wait long enough for a server to reject zero-grace authentication after
-/// the handshake. The final close check covers a close racing the timer.
+
 pub(crate) async fn survives_auth_close_window(conn: &Connection) -> bool {
     let wait = (2 * conn.rtt()).max(Duration::from_millis(2));
     tokio::select! {
@@ -314,40 +1075,229 @@ pub(crate) async fn survives_auth_close_window(conn: &Connection) -> bool {
     }
 }
 
+#[cfg(test)]
+mod path_health_tests {
+    use super::*;
+    use crate::proxy::QuicSendToken;
+
+    fn health(last_ack: u64, epoch: u64, streak: u8, since: u64) -> QuicPathHealth {
+        QuicPathHealth {
+            ack_state: AtomicU64::new(path_state(epoch, since != 0)),
+            last_acked_packets: AtomicU64::new(last_ack),
+            sampled_acked_packets: AtomicU64::new(last_ack),
+            sampled_sent_ack_eliciting_packets: AtomicU64::new(last_ack),
+            waiting_sent_baseline: AtomicU64::new(last_ack),
+            waiting_acked_baseline: AtomicU64::new(last_ack),
+            unacked_since_ms: AtomicU64::new(0),
+            last_sample_ms: AtomicU64::new(path_now_millis()),
+            timeout_state: AtomicU64::new(timeout_state(epoch, streak)),
+            waiting_since_ms: AtomicU64::new(since),
+            send_timeout_ms: AtomicU64::new(1_000),
+            path_stall_timeout_ms: AtomicU64::new(10_000),
+            path_stalled: AtomicBool::new(false),
+            telemetry_enabled: AtomicBool::new(false),
+        }
+    }
+
+    #[test]
+    fn send_deadline_is_bounded_by_rtt() {
+        assert_eq!(
+            bounded_quic_send_timeout(Duration::ZERO),
+            Duration::from_secs(1)
+        );
+        assert_eq!(
+            bounded_quic_send_timeout(Duration::from_millis(250)),
+            Duration::from_secs(1)
+        );
+        assert_eq!(
+            bounded_quic_send_timeout(Duration::from_secs(2)),
+            Duration::from_secs(5)
+        );
+        assert_eq!(elapsed_since_millis(20_000, 0), Duration::ZERO);
+        assert_eq!(
+            elapsed_since_millis(20_000, 19_990),
+            Duration::from_millis(10)
+        );
+    }
+
+    #[test]
+    fn repeated_timeouts_or_long_silence_retire() {
+        assert!(!should_retire_path(
+            Duration::from_secs(3),
+            Duration::from_secs(10),
+            PATH_TIMEOUT_STREAK,
+            0,
+            Duration::from_secs(4),
+            Duration::from_secs(10),
+        ));
+        assert!(should_retire_path(
+            Duration::from_secs(4),
+            Duration::ZERO,
+            PATH_TIMEOUT_STREAK,
+            0,
+            Duration::from_secs(4),
+            Duration::from_secs(10),
+        ));
+        assert!(!should_retire_path(
+            Duration::from_secs(10),
+            Duration::from_secs(10),
+            0,
+            1,
+            Duration::from_secs(4),
+            Duration::from_secs(10),
+        ));
+        assert!(should_retire_path(
+            Duration::ZERO,
+            Duration::from_secs(10),
+            0,
+            PATH_MIN_UNACKED_SENDS,
+            Duration::from_secs(4),
+            Duration::from_secs(10),
+        ));
+    }
+    #[test]
+    fn ack_progress_clears_wait_and_stale_completion_cannot_rearm() {
+        let h = health(3, 0, 2, 42);
+        assert!(h.note_ack_progress(4));
+        assert!(!h.complete_send(QuicSendToken::new(0, 3, 3, 10), SendCompletion::Timeout, 4,));
+        assert_eq!(h.ack_state.load(Ordering::Acquire) & PATH_WAITING, 0);
+        assert_eq!(
+            timeout_state_streak(h.timeout_state.load(Ordering::Acquire)),
+            0
+        );
+    }
+
+    #[test]
+    fn historical_losses_do_not_count_as_current_unacked_sends() {
+        let h = health(95, 0, 0, 0);
+        h.sampled_sent_ack_eliciting_packets
+            .store(100, Ordering::Release);
+        assert!(h.complete_send(
+            QuicSendToken::new(0, 95, 100, 10),
+            SendCompletion::Timeout,
+            95,
+        ));
+        h.sampled_sent_ack_eliciting_packets
+            .store(101, Ordering::Release);
+        assert_eq!(h.unacked_sends_since_wait(), 1);
+        assert!(!should_retire_path(
+            Duration::from_secs(10),
+            Duration::from_secs(10),
+            0,
+            h.unacked_sends_since_wait(),
+            Duration::from_secs(4),
+            Duration::from_secs(10),
+        ));
+    }
+
+    #[test]
+    fn timeout_streak_is_scoped_to_ack_epoch() {
+        let h = health(0, 0, 0, 0);
+        assert!(h.complete_send(QuicSendToken::new(0, 0, 0, 10), SendCompletion::Timeout, 0,));
+        assert!(h.complete_send(QuicSendToken::new(0, 0, 0, 20), SendCompletion::Timeout, 0,));
+        assert_eq!(
+            timeout_state_streak(h.timeout_state.load(Ordering::Acquire)),
+            2
+        );
+        assert_ne!(h.ack_state.load(Ordering::Acquire) & PATH_WAITING, 0);
+    }
+
+    #[test]
+    fn concurrent_send_completion_keeps_earliest_baseline() {
+        let h = health(0, 0, 0, 0);
+        assert!(h.complete_send(
+            QuicSendToken::new(0, 0, 20, 200),
+            SendCompletion::Success,
+            0,
+        ));
+        assert!(h.complete_send(
+            QuicSendToken::new(0, 0, 10, 100),
+            SendCompletion::Success,
+            0,
+        ));
+        h.sampled_sent_ack_eliciting_packets
+            .store(20, Ordering::Release);
+        assert_eq!(h.waiting_sent_baseline.load(Ordering::Acquire), 10);
+        assert_eq!(h.waiting_since_ms.load(Ordering::Acquire), 100);
+        assert_eq!(h.unacked_sends_since_wait(), 10);
+    }
+
+    #[test]
+    fn successful_send_preserves_first_stall_deadline() {
+        let h = health(0, 0, 2, 42);
+        assert!(h.complete_send(QuicSendToken::new(0, 0, 0, 100), SendCompletion::Success, 0,));
+        assert_eq!(h.waiting_since_ms.load(Ordering::Acquire), 42);
+        assert_eq!(
+            timeout_state_streak(h.timeout_state.load(Ordering::Acquire)),
+            0
+        );
+    }
+
+    #[test]
+    fn ack_progress_invalidates_all_old_send_tokens() {
+        let h = health(0, 0, 0, 0);
+        let token = QuicSendToken::new(0, 0, 0, 100);
+        assert!(h.note_ack_progress(1));
+        assert!(!h.complete_send(token, SendCompletion::Success, 1));
+        assert_eq!(h.ack_state.load(Ordering::Acquire) & PATH_WAITING, 0);
+    }
+}
 /// UDP fragment reassembly shared by the TUIC and Hysteria2 session bridges
 /// (sing `udpDefragger` parity).
 pub(crate) mod defrag {
     use std::collections::HashMap;
     use std::time::{Duration, Instant};
 
-    /// Maximum pending fragmented packets kept for reassembly per session.
     const DEFRAG_MAX_PENDING: usize = 64;
-    /// Maximum age of a pending fragmented packet before it is dropped.
+    const DEFRAG_MAX_FRAGMENTS: usize = 64;
     const DEFRAG_MAX_AGE: Duration = Duration::from_secs(10);
 
-    /// Reassembly state for one fragmented packet.
     struct DefragBuffer {
         frags: Vec<Option<Vec<u8>>>,
         count: usize,
+        bytes: usize,
         updated: Instant,
     }
 
-    /// Reassembles fragmented UDP packets, bounding memory by capping the
-    /// number of pending packets and expiring stale ones.
-    #[derive(Default)]
     pub(crate) struct Defragmenter {
-        map: HashMap<u16, DefragBuffer>,
+        map: HashMap<u64, DefragBuffer>,
+        latest_packet: Option<u64>,
+        max_payload: usize,
     }
 
     impl Defragmenter {
-        pub(crate) fn new() -> Self {
-            Self::default()
+        pub(crate) fn new(max_payload: usize) -> Self {
+            Self {
+                map: HashMap::new(),
+                latest_packet: None,
+                max_payload,
+            }
         }
 
-        /// Feed one fragment; returns the reassembled payload when the last
-        /// missing fragment arrives. Unfragmented packets (`frag_total <= 1`)
-        /// pass through immediately; invalid or duplicate fragments are
-        /// dropped (`None`).
+        fn packet_key(&mut self, packet_id: u16) -> u64 {
+            let packet_id = u64::from(packet_id);
+            let Some(latest) = self.latest_packet else {
+                // Leave one complete cycle below the initial key for delayed fragments.
+                let key = (1 << 16) | packet_id;
+                self.latest_packet = Some(key);
+                return key;
+            };
+            let base = latest & !u64::from(u16::MAX);
+            let candidate = base | packet_id;
+            let delta = candidate as i128 - latest as i128;
+            let key = if delta > i128::from(1u64 << 15) {
+                candidate.saturating_sub(1 << 16)
+            } else if delta < -i128::from(1u64 << 15) {
+                candidate.saturating_add(1 << 16)
+            } else {
+                candidate
+            };
+            if key > latest {
+                self.latest_packet = Some(key);
+            }
+            key
+        }
+
         pub(crate) fn feed(
             &mut self,
             packet_id: u16,
@@ -355,45 +1305,112 @@ pub(crate) mod defrag {
             frag_total: u8,
             data: Vec<u8>,
         ) -> Option<Vec<u8>> {
-            if frag_total <= 1 {
-                return Some(data);
-            }
-            if frag_id >= frag_total {
+            if frag_total == 0
+                || usize::from(frag_id) >= usize::from(frag_total)
+                || usize::from(frag_total) > DEFRAG_MAX_FRAGMENTS
+                || data.len() > self.max_payload
+            {
                 return None;
             }
-            let map = &mut self.map;
-            if map.len() >= DEFRAG_MAX_PENDING && !map.contains_key(&packet_id) {
-                map.retain(|_, b| b.updated.elapsed() < DEFRAG_MAX_AGE);
-                if map.len() >= DEFRAG_MAX_PENDING {
+            let packet_key = self.packet_key(packet_id);
+            if frag_total == 1 {
+                return Some(data);
+            }
+            let frag_total = usize::from(frag_total);
+            if self.map.len() >= DEFRAG_MAX_PENDING && !self.map.contains_key(&packet_key) {
+                self.map
+                    .retain(|_, buffer| buffer.updated.elapsed() < DEFRAG_MAX_AGE);
+                if self.map.len() >= DEFRAG_MAX_PENDING {
                     return None;
                 }
             }
-            let frag_total = frag_total as usize;
-            let entry = map.entry(packet_id).or_insert_with(|| DefragBuffer {
+            let entry = self.map.entry(packet_key).or_insert_with(|| DefragBuffer {
                 frags: (0..frag_total).map(|_| None).collect(),
                 count: 0,
+                bytes: 0,
                 updated: Instant::now(),
             });
             if entry.frags.len() != frag_total {
                 entry.frags = (0..frag_total).map(|_| None).collect();
                 entry.count = 0;
+                entry.bytes = 0;
             }
-            let frag_id = frag_id as usize;
+            let frag_id = usize::from(frag_id);
             if entry.frags[frag_id].is_some() {
+                return None;
+            }
+            let Some(bytes) = entry.bytes.checked_add(data.len()) else {
+                self.map.remove(&packet_key);
+                return None;
+            };
+            if bytes > self.max_payload {
+                self.map.remove(&packet_key);
                 return None;
             }
             entry.frags[frag_id] = Some(data);
             entry.count += 1;
+            entry.bytes = bytes;
             entry.updated = Instant::now();
             if entry.count != entry.frags.len() {
                 return None;
             }
-            let entry = map.remove(&packet_id).expect("entry just inserted");
-            let mut data = Vec::new();
+            let entry = self.map.remove(&packet_key).expect("entry just inserted");
+            let mut data = Vec::with_capacity(entry.bytes);
             for frag in entry.frags.into_iter().flatten() {
                 data.extend_from_slice(&frag);
             }
             Some(data)
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn reassembly_is_bounded_and_packet_id_wrap_is_distinct() {
+            let mut defrag = Defragmenter::new(4);
+            assert!(defrag.feed(7, 0, 65, vec![]).is_none());
+            assert!(defrag.feed(8, 0, 2, vec![1, 2, 3]).is_none());
+            assert!(defrag.feed(8, 1, 2, vec![4, 5]).is_none());
+
+            assert!(defrag.feed(0, 0, 2, vec![0]).is_none());
+            assert_eq!(defrag.feed(32_767, 0, 1, vec![0]), Some(vec![0]));
+            assert_eq!(defrag.feed(65_534, 0, 1, vec![0]), Some(vec![0]));
+            assert_eq!(defrag.feed(1, 0, 1, vec![0]), Some(vec![0]));
+            assert!(defrag.feed(0, 0, 2, vec![2]).is_none());
+            assert_eq!(defrag.feed(0, 1, 2, vec![3]), Some(vec![2, 3]));
+        }
+
+        #[test]
+        fn inferred_previous_cycle_ids_never_alias() {
+            let mut defrag = Defragmenter::new(8);
+            assert!(defrag.feed(1, 0, 2, vec![1]).is_none());
+            assert!(defrag.feed(40_001, 0, 2, vec![2]).is_none());
+            assert!(defrag.feed(50_001, 1, 2, vec![3]).is_none());
+            assert_eq!(defrag.feed(40_001, 1, 2, vec![4]), Some(vec![2, 4]));
+            assert_eq!(defrag.feed(50_001, 0, 2, vec![5]), Some(vec![5, 3]));
+        }
+
+        #[test]
+        fn delayed_previous_cycle_fragments_do_not_collide() {
+            let mut defrag = Defragmenter::new(8);
+            assert!(defrag.feed(65_530, 0, 2, vec![1]).is_none());
+            assert!(defrag.feed(100, 0, 2, vec![2]).is_none());
+            assert!(defrag.feed(0, 0, 2, vec![3]).is_none());
+            assert!(defrag.feed(65_500, 0, 2, vec![4]).is_none());
+            assert_eq!(defrag.feed(0, 1, 2, vec![5]), Some(vec![3, 5]));
+            assert_eq!(defrag.feed(65_500, 1, 2, vec![6]), Some(vec![4, 6]));
+        }
+
+        #[test]
+        fn malformed_fragments_do_not_advance_packet_epoch() {
+            let mut defrag = Defragmenter::new(8);
+            assert_eq!(defrag.packet_key(10), (1 << 16) | 10);
+            assert!(defrag.feed(65_000, 0, 65, vec![1]).is_none());
+            assert_eq!(defrag.latest_packet, Some((1 << 16) | 10));
+            assert!(defrag.feed(11, 0, 2, vec![2]).is_none());
+            assert_eq!(defrag.feed(11, 1, 2, vec![3]), Some(vec![2, 3]));
         }
     }
 }
@@ -429,6 +1446,10 @@ pub fn client_endpoint(ipv6: bool) -> io::Result<Endpoint> {
     client_endpoint_with_mtu(ipv6, 1252)
 }
 
+fn clamp_quic_payload_size(mtu: u16) -> u16 {
+    mtu.clamp(1200, 65527)
+}
+
 fn default_gso_enabled(max_udp_payload_size: u16) -> bool {
     max_udp_payload_size > 1252
 }
@@ -448,6 +1469,7 @@ fn gso_transmit_segments(enabled: bool, kernel_max: usize) -> usize {
 /// the operator has already declared that the path carries larger datagrams.
 /// `HONK_QUIC_GSO=0|1` overrides that policy process-wide.
 pub fn client_endpoint_with_mtu(ipv6: bool, max_udp_payload_size: u16) -> io::Result<Endpoint> {
+    let max_udp_payload_size = clamp_quic_payload_size(max_udp_payload_size);
     let socket = marked_udp_socket(ipv6)?;
     let runtime = quinn::default_runtime()
         .ok_or_else(|| io::Error::other("no async runtime available for QUIC"))?;
@@ -472,7 +1494,9 @@ pub fn client_endpoint_with_mtu(ipv6: bool, max_udp_payload_size: u16) -> io::Re
 /// for why 1252 is the safe default on PMTU-black-holed last miles).
 pub(crate) fn endpoint_config_with_mtu(mtu: u16) -> io::Result<EndpointConfig> {
     let mut config = EndpointConfig::default();
-    config.max_udp_payload_size(mtu).map_err(io::Error::other)?;
+    config
+        .max_udp_payload_size(clamp_quic_payload_size(mtu))
+        .map_err(io::Error::other)?;
     Ok(config)
 }
 
@@ -551,14 +1575,129 @@ impl quinn::UdpPoller for NoGsoUdpPoller {
     }
 }
 
+/// Keeps one QUIC connection in the aggregate metrics registry until it is
+/// closed or the owning pooled client drops it.
+pub struct QuicConnectionMonitor {
+    id: u64,
+    conn: Connection,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for QuicConnectionMonitor {
+    fn drop(&mut self) {
+        self.task.abort();
+        finish_quic_connection(self.id, self.conn.stats());
+    }
+}
+
+/// Register a pooled QUIC connection for one-second aggregate sampling.
+pub fn monitor_quic_connection(conn: &Connection) -> QuicConnectionMonitor {
+    spawn_quic_connection_monitor(conn.clone())
+}
+fn spawn_quic_connection_monitor(conn: Connection) -> QuicConnectionMonitor {
+    let id = register_quic_connection(conn.stats());
+    let task_conn = conn.clone();
+    let task = tokio::spawn(async move {
+        let mut ticker = tokio::time::interval_at(
+            tokio::time::Instant::now() + QUIC_SAMPLE_INTERVAL,
+            QUIC_SAMPLE_INTERVAL,
+        );
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            tokio::select! {
+                _ = task_conn.closed() => break,
+                _ = ticker.tick() => {
+                    update_quic_connection(id, task_conn.stats());
+                }
+            }
+        }
+        let final_stats = task_conn.stats();
+        update_quic_connection(id, final_stats);
+        finish_quic_connection(id, final_stats);
+    });
+    QuicConnectionMonitor { id, conn, task }
+}
+
+struct TrackedConnection<C> {
+    id: u64,
+    connection: Connection,
+    _endpoint: Endpoint,
+    state: Weak<C>,
+}
+
 struct State<C> {
     /// Lazily created endpoint, tagged with its address family. Recreated when
     /// the family of the resolved server address changes.
     endpoint: Option<(bool, Endpoint)>,
     conn: Option<(Connection, Arc<C>)>,
+    connections: Vec<TrackedConnection<C>>,
+    next_connection_id: u64,
+    metrics_enabled: bool,
+
     /// Set by [`QuicClient::force_close`]: future dials fail instead of
     /// re-dialing into a closed client.
     closed: bool,
+}
+
+impl<C> State<C> {
+    fn prune_connections(&mut self) {
+        self.connections.retain(|tracked| {
+            if tracked.connection.close_reason().is_some() {
+                return false;
+            }
+            if tracked.state.upgrade().is_some() {
+                return true;
+            }
+            tracked
+                .connection
+                .close(VarInt::from_u32(0), b"state dropped");
+            false
+        });
+    }
+}
+
+fn spawn_tracked_connection_cleanup<C: Send + Sync + 'static>(
+    state: Weak<Mutex<State<C>>>,
+    id: u64,
+    connection: Connection,
+    owner: Weak<C>,
+) {
+    tokio::spawn(async move {
+        loop {
+            if owner.upgrade().is_none() {
+                connection.close(VarInt::from_u32(0), b"state dropped");
+                break;
+            }
+            tokio::select! {
+                _ = connection.closed() => break,
+                _ = tokio::time::sleep(QUIC_SAMPLE_INTERVAL) => {}
+            }
+        }
+        if let Some(state) = state.upgrade() {
+            let mut state = state.lock().await;
+            state.connections.retain(|tracked| tracked.id != id);
+        }
+    });
+}
+
+struct ConnectionCloseGuard(Option<Connection>);
+
+impl ConnectionCloseGuard {
+    fn new(conn: Connection) -> Self {
+        Self(Some(conn))
+    }
+
+    fn disarm(&mut self) {
+        self.0 = None;
+    }
+}
+
+impl Drop for ConnectionCloseGuard {
+    fn drop(&mut self) {
+        if let Some(conn) = self.0.take() {
+            conn.close(VarInt::from_u32(0), b"connection setup cancelled");
+        }
+    }
 }
 
 /// Per-server QUIC connection holder.
@@ -586,10 +1725,10 @@ pub struct QuicClient<C> {
     /// Advertised `max_udp_payload_size` cap for the default endpoint (see
     /// [`client_endpoint`] for the safe 1252 default).
     mtu: u16,
-    state: Mutex<State<C>>,
+    state: Arc<Mutex<State<C>>>,
 }
 
-impl<C> QuicClient<C> {
+impl<C: Send + Sync + 'static> QuicClient<C> {
     pub fn new(
         server_host: impl Into<String>,
         server_port: u16,
@@ -603,11 +1742,14 @@ impl<C> QuicClient<C> {
             config,
             endpoint_factory: None,
             mtu: 1252,
-            state: Mutex::new(State {
+            state: Arc::new(Mutex::new(State {
                 endpoint: None,
                 conn: None,
+                connections: Vec::new(),
+                next_connection_id: 1,
+                metrics_enabled: false,
                 closed: false,
-            }),
+            })),
         }
     }
 
@@ -616,7 +1758,7 @@ impl<C> QuicClient<C> {
     /// Larger datagrams directly lower the per-packet processing cost that
     /// caps single-connection QUIC throughput (~180k pps at 1252B).
     pub fn with_max_udp_payload_size(mut self, mtu: u16) -> Self {
-        self.mtu = mtu;
+        self.mtu = clamp_quic_payload_size(mtu);
         self
     }
 
@@ -629,6 +1771,16 @@ impl<C> QuicClient<C> {
     ) -> Self {
         self.endpoint_factory = Some(Arc::new(factory));
         self
+    }
+    pub(crate) async fn enable_metrics(&self)
+    where
+        C: QuicConnState,
+    {
+        let mut state = self.state.lock().await;
+        state.metrics_enabled = true;
+        if let Some((conn, ctx)) = state.conn.as_ref() {
+            ctx.install_metrics_monitor(conn.clone());
+        }
     }
 
     /// Return the shared connection (plus its protocol state), dialing and
@@ -645,13 +1797,48 @@ impl<C> QuicClient<C> {
         F: FnOnce(Connection) -> Fut,
         Fut: Future<Output = anyhow::Result<C>>,
     {
+        self.connection_with_inner(connect_timeout, setup, |_, _| {})
+            .await
+    }
+
+    pub(crate) async fn connection_with_metrics<F, Fut>(
+        &self,
+        connect_timeout: Duration,
+        setup: F,
+    ) -> anyhow::Result<(Connection, Arc<C>)>
+    where
+        C: QuicConnState,
+        F: FnOnce(Connection) -> Fut,
+        Fut: Future<Output = anyhow::Result<C>>,
+    {
+        self.connection_with_inner(connect_timeout, setup, |ctx, conn| {
+            ctx.install_metrics_monitor(conn.clone());
+        })
+        .await
+    }
+
+    async fn connection_with_inner<F, Fut, H>(
+        &self,
+        connect_timeout: Duration,
+        setup: F,
+        mut on_publish: H,
+    ) -> anyhow::Result<(Connection, Arc<C>)>
+    where
+        F: FnOnce(Connection) -> Fut,
+        Fut: Future<Output = anyhow::Result<C>>,
+        H: FnMut(&C, &Connection),
+    {
         let mut state = self.state.lock().await;
         if state.closed {
             anyhow::bail!("QUIC client is closed");
         }
+        state.prune_connections();
         if let Some((conn, ctx)) = &state.conn
             && conn.close_reason().is_none()
         {
+            if state.metrics_enabled {
+                on_publish(ctx.as_ref(), conn);
+            }
             return Ok((conn.clone(), Arc::clone(ctx)));
         }
         state.conn = None;
@@ -673,6 +1860,7 @@ impl<C> QuicClient<C> {
             .map(|(ipv6, endpoint)| (*ipv6, endpoint.clone()));
         let raced = crate::address_race::race_resolved_addrs(&addrs, |server_addr| {
             let ipv6 = server_addr.is_ipv6();
+            let dial_config = self.config.clone();
             let endpoint = cached_endpoint
                 .as_ref()
                 .filter(|(cached_ipv6, _)| *cached_ipv6 == ipv6)
@@ -691,7 +1879,7 @@ impl<C> QuicClient<C> {
                 // races addresses for this node, never protocol attempts or nodes.
                 for attempt in 1..=3u8 {
                     let connecting = match endpoint.connect_with(
-                        self.config.clone(),
+                        dial_config.clone(),
                         server_addr,
                         &self.server_name,
                     ) {
@@ -720,18 +1908,29 @@ impl<C> QuicClient<C> {
             Some(result) => result?,
             None => anyhow::bail!("resolve {host}: no addresses"),
         };
-        state.endpoint = Some((ipv6, endpoint));
-        let ctx = setup(conn.clone()).await.inspect_err(|_| {
-            conn.close(VarInt::from_u32(0), b"setup failed");
-        })?;
+        state.endpoint = Some((ipv6, endpoint.clone()));
+        let mut close_guard = ConnectionCloseGuard::new(conn.clone());
+        let ctx = setup(conn.clone()).await?;
         let ctx = Arc::new(ctx);
-        // The single-flight mutex makes this unreachable today; the guard
-        // keeps a freshly dialed connection out of a closed client if the
-        // critical section is ever narrowed.
+        // The single-flight mutex makes this unreachable today; keep the
+        // freshly dialed connection out of a closed client if that changes.
         if state.closed {
-            conn.close(VarInt::from_u32(0), b"generation shutdown");
             anyhow::bail!("QUIC client closed during dial");
         }
+        if state.metrics_enabled {
+            on_publish(ctx.as_ref(), &conn);
+        }
+        close_guard.disarm();
+        let id = state.next_connection_id;
+        state.next_connection_id = state.next_connection_id.wrapping_add(1).max(1);
+        let owner = Arc::downgrade(&ctx);
+        state.connections.push(TrackedConnection {
+            id,
+            connection: conn.clone(),
+            _endpoint: endpoint.clone(),
+            state: owner.clone(),
+        });
+        spawn_tracked_connection_cleanup(Arc::downgrade(&self.state), id, conn.clone(), owner);
         state.conn = Some((conn.clone(), Arc::clone(&ctx)));
         Ok((conn, ctx))
     }
@@ -746,6 +1945,7 @@ impl<C> QuicClient<C> {
         {
             state.conn = None;
         }
+        state.prune_connections();
     }
 
     /// Release the reusable holder without closing flows that already own
@@ -754,6 +1954,7 @@ impl<C> QuicClient<C> {
         let mut state = self.state.lock().await;
         state.conn = None;
         state.endpoint = None;
+        state.prune_connections();
     }
 
     /// Close the cached connection and endpoint, terminating every flow that
@@ -763,8 +1964,11 @@ impl<C> QuicClient<C> {
     pub async fn force_close(&self) {
         let mut state = self.state.lock().await;
         state.closed = true;
-        if let Some((conn, _)) = state.conn.take() {
-            conn.close(VarInt::from_u32(0), b"generation shutdown");
+        state.conn = None;
+        for tracked in state.connections.drain(..) {
+            tracked
+                .connection
+                .close(VarInt::from_u32(0), b"generation shutdown");
         }
         if let Some((_, endpoint)) = state.endpoint.take() {
             endpoint.close(VarInt::from_u32(0), b"generation shutdown");
@@ -888,6 +2092,9 @@ pub(crate) trait QuicConnState: Send + Sync + 'static {
     fn touch(&self);
     /// Counter of open streams/bridges on this connection.
     fn open_counter(&self) -> &Arc<AtomicUsize>;
+    /// Keep aggregate metrics alive with active protocol flows after the
+    /// reusable client releases its cached connection.
+    fn install_metrics_monitor(&self, conn: Connection);
 }
 
 /// TUIC-style exporter authentication (sing `clientHandshake`,
@@ -980,13 +2187,8 @@ pub(crate) fn spawn_conn_reaper(
     });
 }
 
-/// Shared TCP-over-QUIC dial skeleton (TUIC/Juicity/Hysteria2): get the
-/// shared connection via `connect` (re-dialing when needed), run the
-/// protocol's stream handshake (`make`), and retry once with a fresh
-/// connection when the handshake fails on a half-dead cached connection and
-/// `retryable` allows it (Hysteria2's server-side refusals are not
-/// retryable). The returned stream decrements the connection's open counter
-/// on drop.
+/// Shared TCP-over-QUIC dial skeleton (TUIC/Juicity/Hysteria2). The returned
+/// stream decrements the connection's open counter on drop.
 pub(crate) async fn dial_quic_stream<S, Connect, Fut, Make, MakeFut>(
     client: &QuicClient<S>,
     connect: Connect,
@@ -1010,13 +2212,10 @@ where
             Ok((send, recv)) => {
                 let open = Arc::clone(state.open_counter());
                 open.fetch_add(1, Ordering::Relaxed);
-                // The flow owns its `(Connection, Arc<S>)` pair: the guard
-                // must hold the state, not just the open counter — a
-                // dropped state makes the connection reaper kill the live
-                // connection ("state dropped") under the stream.
+                let stream_state = Arc::clone(&state);
                 let stream = QuicBiStream::new(send, recv).with_on_drop(move || {
                     open.fetch_sub(1, Ordering::Relaxed);
-                    let _state_kept_alive_under_this_stream = &state;
+                    let _state_kept_alive_under_this_stream = &stream_state;
                 });
                 return Ok(stream);
             }
@@ -1154,6 +2353,16 @@ mod brutal_tests {
         // Initial RTT guess 333ms: BDP = 12.5e6 × 0.333 ≈ 4.16 MB.
         let w = cc.window();
         assert!((4_000_000..4_400_000).contains(&w), "window {w}");
+    }
+
+    #[test]
+    fn bdp_divides_before_u64_clamp() {
+        let brutal = Brutal {
+            rate: 1_000_000_000_000_000,
+            rtt: Duration::from_secs(1),
+            mtu: 1200,
+        };
+        assert_eq!(brutal.bdp(), 1_000_000_000_000_000);
     }
 
     #[test]
@@ -1431,6 +2640,8 @@ mod client_tests {
             .unwrap();
         assert_ne!(first.stable_id(), second.stable_id());
         client.force_close().await;
+        assert!(first.close_reason().is_some());
+        assert!(second.close_reason().is_some());
     }
 
     /// A cold-node health probe dials QUIC through an ephemeral runtime;
@@ -1536,13 +2747,22 @@ mod client_tests {
 // QUIC over a proxied UDP tunnel
 // ---------------------------------------------------------------------------
 
-use crate::proxy::{PacketErrorClass, PacketTransport, packet_error_class};
+use crate::proxy::{PacketErrorClass, PacketTransport, QuicSendAttempt, packet_error_class};
 
 /// quinn [`AsyncUdpSocket`] over a framed [`PacketTransport`]: outbound
 /// datagrams ride a bounded channel drained by a forwarder task (the
 /// transport's async send cannot run in a poll context), while inbound
 /// datagrams are accepted only from the configured QUIC peer.
 const TRANSPORT_QUEUE_CAP: usize = 64;
+/// A queued QUIC datagram must not wait behind a full adapter queue longer
+/// than the longest per-packet send deadline.
+const TRANSPORT_PACKET_MAX_AGE: Duration = Duration::from_secs(5);
+
+#[derive(Debug)]
+struct QueuedTransportPacket {
+    data: Vec<u8>,
+    enqueued_at: Instant,
+}
 
 #[derive(Debug)]
 struct TransportIoError {
@@ -1586,18 +2806,27 @@ type SharedTransportError = Arc<SyncMutex<Option<TransportIoError>>>;
 #[derive(Debug)]
 struct TransportQuinnSocket {
     remote: SocketAddr,
-    outbound: tokio::sync::mpsc::Sender<Vec<u8>>,
+    outbound: tokio::sync::mpsc::Sender<QueuedTransportPacket>,
     inbound: SyncMutex<tokio::sync::mpsc::Receiver<Vec<u8>>>,
     send_error: SharedTransportError,
     recv_error: SharedTransportError,
     recv_waker: SharedRecvWaker,
     tasks: Mutex<Vec<tokio::task::JoinHandle<()>>>,
+    metrics_enabled: bool,
 }
 
 impl TransportQuinnSocket {
     fn new(transport: Arc<dyn PacketTransport>, remote: SocketAddr) -> Arc<Self> {
+        Self::new_with_metrics(transport, remote, false)
+    }
+
+    fn new_with_metrics(
+        transport: Arc<dyn PacketTransport>,
+        remote: SocketAddr,
+        metrics_enabled: bool,
+    ) -> Arc<Self> {
         let (outbound_tx, mut outbound_rx) =
-            tokio::sync::mpsc::channel::<Vec<u8>>(TRANSPORT_QUEUE_CAP);
+            tokio::sync::mpsc::channel::<QueuedTransportPacket>(TRANSPORT_QUEUE_CAP);
         let (inbound_tx, inbound_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(TRANSPORT_QUEUE_CAP);
         let send_error = Arc::new(SyncMutex::new(None));
         let recv_error = Arc::new(SyncMutex::new(None));
@@ -1608,20 +2837,56 @@ impl TransportQuinnSocket {
             let recv_waker = Arc::clone(&recv_waker);
             async move {
                 let mut first_datagram = true;
-                while let Some(data) = outbound_rx.recv().await {
-                    let result = if first_datagram {
-                        transport.send_packet_confirmed(&data).await
-                    } else {
-                        transport.send_packet(&data).await
+                while let Some(queued) = outbound_rx.recv().await {
+                    if queued.enqueued_at.elapsed() >= TRANSPORT_PACKET_MAX_AGE {
+                        if metrics_enabled {
+                            record_transport_tx_drop();
+                        }
+                        continue;
+                    }
+                    let first = first_datagram;
+                    let data = queued.data;
+                    let timeout = transport.send_timeout().max(Duration::from_millis(1));
+                    let attempt = QuicSendAttempt::new(transport.as_ref());
+                    let result = tokio::time::timeout(timeout, async {
+                        if first {
+                            transport.send_packet_confirmed(&data).await
+                        } else {
+                            transport.send_packet(&data).await
+                        }
+                    })
+                    .await;
+                    let timed_out = match &result {
+                        Err(_) => true,
+                        Ok(Err(error)) => error.kind() == io::ErrorKind::TimedOut,
+                        Ok(Ok(())) => false,
+                    };
+                    let result = match result {
+                        Ok(result) => result,
+                        Err(_) => Err(io::Error::new(
+                            io::ErrorKind::TimedOut,
+                            "QUIC PacketTransport send deadline exceeded",
+                        )),
                     };
                     match result {
-                        Ok(()) => first_datagram = false,
+                        Ok(()) => {
+                            first_datagram = false;
+                            attempt.success();
+                        }
                         Err(error) => {
+                            if timed_out {
+                                attempt.timeout();
+                            } else {
+                                attempt.failure();
+                            }
                             let congestion = packet_error_class(&error)
                                 == PacketErrorClass::Congestion
                                 || (error.kind() == io::ErrorKind::TimedOut
                                     && transport.send_timeout_is_congestion());
                             if congestion {
+                                if metrics_enabled {
+                                    record_transport_tx_drop();
+                                }
                                 continue;
                             }
                             *send_error.lock() = Some(TransportIoError::fatal(error));
@@ -1664,8 +2929,21 @@ impl TransportQuinnSocket {
                     }
                     // A full queue drops the datagram (UDP semantics); the
                     // transport read must never backpressure or allocate for a drop.
-                    if let Ok(permit) = inbound_tx.try_reserve() {
-                        permit.send(buf[..n].to_vec());
+                    match inbound_tx.try_reserve() {
+                        Ok(permit) => permit.send(buf[..n].to_vec()),
+                        Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                            if metrics_enabled {
+                                record_transport_rx_drop();
+                            }
+                        }
+                        Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                            *recv_error.lock() = Some(TransportIoError::fatal(io::Error::new(
+                                io::ErrorKind::BrokenPipe,
+                                "QUIC adapter receive queue closed",
+                            )));
+                            wake_recv(&recv_waker);
+                            return;
+                        }
                     }
                 }
             }
@@ -1678,6 +2956,7 @@ impl TransportQuinnSocket {
             recv_error,
             recv_waker,
             tasks: Mutex::new(vec![sender, receiver]),
+            metrics_enabled,
         })
     }
 
@@ -1719,8 +2998,10 @@ impl Drop for TransportQuinnSocket {
     }
 }
 
-type TransportSendPermit =
-    Result<tokio::sync::mpsc::OwnedPermit<Vec<u8>>, tokio::sync::mpsc::error::SendError<()>>;
+type TransportSendPermit = Result<
+    tokio::sync::mpsc::OwnedPermit<QueuedTransportPacket>,
+    tokio::sync::mpsc::error::SendError<()>,
+>;
 
 struct TransportUdpPoller {
     socket: Arc<TransportQuinnSocket>,
@@ -1762,7 +3043,6 @@ impl quinn::UdpPoller for TransportUdpPoller {
         }
     }
 }
-
 impl quinn::AsyncUdpSocket for TransportQuinnSocket {
     fn create_io_poller(self: Arc<Self>) -> Pin<Box<dyn quinn::UdpPoller>> {
         Box::pin(TransportUdpPoller {
@@ -1790,10 +3070,16 @@ impl quinn::AsyncUdpSocket for TransportQuinnSocket {
 
         match self.outbound.try_reserve() {
             Ok(permit) => {
-                permit.send(transmit.contents.to_vec());
+                permit.send(QueuedTransportPacket {
+                    data: transmit.contents.to_vec(),
+                    enqueued_at: Instant::now(),
+                });
                 Ok(())
             }
             Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                if self.metrics_enabled {
+                    record_transport_tx_would_block();
+                }
                 Err(io::Error::from(io::ErrorKind::WouldBlock))
             }
             Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => Err(self
@@ -1801,7 +3087,6 @@ impl quinn::AsyncUdpSocket for TransportQuinnSocket {
                 .unwrap_or_else(|| io::Error::from(io::ErrorKind::BrokenPipe))),
         }
     }
-
     fn poll_recv(
         &self,
         cx: &mut Context<'_>,
@@ -1821,12 +3106,17 @@ impl quinn::AsyncUdpSocket for TransportQuinnSocket {
         for (buf, meta_slot) in bufs.iter_mut().zip(meta.iter_mut()) {
             match inbound.poll_recv(cx) {
                 Poll::Ready(Some(data)) => {
-                    // quic-go may coalesce a 1280-byte first flight despite the
-                    // 1252-byte advertisement. Preserve complete leading packets
-                    // as a bounded native UDP receive would; Quinn discards a
-                    // truncated tail and requests retransmission.
-                    let len = data.len().min(buf.len());
-                    buf[..len].copy_from_slice(&data[..len]);
+                    // The endpoint advertises a 1252-byte receive buffer. Never hand Quinn a
+                    // truncated packet: a partial QUIC packet is indistinguishable from wire
+                    // corruption. Fail the adapter so the caller can redial with a safe path.
+                    if data.len() > buf.len() {
+                        return Poll::Ready(Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "PacketTransport returned a datagram larger than the QUIC receive buffer",
+                        )));
+                    }
+                    let len = data.len();
+                    buf[..len].copy_from_slice(&data);
                     *meta_slot = quinn::udp::RecvMeta {
                         addr: self.remote,
                         len,
@@ -1846,10 +3136,14 @@ impl quinn::AsyncUdpSocket for TransportQuinnSocket {
                     };
                 }
                 Poll::Pending => {
-                    return if count == 0 {
-                        Poll::Pending
+                    if count != 0 {
+                        return Poll::Ready(Ok(count));
+                    }
+                    drop(inbound);
+                    return if let Some(error) = self.terminal_error() {
+                        Poll::Ready(Err(error))
                     } else {
-                        Poll::Ready(Ok(count))
+                        Poll::Pending
                     };
                 }
             }
@@ -1909,10 +3203,21 @@ impl PacketTransportEndpoint {
 }
 
 /// Create a [`PacketTransportEndpoint`] pinned to `remote` with the safe
-/// 1252-byte UDP payload cap.
+/// 1252-byte UDP payload cap. Metrics are disabled because this constructor is
+/// also used by temporary health probes.
 pub fn packet_transport_endpoint(
     transport: Arc<dyn PacketTransport>,
     remote: SocketAddr,
+) -> io::Result<PacketTransportEndpoint> {
+    packet_transport_endpoint_with_metrics(transport, remote, false)
+}
+
+/// Create a packet-backed endpoint whose adapter pressure counters belong to a
+/// persistent pooled DNS connection.
+pub fn packet_transport_endpoint_with_metrics(
+    transport: Arc<dyn PacketTransport>,
+    remote: SocketAddr,
+    metrics_enabled: bool,
 ) -> io::Result<PacketTransportEndpoint> {
     if transport.relay_addr() != remote {
         return Err(io::Error::new(
@@ -1922,7 +3227,11 @@ pub fn packet_transport_endpoint(
     }
     let runtime = quinn::default_runtime()
         .ok_or_else(|| io::Error::other("no async runtime available for QUIC"))?;
-    let socket = TransportQuinnSocket::new(transport, remote);
+    let socket = if metrics_enabled {
+        TransportQuinnSocket::new_with_metrics(transport, remote, true)
+    } else {
+        TransportQuinnSocket::new(transport, remote)
+    };
     let endpoint = Endpoint::new_with_abstract_socket(
         endpoint_config_with_mtu(1252)?,
         None,
@@ -1957,7 +3266,6 @@ pub async fn quic_handshake_probe(
         .context("QUIC handshake timeout")??;
     let elapsed = start.elapsed();
     conn.close(quinn::VarInt::from_u32(0), b"probe");
-    // `wait_idle` cannot complete while this handle is still alive.
     drop(conn);
     endpoint.close(Duration::ZERO).await;
     Ok(elapsed)
@@ -2289,9 +3597,9 @@ mod probe_tests {
         .unwrap_err();
         assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
 
-        let mut data = [0; 64];
+        let mut data = [0u8; 64];
         let mut meta = [quinn::udp::RecvMeta::default()];
-        let received = tokio::time::timeout(
+        let error = tokio::time::timeout(
             Duration::from_secs(1),
             std::future::poll_fn(|cx| {
                 let mut bufs = [std::io::IoSliceMut::new(&mut data)];
@@ -2300,11 +3608,8 @@ mod probe_tests {
         )
         .await
         .unwrap()
-        .unwrap();
-        assert_eq!(received, 1);
-        assert_eq!(meta[0].len, data.len());
-        assert_eq!(data, [0x5a; 64]);
-        assert_eq!(meta[0].addr, remote);
+        .unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
     }
 
     #[tokio::test]

--- a/crates/honk-outbound/src/quic.rs
+++ b/crates/honk-outbound/src/quic.rs
@@ -1910,7 +1910,14 @@ impl<C: Send + Sync + 'static> QuicClient<C> {
         };
         state.endpoint = Some((ipv6, endpoint.clone()));
         let mut close_guard = ConnectionCloseGuard::new(conn.clone());
-        let ctx = setup(conn.clone()).await?;
+        let ctx = match setup(conn.clone()).await {
+            Ok(ctx) => ctx,
+            Err(error) => {
+                close_guard.disarm();
+                conn.close(VarInt::from_u32(0), b"setup failed");
+                return Err(error);
+            }
+        };
         let ctx = Arc::new(ctx);
         // The single-flight mutex makes this unreachable today; keep the
         // freshly dialed connection out of a closed client if that changes.

--- a/crates/honk-outbound/src/runtime.rs
+++ b/crates/honk-outbound/src/runtime.rs
@@ -35,13 +35,13 @@ pub enum GenerationRuntime {
 }
 
 impl GenerationRuntime {
-    pub(crate) fn build(self) -> ProtocolRuntime {
+    pub(crate) fn build(self, metrics_enabled: bool) -> ProtocolRuntime {
         match self {
             Self::None => ProtocolRuntime::None,
             Self::AnyTls => ProtocolRuntime::AnyTls(AnyTlsRuntime::new()),
             Self::VlessH2Mux => ProtocolRuntime::VlessMux(VlessMuxRuntime::h2()),
             Self::VlessCoolMux => ProtocolRuntime::VlessMux(VlessMuxRuntime::cool()),
-            Self::Quic => ProtocolRuntime::Quic(QuicRuntime::new()),
+            Self::Quic => ProtocolRuntime::Quic(QuicRuntime::new(metrics_enabled)),
         }
     }
 }
@@ -67,6 +67,8 @@ pub enum ProtocolRuntime {
 #[async_trait::async_trait]
 pub trait QuicRuntimeClient: Send + Sync + 'static {
     fn into_erased(self: Arc<Self>) -> Arc<dyn std::any::Any + Send + Sync>;
+    /// Start aggregate telemetry for a persistent QUIC client.
+    async fn enable_metrics(&self) {}
     /// Close the cached connection and endpoint, awaiting any in-flight
     /// dial so its late-arriving connection is closed too.
     async fn force_close(&self);
@@ -89,6 +91,7 @@ pub struct QuicRuntime {
 struct QuicRuntimeState {
     client: Option<Arc<dyn QuicRuntimeClient>>,
     closed: bool,
+    metrics_enabled: bool,
 }
 
 impl std::fmt::Debug for QuicRuntime {
@@ -96,11 +99,13 @@ impl std::fmt::Debug for QuicRuntime {
         f.debug_struct("QuicRuntime").finish_non_exhaustive()
     }
 }
-
 impl QuicRuntime {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(metrics_enabled: bool) -> Self {
         Self {
-            state: tokio::sync::Mutex::new(QuicRuntimeState::default()),
+            state: tokio::sync::Mutex::new(QuicRuntimeState {
+                metrics_enabled,
+                ..Default::default()
+            }),
         }
     }
 
@@ -121,6 +126,9 @@ impl QuicRuntime {
                 .map_err(|_| anyhow::anyhow!("QUIC client slot type mismatch"));
         }
         let client = build().await?;
+        if state.metrics_enabled {
+            client.enable_metrics().await;
+        }
         state.client = Some(Arc::clone(&client) as Arc<dyn QuicRuntimeClient>);
         Ok(client)
     }
@@ -143,7 +151,13 @@ impl QuicRuntime {
                 .into_erased()
                 .downcast::<T>()
                 .map_err(|_| anyhow::anyhow!("QUIC client slot type mismatch"))?;
+            if state.metrics_enabled {
+                client.enable_metrics().await;
+            }
             return Ok(());
+        }
+        if state.metrics_enabled {
+            client.enable_metrics().await;
         }
         state.client = Some(client as Arc<dyn QuicRuntimeClient>);
         Ok(())
@@ -456,7 +470,7 @@ impl NodeRuntime {
             udp_capable: (crate::descriptor::descriptor(node.protocol()).supports_udp)(node),
             runtime: crate::descriptor::descriptor(node.protocol())
                 .generation_runtime(node)
-                .build(),
+                .build(false),
             ephemeral: true,
             warm_retention: Arc::new(tokio::sync::Mutex::new(0)),
         })
@@ -1023,7 +1037,7 @@ impl OutboundRuntimeRegistry {
                     ),
                     runtime: crate::descriptor::descriptor(node.protocol())
                         .generation_runtime(node)
-                        .build(),
+                        .build(true),
                     ephemeral: false,
                     warm_retention: Arc::new(tokio::sync::Mutex::new(0)),
                 }),
@@ -1803,7 +1817,7 @@ mod tests {
 
     #[tokio::test]
     async fn speculative_quic_publish_keeps_a_concurrent_incumbent() {
-        let runtime = QuicRuntime::new();
+        let runtime = QuicRuntime::new(true);
         let incumbent: Arc<FakeQuicClient> = runtime
             .client(|| async { Ok(Arc::new(FakeQuicClient::default())) })
             .await
@@ -1824,7 +1838,7 @@ mod tests {
 
     #[tokio::test]
     async fn cancelled_quic_publish_before_slot_lock_changes_nothing() {
-        let runtime = Arc::new(QuicRuntime::new());
+        let runtime = Arc::new(QuicRuntime::new(true));
         let state_guard = runtime.state.lock().await;
         let detached = Arc::new(FakeQuicClient::default());
         let detached_weak = Arc::downgrade(&detached);
@@ -1891,7 +1905,7 @@ mod tests {
 
     #[tokio::test]
     async fn quic_runtime_close_covers_client_and_rejects_new_builds() {
-        let runtime = QuicRuntime::new();
+        let runtime = QuicRuntime::new(true);
         let client: Arc<FakeQuicClient> = runtime
             .client(|| async { Ok(Arc::new(FakeQuicClient::default())) })
             .await

--- a/doc/en/design/outbound.md
+++ b/doc/en/design/outbound.md
@@ -467,6 +467,18 @@ pair. When the holder replaces a closed or invalidated connection, new work
 uses the replacement while existing flows can finish on their old clones.
 Dropping final warm ownership removes future reuse without cutting active flows.
 
+Each pooled QUIC connection samples Quinn path and UDP I/O counters once per
+second for the aggregate `quic` section of `/stats`. Temporary URL/health probe
+connections are intentionally excluded.
+Native TUIC and Hysteria2 UDP
+endpoints use a per-send deadline of `clamp(4 × SRTT, 1 s, 5 s)`. Three
+consecutive send deadlines, or no newly acknowledged QUIC packet is observed for
+`max(8 × SRTT, 10 s)`, retires the endpoint and closes that connection so the
+next flow redials. A successful send resets the send streak; observed delivery
+progress resets both clocks. Attempted UDP packets are never replayed. TUIC
+also enables Quinn PING keepalive, including its UDP-over-stream fallback where
+protocol heartbeat datagrams are unavailable.
+
 ### Protocol contracts
 
 | Protocol | Authentication and TCP | UDP | Transport policy |

--- a/doc/en/reference/api.md
+++ b/doc/en/reference/api.md
@@ -91,6 +91,13 @@ A non-empty `external_ui_download_detour` forces the initial request and redirec
 {
   outbounds: [{ name, totalConns, activeConns, upload, download, errors }],
   pool: { readyHits, readyMisses, entries },
+  quic: {
+    activeConnections, srttUs, cwndBytes, lossRatePpm, sentPackets, ackFrames,
+    lostPackets, sentPlpmtudProbes, lostPlpmtudProbes, currentMtu, blackHoles,
+    congestionEvents, txBytes, rxBytes, txDatagrams, rxDatagrams, txIos, rxIos,
+    transportTxWouldBlock, transportTxDrops, transportRxDrops, sessionRxDrops,
+    sendTimeouts, pathStalls
+  },
   warm: {
     nodes: { preconnect, health, udp, selector, traffic },
     sessions: { anytls, vless, tuic, juicity, hysteria2 }
@@ -138,6 +145,22 @@ R = {
 | `activeFlows` | Accepted transparent TCP flows currently holding an admission permit. |
 | `limit` | Current process-wide TCP-flow admission ceiling; it starts at the descriptor-derived floor and scales with idle descriptor headroom. |
 | `capacity.rejected` | Monotonic count of accept-loop iterations that waited for a permit because the TCP budget was full; accepted sockets remain in the kernel backlog rather than being dropped. |
+
+### QUIC fields
+
+`srttUs`, `cwndBytes`, and `currentMtu` are averages across active connections and are
+zero when none are active. Packet, byte, I/O, loss, black-hole, and congestion
+counters include completed pooled connections. `ackFrames` counts received ACK
+frames and is a path-progress signal; duplicate ACK frames may count more than
+once. `lossRatePpm` excludes PLPMTUD probes: its denominator is
+`sentPackets - sentPlpmtudProbes`, while `lostPackets` likewise excludes probe
+losses. `sentPlpmtudProbes` and `lostPlpmtudProbes` expose those probes separately.
+`txIos` and `rxIos` expose batching efficiency. `transportTxWouldBlock` counts
+full 64-packet adapter queues (Quinn retries); `transportTxDrops` counts
+datagrams intentionally discarded after the proxied transport reports
+congestion or timeout. `transportRxDrops` counts full adapter receive queues,
+and `sessionRxDrops` counts full 256-packet TUIC/Hysteria2 session queues.
+`sendTimeouts` and `pathStalls` are process-lifetime recovery events.
 
 ### Score selection-reason fields
 

--- a/doc/zh/design/outbound.md
+++ b/doc/zh/design/outbound.md
@@ -424,6 +424,15 @@ pair。当 holder 替换已关闭或失效连接时，新工作使用 replacemen
 flow 可以在旧 clone 上完成。移除最后一份 warm 所有权只会移除未来复用，
 不会切断 active flow。
 
+每条池化 QUIC connection 每秒采样一次 Quinn path 与 UDP I/O counter，汇总到
+`/stats` 的 `quic` 字段；临时 URL/健康探测连接明确排除。
+endpoint 的单次发送截止时间为 `clamp(4 × SRTT, 1 s, 5 s)`。连续三次发送
+超时，或超过 `max(8 × SRTT, 10 s)` 没有新的 QUIC packet 被确认，endpoint 会被退役
+并关闭该 connection，让下一条 flow 重新拨号。发送成功会重置超时 streak；确认进度
+会同时重置两个时钟；已尝试的 UDP 报文绝不重放。TUIC 还启用 Quinn
+PING keepalive，包括无法发送协议 heartbeat datagram 的 UDP-over-stream
+fallback。
+
 ### 协议契约
 
 | 协议 | 认证与 TCP | UDP | Transport 策略 |

--- a/doc/zh/reference/api.md
+++ b/doc/zh/reference/api.md
@@ -91,6 +91,13 @@ Hysteria2 还遵循 sing-box 的 lazy-handshake 规则：其目标请求与首�
 {
   outbounds: [{ name, totalConns, activeConns, upload, download, errors }],
   pool: { readyHits, readyMisses, entries },
+  quic: {
+    activeConnections, srttUs, cwndBytes, lossRatePpm, sentPackets, ackFrames,
+    lostPackets, sentPlpmtudProbes, lostPlpmtudProbes, currentMtu, blackHoles,
+    congestionEvents, txBytes, rxBytes, txDatagrams, rxDatagrams, txIos, rxIos,
+    transportTxWouldBlock, transportTxDrops, transportRxDrops, sessionRxDrops,
+    sendTimeouts, pathStalls
+  },
   warm: {
     nodes: { preconnect, health, udp, selector, traffic },
     sessions: { anytls, vless, tuic, juicity, hysteria2 }
@@ -138,6 +145,10 @@ R = {
 | `activeFlows` | 当前持有 TCP admission permit 的透明 TCP 流。 |
 | `limit` | 当前进程级 TCP 流准入上限；从描述符导出的 floor 开始，并随空闲描述符余量动态扩缩。 |
 | `capacity.rejected` | 因 TCP 预算已满而等待 permit 的 accept-loop 单调计数；accepted socket 保留在内核 backlog 中，不会被丢弃。 |
+
+### QUIC 字段
+
+`srttUs`、`cwndBytes` 与 `currentMtu` 是活动连接的平均值；没有活动连接时为零。报文、字节、I/O、丢包、黑洞和拥塞计数包含已完成的池化连接。`ackFrames` 统计收到的 ACK frame，是路径进度信号；重复 ACK frame 可能被重复计数。`lossRatePpm` 排除 PLPMTUD 探测：分母为 `sentPackets - sentPlpmtudProbes`，而 `lostPackets` 同样不包含探测丢包。`sentPlpmtudProbes` 与 `lostPlpmtudProbes` 单独暴露探测计数。`txIos` 与 `rxIos` 表示批处理效率。`transportTxWouldBlock` 统计满载的 64 包 adapter 队列（Quinn 会重试）；底层代理报告拥塞或超时后主动丢弃的报文计入 `transportTxDrops`；满载的 adapter 接收队列计入 `transportRxDrops`，满载的 TUIC/Hysteria2 256 包会话队列计入 `sessionRxDrops`。`sendTimeouts` 与 `pathStalls` 是进程生命周期内的恢复事件。
 
 ### Score 选路原因字段
 


### PR DESCRIPTION
## Summary

- expose aggregate pooled-QUIC RTT, loss, congestion, MTU, UDP I/O, queue-drop, timeout, and stall counters through `/stats.quic`
- expire queued UDP datagrams from their original receive time; use `clamp(4 × SRTT, 1s, 5s)` QUIC send deadlines and retire paths after three deadlines or `max(8 × SRTT, 10s)` without ACK progress
- keep TUIC UDP-over-stream fallback alive with QUIC PINGs and account bounded TUIC, Hysteria2, Juicity, and QUIC transport queue drops
- preserve cancellation, DNS-fallback, NFQUEUE, and endpoint-generation ordering while carrying receive timestamps end to end

## Verification

- `just outbound-ci`
- `cargo clippy -p honk-core --all-targets -- -D warnings`
- `cargo test -p honk-core --lib control::tests::udp_dns` — 5 passed
- `cargo test -p honk-outbound quic::path_health_tests` — 8 passed
- four independent final reviews: all findings fixed; correctness and performance re-reviews clean

## Performance and stability

Bench worktree: `/root/code/honk-bench-live`, branch `bench`. Baseline `d6e3b5c`; candidate built from this branch.

- 20 interleaved loopback pairs × 100 samples per arm: median total-time deltas were Hy2 `-0.24%`, TUIC `-0.37%`, Juicity `-0.43%`; no throughput-path regression signal
- 5,000 sequential handshakes per arm/protocol completed with stable RSS
- 80 ms / 1% loss netem: baseline and candidate completed 10/10 for Hy2, TUIC, and Juicity
- repeated 200 ms / 3% loss TUIC batches: candidate completed 7/8 batches versus baseline 5/8; successful-batch medians remained near 0.8 s
- 600 ms / 10% loss exceeded the unchanged fixed probe deadline for both arms; not treated as comparative evidence

P1 adaptive receive-window control remains a separate change because it requires additional Quinn flow-control APIs and a separate high-BDP benchmark gate.
