### PR TITLE
fix: review follow-ups for the #111–#124 batch

### DIFF
--- a/crates/honk-config/src/config.rs
+++ b/crates/honk-config/src/config.rs
@@ -760,6 +760,26 @@ impl Config {
             check_outbound(rule.outbound.as_str(), false)?;
         }
         check_outbound(&self.routing.default_outbound, true)?;
+        for subscription in &self.subscriptions {
+            if subscription.name.is_empty() {
+                return Err(crate::ConfigError::Validation(
+                    "subscription name must not be empty".into(),
+                ));
+            }
+            if subscription.url.is_empty() {
+                return Err(crate::ConfigError::Validation(format!(
+                    "subscription '{}' has an empty url",
+                    subscription.name
+                )));
+            }
+            if !subscription.url.starts_with("http://") && !subscription.url.starts_with("https://")
+            {
+                return Err(crate::ConfigError::Validation(format!(
+                    "subscription '{}' url must use http:// or https://",
+                    subscription.name
+                )));
+            }
+        }
         Ok(())
     }
 }
@@ -816,6 +836,34 @@ mod builtin_nodes_tests {
         let mut config = Config::default();
         config.dns.bind = "tcp+udp://localhost:0".into();
         config.validate().unwrap();
+    }
+
+    #[test]
+    fn test_validate_rejects_invalid_subscriptions() {
+        let valid = crate::subscription::Subscription {
+            name: "sub".into(),
+            url: "https://example.test/feed".into(),
+            ..Default::default()
+        };
+        let mut config = Config::default();
+        config.subscriptions.push(valid.clone());
+        config.validate().unwrap();
+
+        for (name, url) in [
+            ("", "https://example.test/feed"),
+            ("sub", ""),
+            ("sub", "ftp://example.test/feed"),
+        ] {
+            let mut config = Config::default();
+            let mut sub = valid.clone();
+            sub.name = name.into();
+            sub.url = url.into();
+            config.subscriptions.push(sub);
+            assert!(
+                config.validate().is_err(),
+                "name={name:?} url={url:?} must fail validation"
+            );
+        }
     }
 
     #[test]

