### PR TITLE
fix(outbound): stop session-pool stalls behind dial backoff and speculative capacity

### DIFF
--- a/crates/honk-outbound/src/session.rs
+++ b/crates/honk-outbound/src/session.rs
@@ -16,9 +16,11 @@
 //!   drops and only an explicit winner commit may publish; provisional slots
 //!   bound speculative work only — normal offers are bounded by real sessions,
 //!   so hung speculative dials can never starve them;
-//! - dial circuit breaker: consecutive establishment failures back off
-//!   exponentially before the pool dials again (a dead server must not
-//!   eat a TCP connect per proxied flow);
+//! - dial circuit breaker: consecutive establishment failures (including
+//!   dead-on-arrival sessions) pace redials with a capped backoff, and
+//!   callers fail fast inside the window instead of parking — a dead server
+//!   neither eats a TCP connect per proxied flow nor stalls flows until
+//!   their outer dial deadline;
 //! - RAII stream-slot permits (`SessionPermit`) as the single capacity
 //!   truth, and [`SessionPool::open_with`] for atomic reserve+open;
 //! - idle reaping, jittered max-age drains and optional prewarm
@@ -378,6 +380,29 @@ impl<S: ManagedSession + 'static> SessionPool<S> {
         PoolState::from(self.state.load(Ordering::Acquire))
     }
 
