### PR TITLE
fix(core): restore datapath admission after a rejected NFQUEUE fence

### DIFF
--- a/crates/honk-core/src/control/reload/transaction.rs
+++ b/crates/honk-core/src/control/reload/transaction.rs
@@ -723,14 +723,14 @@ impl ControlPlane {
             pending.cancel_all().await;
         }
         if !self.udp_pool.cancel_initializers_and_wait().await {
-            warn!("UDP initializers did not drain after NFQUEUE reopen failure");
+            warn!("UDP initializers did not drain during admission teardown");
         }
         #[cfg(feature = "ebpf")]
         if let Some(pending) = self.pending_udp_verdicts.as_ref() {
             pending.wait_empty().await;
         }
         if !self.udp_pool.wait_for_retirements().await {
-            warn!("UDP endpoint retirements did not drain after NFQUEUE reopen failure");
+            warn!("UDP endpoint retirements did not drain during admission teardown");
         }
     }
 

--- a/crates/honk-core/src/control/reload/transaction.rs
+++ b/crates/honk-core/src/control/reload/transaction.rs
@@ -399,12 +399,16 @@ impl ControlPlane {
             .await
             .mark_datapath_flags_write_origin(crate::ebpf::DatapathFlagsWriteOrigin::FenceNfqueue);
         if let Err(error) = datapath_flags.fence_nfqueue().await {
-            error!(%error, "failed to fence NFQUEUE before reload");
-            self.datapath_healthy
-                .store(false, std::sync::atomic::Ordering::Release);
-            drain.start_rejecting();
-            self.drain_tracker.start_rejecting();
+            error!(error = %format_args!("{error:#}"), "failed to fence NFQUEUE before reload");
             self.close_and_drain_pending_udp_admission().await;
+            // Nothing was torn down yet: restore the old flags and keep
+            // serving instead of rejecting new connections forever.
+            self.restore_datapath_flags_after_rejected_reload(
+                &datapath_flags,
+                old_static_flags,
+                drain,
+            )
+            .await;
             return false;
         }
         drain.start_rejecting();

--- a/crates/honk-core/src/control/reload_tests.rs
+++ b/crates/honk-core/src/control/reload_tests.rs
@@ -269,6 +269,10 @@ fn group_connectivity_follows_reordered_outbound_ids() {
 }
 
 async fn test_cp() -> ControlPlane {
+    test_cp_with_nfq(false).await
+}
+
+async fn test_cp_with_nfq(nfqueue: bool) -> ControlPlane {
     let mut control_plane = ControlPlane::new(
         Config::default(),
         Box::new(MockEbpfBackend::new()),
@@ -293,7 +297,7 @@ async fn test_cp() -> ControlPlane {
     )));
     control_plane.start_datapath_flags_coordinator().unwrap();
     control_plane
-        .initialize_datapath_flags(false, false)
+        .initialize_datapath_flags(nfqueue, nfqueue)
         .await
         .unwrap();
     control_plane
@@ -599,6 +603,59 @@ async fn fence_failure_rejects_reload_without_stranding_datapath() {
     );
     assert!(trace[0].failed);
     assert!(!trace[1].failed && !trace[2].failed);
+}
+
+/// The production incident shape: quiesce fails after READY=false was
+/// published. The reload is rejected and restore must republish the exact
+/// pre-fence flags (READY set) while keeping admission open.
+#[tokio::test]
+async fn quiesce_failure_rejects_reload_and_restores_ready_flags() {
+    let cp = test_cp_with_nfq(true).await;
+    let expected_flags = {
+        let ebpf = cp.ebpf.read().await;
+        *ebpf.datapath_flags_write_log().last().unwrap()
+    };
+    assert_ne!(
+        expected_flags & honk_ebpf_common::DATAPATH_FLAG_NFQ_READY,
+        0
+    );
+    {
+        let mut ebpf = cp.ebpf.write().await;
+        ebpf.clear_datapath_flags_write_log();
+        ebpf.arm_quiesce_fault();
+    }
+    let drain = DrainTracker::new();
+    let interval = Config::default().global.check_interval_secs + 1;
+    assert!(
+        !cp.apply_runtime_config(score_reload_config(interval), &drain)
+            .await,
+        "quiesce failure must reject the reload"
+    );
+    assert!(cp.is_datapath_healthy());
+    assert!(!drain.should_reject());
+    assert!(!cp.drain_tracker.should_reject());
+    let ebpf = cp.ebpf.read().await;
+    let trace = ebpf.datapath_flags_write_trace();
+    let origins: Vec<_> = trace.iter().map(|write| write.origin).collect();
+    assert_eq!(
+        origins,
+        vec![
+            DatapathFlagsWriteOrigin::FenceNfqueue,
+            DatapathFlagsWriteOrigin::SetStatic,
+            DatapathFlagsWriteOrigin::ReopenNfqueue,
+        ]
+    );
+    assert!(!trace.iter().any(|write| write.failed));
+    assert_eq!(
+        trace[0].flags & honk_ebpf_common::DATAPATH_FLAG_NFQ_READY,
+        0,
+        "fence publishes READY=false before quiesce runs"
+    );
+    assert_eq!(
+        trace.last().unwrap().flags,
+        expected_flags,
+        "restore must republish the exact pre-fence flags (READY set)"
+    );
 }
 
 #[tokio::test]

--- a/crates/honk-core/src/control/reload_tests.rs
+++ b/crates/honk-core/src/control/reload_tests.rs
@@ -553,6 +553,54 @@ async fn post_publication_datapath_failure_is_committed_degraded() {
     }
 }
 
