### PR TITLE
fix(routing): prevent LPM exhaustion during reload

### DIFF
--- a/crates/honk-core/src/control/routing_matcher.rs
+++ b/crates/honk-core/src/control/routing_matcher.rs
@@ -317,8 +317,8 @@ impl RoutingMatcherBuilder {
     /// 1. compile the whole ruleset (MatchSets + LPM plan + group bitmaps)
     ///    without touching any map;
     /// 2. fill the inactive `ROUTING_MAP` bank;
-    /// 3. publish LPM values containing both the active and staged generation,
-    ///    pruning only keys referenced by neither;
+    /// 3. prune keys referenced by neither bank, then publish LPM values
+    ///    containing both the active and staged generation;
     /// 4. write the staged generation's exploded introspection metadata and
     ///    all four packed `RoutingGroupMeta` entries;
     /// 5. flip the one-slot generation selector only after that bank is
@@ -486,8 +486,8 @@ impl RoutingMatcherBuilder {
             generation,
         );
         ebpf.set_routing_rules(generation, &plan.match_sets)?;
-        lpm.apply(ebpf)?;
         ebpf.prune_lpm_entries(&lpm.keep_set())?;
+        lpm.apply(ebpf)?;
         ebpf.publish_routing_generation(
             generation,
             plan.match_sets.len() as u32,
@@ -1820,6 +1820,46 @@ mod tests {
         assert_eq!(backend.dest_lpm_bitmap.len(), 1);
         assert!(!backend.dest_lpm_bitmap.contains_key(&old_key));
         assert!(backend.dest_lpm_bitmap.contains_key(&new_key));
+    }
+
+    #[test]
+    fn reload_prunes_retired_lpm_keys_before_writing_replacement() {
+        let mut backend = MockEbpfBackend::new();
+        let outbound_map = HashMap::from([("direct".to_string(), OutboundIndex::Direct as u8)]);
+        let compile = |name: &str, cidr: &str| {
+            let nets = vec![cidr.parse().unwrap()];
+            RoutingMatcherBuilder::compile(
+                &[CompiledRoute {
+                    ip_nets: nets.clone(),
+                    ip_trie: crate::routing::BinaryLpmTrie::from_nets(&nets),
+                    ..make_route(name, "direct")
+                }],
+                &outbound_map,
+                "direct",
+                DialMode::Ip,
+            )
+            .unwrap()
+        };
+        let first = compile("first", "10.0.0.0/8");
+        let second = compile("second", "192.168.0.0/16");
+        let third = compile("third", "172.16.0.0/12");
+
+        RoutingMatcherBuilder::push_plan(&mut backend, &first).unwrap();
+        RoutingMatcherBuilder::push_transition(&mut backend, Some(&first), &second).unwrap();
+        let accepted = backend.routing_snapshot();
+        let first_key = maps::lpm_key_bytes(&maps::cidr_to_lpm_key("10.0.0.0/8").unwrap());
+        let second_key = maps::lpm_key_bytes(&maps::cidr_to_lpm_key("192.168.0.0/16").unwrap());
+
+        backend.fail_next_routing_phase(RoutingPushPhase::DestinationLpm);
+        assert!(
+            RoutingMatcherBuilder::push_transition(&mut backend, Some(&second), &third).is_err()
+        );
+
+        assert!(!backend.dest_lpm_bitmap.contains_key(&first_key));
+        assert!(backend.dest_lpm_bitmap.contains_key(&second_key));
+        assert_eq!(backend.routing_snapshot(), accepted);
+        RoutingMatcherBuilder::push_transition(&mut backend, Some(&second), &second).unwrap();
+        assert_eq!(backend.routing_snapshot(), accepted);
     }
 
     #[test]

--- a/crates/honk-ebpf/src/maps.rs
+++ b/crates/honk-ebpf/src/maps.rs
@@ -18,11 +18,9 @@ use honk_ebpf_common::{DaeParam, ROUTING_MAP_LEN, RedirectEntry, RedirectTuple};
 use crate::route::{RouteCtx, WanEgressRouteScratch};
 use crate::transport::ParsedPacket;
 
-/// Maximum LPM trie size: 65,536 entries.
-/// Reduced from 2,048,000 to stay under kernel memory limits.
-/// Each entry consumes ~20 bytes of kernel memory, so 65,536 entries
-/// ≈ 1.3 MB per LPM map.
-pub const MAX_LPM_SIZE: usize = 65536;
+/// LPM tries allocate entries on demand; the shared limit preserves large
+/// GeoIP sets without reserving their maximum capacity at map creation.
+pub const MAX_LPM_SIZE: usize = honk_ebpf_common::MAX_LPM_SIZE as usize;
 pub const MAX_ROUTING_HANDOFF_NUM: usize = 65536;
 pub const MAX_LPM_NUM: usize = MAX_MATCH_SET_LEN + 8;
 pub const MAX_COOKIE_PID_PNAME_MAPPING_NUM: usize = 65536;


### PR DESCRIPTION
## Summary

- prune LPM keys unused by either routing generation before staging replacement values
- restore the LPM trie capacity to the shared 2,048,000-entry limit for large GeoIP sets
- cover failed replacement writes and active-plan replay with a regression test

## Tests

- `cargo test -p honk-core --lib control::routing_matcher::tests` (40 passed)
- `cargo test -p honk-core --lib routing_push_failure_replays_old_plan_and_keeps_userspace_generation`
- `cargo +nightly build --release -Zbuild-std=core --target bpfel-unknown-none` in `crates/honk-ebpf`