### PR TITLE
fix(outbound): fire TCP keepalive before server idle-kill windows

### DIFF
--- a/crates/honk-outbound/src/util.rs
+++ b/crates/honk-outbound/src/util.rs
@@ -34,12 +34,15 @@ pub fn set_mark_result_best_effort(result: io::Result<()>) -> io::Result<()> {
     }
 }
 
-/// Apply TCP keepalive tuning (idle 60s, interval 10s, 3 probes) via
-/// socket2's safe API — no raw setsockopt.
+/// Apply TCP keepalive tuning (idle 15s, interval 10s, 3 probes) via
+/// socket2's safe API — no raw setsockopt. The first probe must fire well
+/// inside a server's idle-kill window (AnyTLS servers drop idle sessions
+/// around 30s): with a 60s first probe, warm mux sessions silently became
+/// corpses that only a real flow would discover (mihomo #1891).
 #[cfg(target_os = "linux")]
 fn apply_tcp_keepalive(socket: &socket2::Socket) -> io::Result<()> {
     let keepalive = socket2::TcpKeepalive::new()
-        .with_time(Duration::from_secs(60))
+        .with_time(Duration::from_secs(15))
         .with_interval(Duration::from_secs(10))
         .with_retries(3);
     socket.set_tcp_keepalive(&keepalive)


### PR DESCRIPTION
## Symptom

Follow-up from the #112 investigation. A user node configured with `min_idle_session=2` (keep two warm AnyTLS sessions) on a server that kills idle connections at ~30s shows recurring mid-use interruptions: flows landing on a silently-killed warm session stall until the janitor/health-check cadence (~30s) replaces the corpse, then it happens again.

## Root cause

honk's control-plane TCP sockets start TCP keepalive only after **60s idle** (`apply_tcp_keepalive`, idle 60s / interval 10s / 3 probes). AnyTLS servers and the middleboxes in front of them drop idle connections around **30s** — nexi subscription links even carry `idle_session_timeout=30s`, and production logs show warm zero-stream sessions dying at a median of **30.187s**. The first keepalive probe never fires before the server-side kill, so warm mux sessions become invisible corpses: the pool keeps offering them as Active, and a real flow is the first thing to discover the death (a hang on v1 servers; a 3s SYNACK watchdog cycle on v2).

This is the same defect class as [mihomo#1891](https://github.com/MetaCubeX/mihomo/issues/1891) (`min_idle_session` retaining sessions whose underlying TCP died because keepalives never fired in time); mihomo settled on a 15s keepalive-idle default.

## Fix

`apply_tcp_keepalive`: first-probe idle time 60s → **15s** (interval/retries unchanged). The first probe now lands well inside a 30s idle-kill window, keeping warm sessions alive and surfacing dead peers via keepalive timeout instead of via stalled user flows. Applies to every control-plane proxy dial/probe/DNS TCP socket; QUIC protocols have their own keep-alive knobs and are untouched.

## Notes / limits

- If a server enforces a hard session max-age (rather than an idle window), keepalive cannot help — that case stays on the janitor/max-age path.
- For v1 AnyTLS servers (no SYNACK) there is still no fast detection of a silently-dead session; the 15s keepalive now prevents the common kill cause, and the #112 breaker handles the rest.
- The 30s server-side kill is confirmed on the gateway's nexi nodes (zero-stream sessions die at a median of 30.187s; links carry `idle_session_timeout=30s`). The field-reported AWS node did **not** idle-kill in a 6-round × 40s idle loop test (`anytls_idle` example, session reused across every pause), so its recurring 30s outages have a different trigger — most consistent with honk's health-check/recovery cadence after failure events, pending post-#112 logs.

## Tests

- Socket-option constant; covered by the existing outbound gates (`ci/outbound-ci.sh` all green). Production A/B requires a node with a 30s idle-kill server (reported in the field); gateway nexi nodes self-reap at the same 30s mark client-side, so they cannot demonstrate it.

Related: #112, #113