--- a/crates/honk-core/src/control/reload/transaction.rs
+++ b/crates/honk-core/src/control/reload/transaction.rs
@@ -46,7 +46,14 @@ fn rebase_subscription_nodes(current: &Config, candidate: &mut Config) {
     for subscription in candidate.subscriptions.iter_mut().filter(|sub| sub.enabled) {
         let candidate_id = subscription.id;
         if let Some(previous) = current.subscriptions.iter().find(|previous| {
-            previous.url == subscription.url && !matched_previous.contains(&previous.id)
+            // Same fetch identity as the cache filename: url + UA + headers.
+            // URL-only matching can swap IDs when same-URL subscriptions with
+            // different user agents are reordered.
+            previous.url == subscription.url
+                && previous.user_agent.as_deref().unwrap_or_default()
+                    == subscription.user_agent.as_deref().unwrap_or_default()
+                && previous.headers == subscription.headers
+                && !matched_previous.contains(&previous.id)
         }) {
             matched_previous.insert(previous.id);
             subscription.id = previous.id;
@@ -790,5 +797,73 @@ impl ControlPlane {
             .with_hosts_snapshot(hosts_snapshot),
         );
         Ok((forwarder, dns_upstream_pool))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn subscription(
+        id: u128,
+        name: &str,
+        ua: Option<&str>,
+    ) -> honk_config::subscription::Subscription {
+        honk_config::subscription::Subscription {
+            id: uuid::Uuid::from_u128(id),
+            name: name.into(),
+            url: "http://same-url".into(),
+            user_agent: ua.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    fn subscription_node(name: &str, subscription_id: u128) -> honk_config::node::Node {
+        honk_config::node::Node {
+            name: name.into(),
+            subscription_id: Some(uuid::Uuid::from_u128(subscription_id)),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn rebase_matches_subscription_identity_beyond_url() {
+        let current = Config {
+            subscriptions: vec![
+                subscription(1, "a", Some("ua-a")),
+                subscription(2, "b", Some("ua-b")),
+            ],
+            nodes: vec![
+                subscription_node("node-a", 1),
+                subscription_node("node-b", 2),
+            ],
+            ..Default::default()
+        };
+
+        // Same file with the subscription order swapped; a fresh parse assigns
+        // fresh IDs.
+        let mut candidate = Config {
+            subscriptions: vec![
+                subscription(3, "b", Some("ua-b")),
+                subscription(4, "a", Some("ua-a")),
+            ],
+            ..Default::default()
+        };
+
+        rebase_subscription_nodes(&current, &mut candidate);
+
+        assert_eq!(candidate.subscriptions[0].id, uuid::Uuid::from_u128(2));
+        assert_eq!(candidate.subscriptions[1].id, uuid::Uuid::from_u128(1));
+        let mut node_names: Vec<&str> = candidate
+            .nodes
+            .iter()
+            .map(|node| node.name.as_str())
+            .collect();
+        node_names.sort_unstable();
+        assert_eq!(node_names, ["node-a", "node-b"]);
+        for node in &candidate.nodes {
+            let expected = if node.name == "node-a" { 1 } else { 2 };
+            assert_eq!(node.subscription_id, Some(uuid::Uuid::from_u128(expected)));
+        }
     }
 }

--- a/crates/honk-outbound/src/proxy/socks5.rs
+++ b/crates/honk-outbound/src/proxy/socks5.rs
@@ -130,9 +130,11 @@ impl Socks5Handler {
             }
 
             if let Some(domain) = target_domain {
+                let domain_len = u8::try_from(domain.len())
+                    .map_err(|_| anyhow::anyhow!("SOCKS5: domain exceeds 255 bytes"))?;
                 request[3] = ATYP_DOMAIN;
                 request.truncate(4);
-                request.push(domain.len() as u8);
+                request.push(domain_len);
                 request.extend_from_slice(domain.as_bytes());
                 request.extend_from_slice(&target.port().to_be_bytes());
             }
@@ -618,6 +620,32 @@ mod tests {
             Socks5Handler::username_password_auth_request("user", "pass").unwrap(),
             b"\x01\x04user\x04pass"
         );
+    }
+
+    #[tokio::test]
+    async fn socks5_tcp_connect_rejects_oversized_domain() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let proxy_addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut greeting = [0u8; 2];
+            stream.read_exact(&mut greeting).await.unwrap();
+            let mut methods = vec![0u8; greeting[1] as usize];
+            stream.read_exact(&mut methods).await.unwrap();
+            stream
+                .write_all(&[SOCKS5_VERSION, METHOD_NO_AUTH])
+                .await
+                .unwrap();
+        });
+
+        let mut client = TcpStream::connect(proxy_addr).await.unwrap();
+        let oversized = "x".repeat(u8::MAX as usize + 1);
+        let target: SocketAddr = "192.0.2.1:443".parse().unwrap();
+        let result =
+            Socks5Handler::handshake(&mut client, target, Some(&oversized), None, None).await;
+        server.await.unwrap();
+        let error = result.expect_err("oversized domain must fail the handshake");
+        assert!(error.to_string().contains("255"));
     }
 
     struct UdpAssociateTestServer {

--- a/crates/honk-outbound/src/session.rs
+++ b/crates/honk-outbound/src/session.rs
@@ -1220,6 +1220,18 @@ impl<S: ManagedSession + 'static> DetachedSessionReservation<S> {
             if self.pool.state() == PoolState::Running {
                 if let Some(session) = session {
                     pool.sessions.retain(|existing| !existing.is_closed());
+                    // Normal offers don't count provisional slots, so a commit
+                    // can arrive after the pool filled up meanwhile. Admit the
+                    // winner drain-only instead of exceeding max_sessions; its
+                    // already-reserved streams are unaffected.
+                    let active = pool
+                        .sessions
+                        .iter()
+                        .filter(|s| s.state() == SessionState::Active)
+                        .count();
+                    if active >= self.pool.config.max_sessions {
+                        session.begin_drain();
+                    }
                     pool.sessions.push(Arc::clone(&session));
                     Ok(session)
                 } else {
@@ -2186,6 +2198,36 @@ mod tests {
             1,
             "commit cannot duplicate insertion"
         );
+    }
+
+    #[tokio::test]
+    async fn detached_commit_at_capacity_admits_drain_only() {
+        let pool = Arc::new(pool(SessionPoolConfig {
+            max_sessions: 1,
+            ..Default::default()
+        }));
+        let mut reservation = match pool.checkout_speculative().await.unwrap() {
+            SpeculativeCheckout::Detached(reservation) => reservation,
+            SpeculativeCheckout::Shared { .. } => panic!("empty pool cannot be shared"),
+        };
+        let winner = TestSession::new();
+        reservation.attach(&winner).unwrap();
+        // Normal offers don't count provisional slots, so the pool can fill
+        // while the speculative dial is detached.
+        let active = pool
+            .offer(|| async { Ok(TestSession::new()) })
+            .await
+            .unwrap();
+
+        let committed = reservation.commit().unwrap();
+
+        assert!(Arc::ptr_eq(&committed, &winner));
+        assert_eq!(
+            committed.state(),
+            SessionState::Draining,
+            "a commit arriving at a full pool must not exceed max_sessions"
+        );
+        assert_eq!(active.state(), SessionState::Active);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Follow-ups to the post-#110 review of the #111–#124 batch. 

- `fix(socks5)`: the TCP handshake encoded the domain length with `as u8`; a >255-byte domain wrapped the length and desynced the request. The UDP path already used `u8::try_from`; the TCP path now matches it.
- `fix(outbound)`: normal offers deliberately ignore provisional slots, so a speculative `commit()` could publish into a pool that had meanwhile filled past `max_sessions`. `commit()` now re-arbitrates under the lock: at capacity the winner is admitted drain-only (`begin_drain`), which is safe because speculative winners take their own stream permit before committing.
- `fix(core)`: subscription rebase on reload matched only by URL while the cache identity is URL + UA + headers, so two same-URL subscriptions with different user agents could swap IDs, carried-over nodes, and `subtag()` attribution when reordered. Rebase now matches on the same full fetch identity.
- `fix(config)`: `Config::validate` never looked at subscriptions; it now rejects an empty name, an empty URL, and non-http(s) URL schemes.

Deferred from the same review: the AnyTLS flush/shutdown completion barrier (writer-queue drain semantics — a design change, not a one-liner) and the QUIC/LPM memory-budget proposal.

Tests: new focused tests for all four fixes; `cargo test --workspace --no-fail-fast -- --skip test_routing_with_config_dae` and `cargo clippy -p honk-config -p honk-outbound -p honk-core --all-targets -- -D warnings` are green.
