### PR TITLE
fix(core): mirror fatal errors into the log file before exit

### DIFF
--- a/crates/honk-core/src/main.rs
+++ b/crates/honk-core/src/main.rs
@@ -265,7 +265,13 @@ async fn async_main() -> anyhow::Result<()> {
         return honk_core::handle_clash_command(&cli).await;
     }
 
-    honk_core::run(cli).await
+    // Mirror fatal failures through tracing: the anyhow return only reaches
+    // stderr, but deployments commonly collect just the log file.
+    let result = honk_core::run(cli).await;
+    if let Err(error) = &result {
+        tracing::error!("fatal error, shutting down: {error:#}");
+    }
+    result
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem

A fatal startup failure never reaches the log file: `run()` returns the error via anyhow, Rust's `Termination` prints it to **stderr**, but deployments that collect only the log file (`global.log_file`, or a crash-looping service manager) see a clean startup followed by an unexplained shutdown. Observed in the field as repeated "starts fine, `Cleaning up dae0 side effects` one second later, no error anywhere" — the actual cause (an unreadable `dns.use_host` file aborting startup) was invisible.

## Fix

`async_main` mirrors a fatal `run()` result into tracing (`error!`) before returning it. The file/console layers are blocking writers in the process-global registry, so the line lands in the log file even while the error propagates to stderr as before.

Verified with a config pointing `use_host` at a missing path under `--mock-ebpf`:

```
ERROR honk_core: fatal error, shutting down: failed to load DNS hosts file /nonexistent/hosts-file.txt: No such file or directory (os error 2)
```

Note: failures before the tracing registry initializes (config parse itself) still only reach stderr — there is no log file to write to yet at that point.