+/// A fence failure rejects the reload before anything was torn down, so the
+/// datapath must stay healthy and keep admitting: restore old flags, reopen
+/// NFQUEUE, and leave both drain trackers alone.
+#[tokio::test]
+async fn fence_failure_rejects_reload_without_stranding_datapath() {
+    let cp = test_cp().await;
+    assert!(cp.datapath_flags.is_some());
+    let first_interval = Config::default().global.check_interval_secs + 1;
+    assert!(
+        cp.apply_runtime_config(score_reload_config(first_interval), &DrainTracker::new())
+            .await
+    );
+    let before_interval = cp.config.read().await.global.check_interval_secs;
+    {
+        let mut ebpf = cp.ebpf.write().await;
+        ebpf.clear_datapath_flags_write_log();
+        ebpf.arm_datapath_flags_write_fault(1).unwrap();
+    }
+    let drain = DrainTracker::new();
+    assert!(
+        !cp.apply_runtime_config(score_reload_config(first_interval + 1), &drain)
+            .await,
+        "fence failure must reject the reload"
+    );
+    assert_eq!(
+        cp.config.read().await.global.check_interval_secs,
+        before_interval,
+        "rejected reload keeps the old config"
+    );
+    assert!(cp.is_datapath_healthy());
+    assert!(!drain.should_reject());
+    assert!(!cp.drain_tracker.should_reject());
+    let ebpf = cp.ebpf.read().await;
+    let trace = ebpf.datapath_flags_write_trace();
+    let origins: Vec<_> = trace.iter().map(|write| write.origin).collect();
+    assert_eq!(
+        origins,
+        vec![
+            DatapathFlagsWriteOrigin::FenceNfqueue,
+            DatapathFlagsWriteOrigin::SetStatic,
+            DatapathFlagsWriteOrigin::ReopenNfqueue,
+        ],
+        "fence failure must restore old flags and reopen admission"
+    );
+    assert!(trace[0].failed);
+    assert!(!trace[1].failed && !trace[2].failed);
+}
+
 #[tokio::test]
 async fn empty_subscription_merge_does_not_publish_runtime() {
     let cp = test_cp().await;

--- a/crates/honk-core/src/ebpf/mock.rs
+++ b/crates/honk-core/src/ebpf/mock.rs
@@ -205,6 +205,8 @@ pub struct MockEbpfBackend {
     #[cfg(test)]
     domain_bitmap_add_faults: usize,
     #[cfg(test)]
+    fail_next_quiesce: bool,
+    #[cfg(test)]
     datapath_flags_fault_nth: Option<usize>,
     #[cfg(test)]
     datapath_flags_writes_after_arm: usize,
@@ -681,6 +683,11 @@ impl EbpfBackend for MockEbpfBackend {
     }
 
     #[cfg(test)]
+    fn arm_quiesce_fault(&mut self) {
+        self.fail_next_quiesce = true;
+    }
+
+    #[cfg(test)]
     fn mark_datapath_flags_write_origin(&mut self, origin: DatapathFlagsWriteOrigin) {
         self.datapath_flags_write_origin = origin;
     }
@@ -703,6 +710,10 @@ impl EbpfBackend for MockEbpfBackend {
     }
 
     fn quiesce_udp_staging(&mut self) -> anyhow::Result<()> {
+        #[cfg(test)]
+        if std::mem::take(&mut self.fail_next_quiesce) {
+            anyhow::bail!("injected quiesce failure");
+        }
         let staged = self
             .udp_conn_states
             .iter()

--- a/crates/honk-core/src/ebpf/mod.rs
+++ b/crates/honk-core/src/ebpf/mod.rs
@@ -344,6 +344,8 @@ pub trait EbpfBackend: Send + Sync {
     #[cfg(test)]
     fn mark_datapath_flags_write_origin(&mut self, _origin: DatapathFlagsWriteOrigin) {}
     #[cfg(test)]
+    fn arm_quiesce_fault(&mut self) {}
+    #[cfg(test)]
     fn datapath_flags_write_log(&self) -> Vec<u32> {
         Vec::new()
     }


### PR DESCRIPTION
Production incident: after an overnight uptime, a reload (SIGHUP or subscription merge) hit `failed to fence NFQUEUE before reload: failed to quiesce staged UDP decisions`, the reload was rejected — and the engine then rejected **every** new connection forever (direct, proxy, DNS all timing out) while health probes kept working. Only a restart recovered.

Root cause of the zombie: the fence-failure branch in `apply_runtime_config_locked` armed `datapath_healthy = false` plus both drain trackers and returned `false` without restoring anything. Nothing was torn down at that point — the fence runs before any drain — so the old generation was perfectly serviceable, yet admission stayed closed permanently (`datapath_healthy=false` also gates every later reload attempt).

Fix: the fence-failure branch now drains pending UDP admission and restores the old datapath flags + reopens NFQUEUE via the same `restore_datapath_flags_after_rejected_reload` path the sibling rejection branches already use, leaving the datapath healthy and admitting on the old config. A persistent quiesce failure now degrades to "reloads rejected, traffic unaffected" instead of a dead gateway. The error log also carries the full anyhow chain (`{error:#}`) so the inner quiesce cause (grace-period timeout vs token mismatch) is visible next time.

Regression test: `fence_failure_rejects_reload_without_stranding_datapath` injects a fence-stage flags-write failure and asserts the reload is rejected, the old config is retained, the datapath stays healthy, neither drain tracker rejects, and the write trace is exactly fence(failed) → set_static → reopen.

The deeper question — *why* quiesce failed after long uptime — is not answered by the surviving logs; the improved error chain is meant to capture it on recurrence.