+    /// Active session count for diagnostics (capacity-park logging).
+    fn active_session_total(&self) -> usize {
+        self.pool
+            .lock()
+            .sessions
+            .iter()
+            .filter(|session| session.state() == SessionState::Active)
+            .count()
+    }
+
+    /// Record one establishment failure and arm the redial backoff. A session
+    /// that is dead on arrival (closed before it could serve a stream) also
+    /// counts — treating it as success would reset the breaker and let the
+    /// pool hot-spin against a server that kills every fresh session.
+    fn record_dial_failure(pool: &mut KeyPool<S>, config: &SessionPoolConfig) -> Duration {
+        pool.dial_failures += 1;
+        let shift = pool.dial_failures.min(8) - 1;
+        let backoff =
+            (config.dial_backoff.saturating_mul(1u32 << shift)).min(config.max_dial_backoff);
+        pool.next_dial_at = Some(Instant::now() + backoff);
+        backoff
+    }
+
     fn occupied_slots(pool: &KeyPool<S>) -> usize {
         pool.sessions
             .iter()
@@ -486,7 +511,7 @@ impl<S: ManagedSession + 'static> SessionPool<S> {
                 Have(Arc<S>),
                 Register(u64, tokio::sync::watch::Sender<DialSignal>),
                 Wait(tokio::sync::watch::Receiver<DialSignal>),
-                Backoff(Duration),
+                Backoff(Duration, u32),
                 Capacity,
             }
             let step = {
@@ -528,7 +553,7 @@ impl<S: ManagedSession + 'static> SessionPool<S> {
                         .and_then(|t| t.checked_duration_since(Instant::now()))
                         .filter(|w| *w > Duration::ZERO)
                     {
-                        candidate.map_or(Step::Backoff(wait), |session| {
+                        candidate.map_or(Step::Backoff(wait, pool.dial_failures), |session| {
                             Step::Have(Arc::clone(session))
                         })
                     } else if occupied_slots >= self.config.max_sessions {
@@ -547,6 +572,11 @@ impl<S: ManagedSession + 'static> SessionPool<S> {
                 Step::Closed => return Err(Self::pool_closed_err()),
                 Step::Have(s) => return Ok(s),
                 Step::Capacity => {
+                    tracing::debug!(
+                        active_sessions = self.active_session_total(),
+                        max = self.config.max_sessions,
+                        "offer parked on pool capacity"
+                    );
                     tokio::select! {
                         _ = self.capacity_notify.notified() => {}
                         _ = shutdown_rx.changed() => {
@@ -554,15 +584,17 @@ impl<S: ManagedSession + 'static> SessionPool<S> {
                         }
                     }
                 }
-                Step::Backoff(wait) => {
-                    tokio::select! {
-                        _ = tokio::time::sleep(wait) => {}
-                        _ = shutdown_rx.changed() => {
-                            return Err(Self::pool_closed_err());
-                        }
-                    }
+                Step::Backoff(wait, failures) => {
+                    // The breaker only paces redials; callers fail fast
+                    // instead of parking — a parked caller rode retry cycles
+                    // until its outer dial deadline killed it without a dial
+                    // ever being attempted.
+                    return Err(anyhow!(
+                        "session dial backing off ({failures} consecutive, {wait:?} remaining)"
+                    ));
                 }
                 Step::Wait(mut rx) => {
+                    tracing::debug!("offer parked on in-flight dial");
                     let signal = tokio::select! {
                         // `wait_for` checks the current value first — no
                         // race with a dial that completed before parking.
@@ -596,14 +628,29 @@ impl<S: ManagedSession + 'static> SessionPool<S> {
                         // A previous Register in this very call consumed
                         // the closure, and the freshly dialed session was
                         // dead on arrival (pruned before it could be
-                        // offered) — fail instead of panic/re-dialing.
-                        return Err(anyhow!("session established but immediately unusable"));
+                        // offered). This second registration never spawns a
+                        // dial, so its inflight entry is a phantom: clear it
+                        // (dropping the sender wakes the waiters to re-elect)
+                        // and count the dead session as a dial failure so the
+                        // breaker paces redials instead of hot-spinning
+                        // against a server that kills every fresh session.
+                        let backoff = {
+                            let mut pool = self.pool.lock();
+                            if pool.dial_done.as_ref().map(|(i, _)| *i) == Some(id) {
+                                pool.dial_done = None;
+                            }
+                            Self::record_dial_failure(&mut pool, &self.config)
+                        };
+                        return Err(anyhow!(
+                            "session established but immediately unusable (backoff {backoff:?})"
+                        ));
                     };
                     let task_pool = Arc::clone(&self.pool);
                     let task_state = Arc::clone(&self.state);
                     let config = self.config.clone();
                     let mut task_shutdown_rx = self.shutdown_tx.subscribe();
                     let dial_scope = crate::runtime::capture_dial_scope();
+                    tracing::debug!(id, "pool dial task spawned");
                     tokio::spawn(dial_scope.scope(async move {
                         let mut guard = DialGuard {
                             pool: Arc::clone(&task_pool),
@@ -638,16 +685,13 @@ impl<S: ManagedSession + 'static> SessionPool<S> {
                                     Ok(Ok(session)) => {
                                         pool.dial_failures = 0;
                                         pool.next_dial_at = None;
+                                        tracing::debug!(id, "pool dial succeeded");
                                         pool.sessions.push(session);
                                         DialSignal::Done
                                     }
                                     Ok(Err(e)) => {
-                                        pool.dial_failures += 1;
-                                        let shift = pool.dial_failures.min(8) - 1;
                                         let backoff =
-                                            (config.dial_backoff.saturating_mul(1u32 << shift))
-                                                .min(config.max_dial_backoff);
-                                        pool.next_dial_at = Some(Instant::now() + backoff);
+                                            Self::record_dial_failure(&mut pool, &config);
                                         // The waiter only sees the outer context; keep
                                         // the full chain available for diagnostics.
                                         tracing::debug!(
@@ -756,10 +800,9 @@ impl<S: ManagedSession + 'static> SessionPool<S> {
                     }
                 }
                 Step::Backoff(wait) => {
-                    tokio::select! {
-                        _ = tokio::time::sleep(wait) => {}
-                        _ = shutdown_rx.changed() => return Err(Self::pool_closed_err()),
-                    }
+                    // Same fast-fail contract as offer(): speculative callers
+                    // are exploratory by definition and must not park.
+                    return Err(anyhow!("session dial backing off ({wait:?} remaining)"));
                 }
                 Step::Wait(mut rx) => {
                     let signal = tokio::select! {
@@ -1888,27 +1931,86 @@ mod tests {
             max_dial_backoff: Duration::from_secs(60),
             ..Default::default()
         });
-        let fail = || async { anyhow::bail!("boom") };
+        let dials = Arc::new(AtomicUsize::new(0));
+        let offer_once = |dials: &Arc<AtomicUsize>| {
+            let dials = Arc::clone(dials);
+            pool.offer(move || async move {
+                dials.fetch_add(1, Ordering::Relaxed);
+                anyhow::bail!("boom")
+            })
+        };
+        assert!(offer_once(&dials).await.is_err());
+        assert_eq!(dials.load(Ordering::Relaxed), 1);
+        // Inside the window callers fail fast instead of parking.
         let start = Instant::now();
-        assert!(pool.offer::<fn() -> _, _>(fail).await.is_err());
+        assert!(offer_once(&dials).await.is_err());
         assert_eq!(start.elapsed(), Duration::ZERO);
-        // Second attempt waits out the backoff before re-dialing.
-        assert!(pool.offer::<fn() -> _, _>(fail).await.is_err());
-        assert!(start.elapsed() >= Duration::from_secs(10));
+        assert_eq!(dials.load(Ordering::Relaxed), 1);
+        // Past the window the pool redials: 10s base, doubling to 20s.
+        tokio::time::advance(Duration::from_secs(10)).await;
+        assert!(offer_once(&dials).await.is_err());
+        assert_eq!(dials.load(Ordering::Relaxed), 2);
+        tokio::time::advance(Duration::from_secs(15)).await;
+        assert!(offer_once(&dials).await.is_err());
+        assert_eq!(dials.load(Ordering::Relaxed), 2);
+        tokio::time::advance(Duration::from_secs(5)).await;
+        assert!(offer_once(&dials).await.is_err());
+        assert_eq!(dials.load(Ordering::Relaxed), 3);
     }
 
     #[tokio::test(start_paused = true)]
-    async fn dial_backoff_cap_keeps_redial_inside_flow_budget() {
+    async fn dial_backoff_is_capped() {
+        let pool = pool(SessionPoolConfig {
+            dial_backoff: Duration::from_secs(10),
+            max_dial_backoff: Duration::from_secs(15),
+            ..Default::default()
+        });
+        let dials = Arc::new(AtomicUsize::new(0));
+        let offer_once = |dials: &Arc<AtomicUsize>| {
+            let dials = Arc::clone(dials);
+            pool.offer(move || async move {
+                dials.fetch_add(1, Ordering::Relaxed);
+                anyhow::bail!("boom")
+            })
+        };
+        assert!(offer_once(&dials).await.is_err());
+        tokio::time::advance(Duration::from_secs(10)).await;
+        assert!(offer_once(&dials).await.is_err());
+        assert_eq!(dials.load(Ordering::Relaxed), 2);
+        // The raw doubling would give 20s; the cap holds it at 15s.
+        tokio::time::advance(Duration::from_secs(14)).await;
+        assert!(offer_once(&dials).await.is_err());
+        assert_eq!(dials.load(Ordering::Relaxed), 2);
+        tokio::time::advance(Duration::from_secs(1)).await;
+        assert!(offer_once(&dials).await.is_err());
+        assert_eq!(dials.load(Ordering::Relaxed), 3);
+    }
+
+    /// A session that dies before serving a stream counts as a dial failure:
+    /// the breaker arms and the next caller fails fast instead of hot-spinning
+    /// fresh dials against a server that kills every fresh session.
+    #[tokio::test(start_paused = true)]
+    async fn dead_on_arrival_session_engages_the_breaker() {
         let pool = pool(SessionPoolConfig::default());
-        let fail = || async { anyhow::bail!("boom") };
-        // Enough consecutive failures to push the raw backoff far past the
-        // cap; every further attempt must still redial within it.
-        for _ in 0..8 {
-            assert!(pool.offer::<fn() -> _, _>(fail).await.is_err());
-        }
-        let start = Instant::now();
-        assert!(pool.offer::<fn() -> _, _>(fail).await.is_err());
-        assert!(start.elapsed() <= Duration::from_secs(2));
+        let dials = Arc::new(AtomicUsize::new(0));
+        let offer_dead = |dials: &Arc<AtomicUsize>| {
+            let dials = Arc::clone(dials);
+            pool.offer(move || async move {
+                dials.fetch_add(1, Ordering::Relaxed);
+                let session = TestSession::new();
+                session.close();
+                Ok(session)
+            })
+        };
+        let error = offer_dead(&dials).await.unwrap_err().to_string();
+        assert!(error.contains("immediately unusable"), "{error}");
+        assert_eq!(dials.load(Ordering::Relaxed), 1);
+        let error = offer_dead(&dials).await.unwrap_err().to_string();
+        assert!(error.contains("backing off"), "{error}");
+        assert_eq!(dials.load(Ordering::Relaxed), 1);
+        tokio::time::advance(Duration::from_secs(2)).await;
+        let _ = offer_dead(&dials).await;
+        assert_eq!(dials.load(Ordering::Relaxed), 2);
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/honk-outbound/src/session.rs
+++ b/crates/honk-outbound/src/session.rs
@@ -56,7 +56,12 @@ pub struct SessionPoolConfig {
     /// First dial-failure backoff; doubles per consecutive failure up to
     /// [`Self::max_dial_backoff`].
     pub dial_backoff: Duration,
-    /// Cap for the dial-failure backoff.
+    /// Cap for the dial-failure backoff. Must stay well below a flow's dial
+    /// budget (`connect_timeout * 3`): a caller parked in a longer backoff
+    /// window dies by its own outer timeout without ever attempting a dial,
+    /// so a brief outage would keep failing flows long after the server
+    /// recovers. Single-flight already paces concurrent dials; this only
+    /// paces redials after a failure.
     pub max_dial_backoff: Duration,
     /// Max session age before it drains (no new streams; existing ones
     /// finish). Jittered ±10% per session to avoid reconnect storms.
@@ -72,7 +77,7 @@ impl Default for SessionPoolConfig {
             spread_sessions: false,
             janitor_interval: Duration::from_secs(30),
             dial_backoff: Duration::from_secs(1),
-            max_dial_backoff: Duration::from_secs(30),
+            max_dial_backoff: Duration::from_secs(2),
             max_session_age: None,
         }
     }
@@ -1867,6 +1872,7 @@ mod tests {
     async fn dial_failures_back_off() {
         let pool = pool(SessionPoolConfig {
             dial_backoff: Duration::from_secs(10),
+            max_dial_backoff: Duration::from_secs(60),
             ..Default::default()
         });
         let fail = || async { anyhow::bail!("boom") };
@@ -1876,6 +1882,20 @@ mod tests {
         // Second attempt waits out the backoff before re-dialing.
         assert!(pool.offer::<fn() -> _, _>(fail).await.is_err());
         assert!(start.elapsed() >= Duration::from_secs(10));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn dial_backoff_cap_keeps_redial_inside_flow_budget() {
+        let pool = pool(SessionPoolConfig::default());
+        let fail = || async { anyhow::bail!("boom") };
+        // Enough consecutive failures to push the raw backoff far past the
+        // cap; every further attempt must still redial within it.
+        for _ in 0..8 {
+            assert!(pool.offer::<fn() -> _, _>(fail).await.is_err());
+        }
+        let start = Instant::now();
+        assert!(pool.offer::<fn() -> _, _>(fail).await.is_err());
+        assert!(start.elapsed() <= Duration::from_secs(2));
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/honk-outbound/src/session.rs
+++ b/crates/honk-outbound/src/session.rs
@@ -13,7 +13,9 @@
 //!   (outcomes broadcast to every waiter);
 //! - caller-owned speculative checkout: atomically reserve an existing stream
 //!   permit or a provisional, cap-counted physical-dial slot that cancellation
-//!   drops and only an explicit winner commit may publish;
+//!   drops and only an explicit winner commit may publish; provisional slots
+//!   bound speculative work only — normal offers are bounded by real sessions,
+//!   so hung speculative dials can never starve them;
 //! - dial circuit breaker: consecutive establishment failures back off
 //!   exponentially before the pool dials again (a dead server must not
 //!   eat a TCP connect per proxied flow);
@@ -502,7 +504,18 @@ impl<S: ManagedSession + 'static> SessionPool<S> {
                                 && s.active_streams() < self.config.max_streams_per_session
                         })
                         .min_by_key(|s| s.active_streams());
-                    let occupied_slots = Self::occupied_slots(&pool);
+                    // The normal dial path is bounded by real sessions
+                    // only: provisional slots are caller-owned speculative
+                    // reservations that may never publish, and parked
+                    // offers have no timeout of their own — counting them
+                    // here let hung speculative work starve normal dials
+                    // until the caller's outer deadline killed them without
+                    // a dial ever being attempted.
+                    let occupied_slots = pool
+                        .sessions
+                        .iter()
+                        .filter(|session| session.state() == SessionState::Active)
+                        .count();
                     let should_spread = self.config.spread_sessions
                         && candidate.is_some_and(|session| session.active_streams() > 0)
                         && occupied_slots < self.config.max_sessions;
@@ -2036,44 +2049,24 @@ mod tests {
         assert_eq!(pool.metrics().sessions, 0);
     }
 
-    #[tokio::test]
-    async fn provisional_slot_blocks_normal_offer_until_released() {
+    #[tokio::test(start_paused = true)]
+    async fn provisional_slot_does_not_block_normal_offer() {
         let pool = Arc::new(pool(SessionPoolConfig {
             max_sessions: 1,
-            janitor_interval: Duration::from_millis(1),
             ..Default::default()
         }));
-        let reservation = match pool.checkout_speculative().await.unwrap() {
+        let _reservation = match pool.checkout_speculative().await.unwrap() {
             SpeculativeCheckout::Detached(reservation) => reservation,
             SpeculativeCheckout::Shared { .. } => panic!("empty pool cannot be shared"),
         };
-        let dials = Arc::new(AtomicUsize::new(0));
-        let offer = tokio::spawn({
-            let pool = Arc::clone(&pool);
-            let dials = Arc::clone(&dials);
-            async move {
-                pool.offer(move || async move {
-                    dials.fetch_add(1, Ordering::Relaxed);
-                    Ok(TestSession::new())
-                })
-                .await
-            }
-        });
-        tokio::time::sleep(Duration::from_millis(10)).await;
-        assert_eq!(
-            dials.load(Ordering::Relaxed),
-            0,
-            "a provisional slot counts against normal pool-owned dial admission"
-        );
-
-        drop(reservation);
-        let session = tokio::time::timeout(Duration::from_secs(1), offer)
+        // A held speculative reservation must not park the normal dial path:
+        // parked offers have no timeout of their own, so a hung speculative
+        // dial would otherwise kill real flows at their outer deadline.
+        let session = pool
+            .offer(|| async { Ok(TestSession::new()) })
             .await
-            .expect("normal offer remained blocked after provisional release")
-            .unwrap()
             .unwrap();
         assert!(!session.is_closed());
-        assert_eq!(dials.load(Ordering::Relaxed), 1);
     }
 
     #[tokio::test]

--- a/crates/honk-outbound/src/session.rs
+++ b/crates/honk-outbound/src/session.rs
@@ -60,12 +60,10 @@ pub struct SessionPoolConfig {
     /// First dial-failure backoff; doubles per consecutive failure up to
     /// [`Self::max_dial_backoff`].
     pub dial_backoff: Duration,
-    /// Cap for the dial-failure backoff. Must stay well below a flow's dial
-    /// budget (`connect_timeout * 3`): a caller parked in a longer backoff
-    /// window dies by its own outer timeout without ever attempting a dial,
-    /// so a brief outage would keep failing flows long after the server
-    /// recovers. Single-flight already paces concurrent dials; this only
-    /// paces redials after a failure.
+    /// Cap for the dial-failure backoff. Callers fail fast inside the
+    /// window, so this cap is the recovery latency after a failure: how soon
+    /// the next arriving flow redials. Keep it small — single-flight already
+    /// paces concurrent dials.
     pub max_dial_backoff: Duration,
     /// Max session age before it drains (no new streams; existing ones
     /// finish). Jittered ±10% per session to avoid reconnect storms.
@@ -380,7 +378,6 @@ impl<S: ManagedSession + 'static> SessionPool<S> {
         PoolState::from(self.state.load(Ordering::Acquire))
     }
 
-    /// Active session count for diagnostics (capacity-park logging).
     fn active_session_total(&self) -> usize {
         self.pool
             .lock()
@@ -529,13 +526,11 @@ impl<S: ManagedSession + 'static> SessionPool<S> {
                                 && s.active_streams() < self.config.max_streams_per_session
                         })
                         .min_by_key(|s| s.active_streams());
-                    // The normal dial path is bounded by real sessions
-                    // only: provisional slots are caller-owned speculative
-                    // reservations that may never publish, and parked
-                    // offers have no timeout of their own — counting them
-                    // here let hung speculative work starve normal dials
-                    // until the caller's outer deadline killed them without
-                    // a dial ever being attempted.
+                    // Normal offers are bounded by real sessions only:
+                    // provisional slots belong to caller-owned speculative
+                    // dials that may never publish — counting them here once
+                    // let hung speculative work park normal dials with no
+                    // timeout of their own.
                     let occupied_slots = pool
                         .sessions
                         .iter()
@@ -586,9 +581,7 @@ impl<S: ManagedSession + 'static> SessionPool<S> {
                 }
                 Step::Backoff(wait, failures) => {
                     // The breaker only paces redials; callers fail fast
-                    // instead of parking — a parked caller rode retry cycles
-                    // until its outer dial deadline killed it without a dial
-                    // ever being attempted.
+                    // instead of parking inside the window.
                     return Err(anyhow!(
                         "session dial backing off ({failures} consecutive, {wait:?} remaining)"
                     ));
@@ -625,15 +618,13 @@ impl<S: ManagedSession + 'static> SessionPool<S> {
                     // Pool-owned dial task: no caller's cancellation can
                     // poison it; the DialGuard is the panic backstop.
                     let Some(dial_fut) = dial.take().map(|d| d()) else {
-                        // A previous Register in this very call consumed
-                        // the closure, and the freshly dialed session was
-                        // dead on arrival (pruned before it could be
-                        // offered). This second registration never spawns a
-                        // dial, so its inflight entry is a phantom: clear it
-                        // (dropping the sender wakes the waiters to re-elect)
-                        // and count the dead session as a dial failure so the
-                        // breaker paces redials instead of hot-spinning
-                        // against a server that kills every fresh session.
+                        // The closure was consumed by this call's earlier
+                        // Register, and the fresh session was pruned dead on
+                        // arrival. This second registration spawns no task,
+                        // so its inflight entry is a phantom nobody will ever
+                        // signal: clear it (dropping the sender wakes waiters
+                        // to re-elect) and count the dead session as a dial
+                        // failure so the breaker paces redials.
                         let backoff = {
                             let mut pool = self.pool.lock();
                             if pool.dial_done.as_ref().map(|(i, _)| *i) == Some(id) {


### PR DESCRIPTION
## Symptom

User report: healthy AnyTLS nodes intermittently fail every dial with `dial timed out after 9s` while HTTP health checks through the same node succeed in ~230ms. Reproduced live on the production gateway with a large AnyTLS subscription whose servers kill some fresh sessions instantly.

## Root cause (one defect chain in `SessionPool`)

A server that accepts the dial but kills the session immediately ("dead on arrival") drives the pool into a state where every later flow parks until its outer dial deadline (`connect_timeout * 3` = 9s) kills it — with zero dial activity in between:

1. **Dial "success" hid the failure from the breaker.** The dial task completes (TCP+TLS+auth all fine), pushes the session, and resets `dial_failures`; the session dies microseconds later. The breaker never engages, so the pool hot-spins fresh dials every ~170ms (instrumented on the gateway) and waiters that keep losing the re-registration race ride `Step::Wait` until their 9s budget expires.
2. **The dead-on-arrival error path left a phantom in-flight dial.** When the registering caller loops back, finds the fresh session already pruned, and errors out ("session established but immediately unusable"), it had *already* published `pool.dial_done = Some((id, Pending))` for its second registration and never spawned the task. No task, no `DialGuard`, no cleanup: every subsequent `offer()` parks in `Step::Wait` on a channel nobody will ever signal. The wedge is permanent until restart — and health checks never see it because cold reusable nodes are probed through guarded ephemeral pools (`probers.rs`). This was the dominant production failure: multi-minute storms of 9s timeouts per node while probes kept reporting the node alive.
3. **Backoff parks amplified everything.** `Step::Backoff` slept the caller for the whole remaining window (up to the 30s `max_dial_backoff` cap), so once real dial failures piled up, flows arriving inside the window died at 9s without a dial being attempted, and the artificial timeouts fed back into dial-failure strikes.
4. **Speculative provisional slots counted against normal offers.** Hung cold-race UDP checkouts could push a cold pool (`max_sessions: 2`) into `Step::Capacity`, another silent unbounded park.

## Fixes

- `fix(outbound): cap session dial backoff below the flow dial budget` — `max_dial_backoff` 30s → 2s; the breaker only paces redials, single-flight already paces concurrent dials.
- `fix(outbound): keep speculative slots from starving normal dials` — `offer()` bounds the normal path by real Active sessions only; `checkout_speculative()` keeps counting provisional slots for its own discipline.
- `fix(outbound): unwedge session pools behind dead-on-arrival sessions` — the dead-on-arrival error path now clears its phantom `dial_done` entry (dropping the sender wakes waiters to re-elect) and records a dial failure so the breaker paces redials; `Step::Backoff` in both `offer()` and `checkout_speculative()` fails fast with the recorded error instead of parking, so flows get a real error in milliseconds and client retries pick a recovered server up within the 2s cap.

## Tests

- New: `dead_on_arrival_session_engages_the_breaker` — reproduces the production wedge: the pre-fix code hung this test forever (phantom `dial_done` parked the second offer); post-fix it errors fast, arms the breaker, and redials after the window.
- New: `dial_backoff_is_capped` — escalation respects `max_dial_backoff`.
- Rewritten: `dial_failures_back_off` (fast-fail inside the window + paced redial after it), `provisional_slot_blocks_normal_offer_until_released` → `provisional_slot_does_not_block_normal_offer` (the old test pinned the wedging behavior).
- Session suite 29/29, AnyTLS suite 81/81, `ci/outbound-ci.sh` all green.

## Production validation

Deployed on the gateway (real eBPF, nexi AnyTLS subscription). Pre-fix: storms of `dial timed out after 9s` per node with zero pool-side logs in between (82 events / 15 min), matching the user's report. The wedge was reproduced and pinned by the new unit test (the pre-fix code hangs it forever).

Post-fix, 15-minute window under normal LAN load: **zero** 9s dial timeouts, 2 dead-on-arrival events resolved as fast errors, 19 real `session dial failed` fast errors, backoff never escalated past 1s, 527 healthy proxied TCP connections.
