### PR TITLE
fix: reject three inputs that fail open or panic

### DIFF
--- a/crates/honk-config/src/config.rs
+++ b/crates/honk-config/src/config.rs
@@ -598,6 +598,14 @@ impl Config {
             .client_subnet_mode()
             .map_err(|error| crate::ConfigError::Validation(error.to_string()))?;
 
+        // A duration that fails to parse becomes zero, and a zero period makes
+        // tokio::time::interval panic, taking the health-check loop down at startup.
+        if self.global.check_interval_secs == 0 {
+            return Err(crate::ConfigError::Validation(
+                "global.check_interval must be a positive duration, such as 30s".into(),
+            ));
+        }
+
         // The eBPF datapath has the mark compiled in; userspace cannot inject
         // a different value, so a custom mark would silently break the proxy.
         if self.global.tproxy_mark != default_tproxy_mark() {
@@ -864,6 +872,17 @@ mod builtin_nodes_tests {
                 "name={name:?} url={url:?} must fail validation"
             );
         }
+    }
+
+    #[test]
+    fn test_validate_rejects_zero_check_interval() {
+        let mut config = Config::default();
+        config.global.check_interval_secs = 0;
+        let error = config.validate().unwrap_err();
+        assert!(
+            error.to_string().contains("global.check_interval"),
+            "validation error must identify global.check_interval: {error}"
+        );
     }
 
     #[test]

--- a/crates/honk-config/src/node/protocol.rs
+++ b/crates/honk-config/src/node/protocol.rs
@@ -105,6 +105,23 @@ impl VlessConfig {
                 )));
             }
         }
+        // A REALITY node without a usable public key falls back to ordinary TLS with the
+        // configured SNI, which is the opposite of what selecting REALITY asked for.
+        let has_key = self
+            .tls
+            .reality_public_key
+            .as_deref()
+            .is_some_and(|key| !key.trim().is_empty());
+        // Presence is the intent, not a non-empty value: an empty short id is documented as
+        // valid, and an empty key is exactly what parse_reality_config reads as "no REALITY".
+        let wants_reality = self.tls.reality_public_key.is_some()
+            || self.tls.reality_short_id.is_some()
+            || self.tls.reality_spider_x.is_some();
+        if wants_reality && !has_key {
+            return Err(crate::ConfigError::Validation(format!(
+                "Node '{name}' selects REALITY without reality_public_key"
+            )));
+        }
         Ok(())
     }
 }

--- a/crates/honk-config/tests/share_link.rs
+++ b/crates/honk-config/tests/share_link.rs
@@ -967,6 +967,48 @@ fn test_validate_rejects_vless_encryption_with_flow() {
 }
 
 #[test]
+fn test_reality_without_public_key_is_rejected_on_every_load_path() {
+    // Share links are validated as they are parsed.
+    for link in [
+        "vless://uuid@example.com:443?security=reality#no-pbk",
+        "vless://uuid@example.com:443?security=reality&pbk=#empty-pbk",
+    ] {
+        let error = Node::from_share_link(link).unwrap_err();
+        assert!(
+            error.to_string().contains("without reality_public_key"),
+            "{link} must be rejected rather than degraded to plain TLS: {error}"
+        );
+    }
+
+    // A structured node reaches the same invariant through Config::validate.
+    let node =
+        Node::from_share_link("vless://uuid@example.com:443?security=reality&pbk=AAA#ok").unwrap();
+    let mut config = Config::default();
+    config.nodes.push(node.clone());
+    config.validate().unwrap();
+
+    // Either an auxiliary REALITY field or the key itself signals the intent; an empty key is
+    // still the intent, and only a node with none of the three is an ordinary TLS node.
+    for (key, short_id) in [
+        (None, Some("0123456789abcdef".to_string())),
+        // An empty short id is documented as valid, so it still signals REALITY.
+        (None, Some(String::new())),
+        (Some(String::new()), None),
+        (Some("  ".to_string()), None),
+    ] {
+        let mut node = node.clone();
+        let tls = node.tls_mut().unwrap();
+        tls.reality_public_key = key;
+        tls.reality_short_id = short_id;
+        tls.reality_spider_x = None;
+        let mut config = Config::default();
+        config.nodes.push(node);
+        let error = config.validate().unwrap_err();
+        assert!(error.to_string().contains("without reality_public_key"));
+    }
+}
+
+#[test]
 fn test_vless_derive_id_differs_by_reality_public_key() {
     let a =
         Node::from_share_link("vless://uuid@example.com:443?security=reality&pbk=AAA#a").unwrap();

--- a/crates/honk-core/src/control/reload/transaction.rs
+++ b/crates/honk-core/src/control/reload/transaction.rs
@@ -128,8 +128,16 @@ impl ControlPlane {
     }
 
     /// Publish an explicit runtime configuration through the same transaction
-    /// used by SIGHUP and subscription refreshes.
+    /// used by SIGHUP and subscription refreshes. This entry point has no caller that has
+    /// already validated, so it validates here, the way the SIGHUP handler does. The check
+    /// stays on this public entry rather than inside the shared transaction: subscription
+    /// merges reach that transaction directly and legitimately publish nodes a whole-config
+    /// check would reject.
     pub async fn reload_runtime_config(&self, new_config: Config) -> bool {
+        if let Err(error) = new_config.validate() {
+            error!(%error, "runtime reload rejected: invalid configuration");
+            return false;
+        }
         let drain = Arc::clone(&self.drain_tracker);
         self.apply_runtime_config(new_config, &drain).await
     }

--- a/crates/honk-core/src/routing/geo.rs
+++ b/crates/honk-core/src/routing/geo.rs
@@ -711,6 +711,17 @@ impl<'a> ProtoDecoder<'a> {
             if shift > 63 {
                 anyhow::bail!("varint overflow");
             }
+            // The tenth byte is shifted by 63, so anything above bit 0 leaves u64 and would be
+            // silently dropped — a 2^64 length would arrive downstream as a small value.
+            if shift == 63 {
+                let next = *self
+                    .data
+                    .get(self.pos)
+                    .ok_or_else(|| anyhow::anyhow!("unexpected end of protobuf data"))?;
+                if next & 0x7f > 1 {
+                    anyhow::bail!("varint overflow");
+                }
+            }
         }
     }
 
@@ -722,12 +733,17 @@ impl<'a> ProtoDecoder<'a> {
     }
 
     fn read_len_delimited(&mut self) -> anyhow::Result<&'a [u8]> {
-        let len = self.read_varint()? as usize;
-        if self.pos + len > self.data.len() {
+        let len = usize::try_from(self.read_varint()?)
+            .map_err(|_| anyhow::anyhow!("length-delimited field length overflows usize"))?;
+        let Some(end) = self
+            .pos
+            .checked_add(len)
+            .filter(|end| *end <= self.data.len())
+        else {
             anyhow::bail!("length-delimited field exceeds data");
-        }
-        let slice = &self.data[self.pos..self.pos + len];
-        self.pos += len;
+        };
+        let slice = &self.data[self.pos..end];
+        self.pos = end;
         Ok(slice)
     }
 
@@ -739,11 +755,16 @@ impl<'a> ProtoDecoder<'a> {
             }
             2 => {
                 // length-delimited
-                let len = self.read_varint()? as usize;
-                if self.pos + len > self.data.len() {
+                let len = usize::try_from(self.read_varint()?)
+                    .map_err(|_| anyhow::anyhow!("skip length overflows usize"))?;
+                let Some(end) = self
+                    .pos
+                    .checked_add(len)
+                    .filter(|end| *end <= self.data.len())
+                else {
                     anyhow::bail!("skip length exceeds data");
-                }
-                self.pos += len;
+                };
+                self.pos = end;
             }
             5 => {
                 // 32-bit
@@ -1436,5 +1457,30 @@ mod scan_tests {
             ),
             crate::dns::routing::DnsResponseDecision::Reject
         );
+    }
+
+    #[test]
+    fn geo_length_guard_rejects_a_wrapping_length() {
+        // Field 1, length-delimited, with u64::MAX encoded as a ten-byte varint. It exceeds
+        // usize on a 32-bit target and would wrap `pos + len` past the guard on a 64-bit one.
+        let asset = [
+            0x0a, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01,
+        ];
+        let mut decoder = ProtoDecoder::new(&asset);
+        decoder.read_tag().expect("tag");
+        assert!(decoder.read_len_delimited().is_err());
+
+        let mut decoder = ProtoDecoder::new(&asset);
+        decoder.read_tag().expect("tag");
+        assert!(decoder.skip_field(2).is_err());
+
+        // 2^64 needs a tenth byte of 0x02, whose payload would be shifted out of u64 and leave a
+        // length of zero — an empty field where the asset declared a huge one.
+        let wider_than_u64 = [
+            0x0a, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x02,
+        ];
+        let mut decoder = ProtoDecoder::new(&wider_than_u64);
+        decoder.read_tag().expect("tag");
+        assert!(decoder.read_len_delimited().is_err());
     }
 }

--- a/doc/en/reference/global.md
+++ b/doc/en/reference/global.md
@@ -24,7 +24,7 @@ Compatibility-only keys are accepted by the dae parser and stored in `GlobalConf
 | `tcp_check_url` | `tcp_check_url` | `["https://www.gstatic.com/generate_204"]` | Comma-separated TCP/HTTP health-check URLs. The current health loop uses the first value; an empty list falls back to a plain TCP check. |
 | `tcp_check_http_method` | `tcp_check_http_method` | `"HEAD"` | HTTP method sent by the URL health check. An empty value is treated as `HEAD`. |
 | `udp_check_dns` | `udp_check_dns` | `["dns.google:53", "8.8.8.8", "2001:4860:4860::8888"]` | Comma-separated DNS targets for UDP health checks; a missing port defaults to `53`. |
-| `check_interval` | `check_interval_secs` | `30s` | Global health-check interval. The UDP warm coordinator also uses it, with an effective minimum of 10 seconds. |
+| `check_interval` | `check_interval_secs` | `30s` | Global health-check interval. Must be positive; a value that fails to parse becomes zero and is rejected at validation. The UDP warm coordinator also uses it, with an effective minimum of 10 seconds. |
 | `check_tolerance` | `check_tolerance_ms` | `50ms` | Latency improvement required before URLTest changes its selected member. |
 | `dial_mode` | `dial_mode` | `"domain"` | Destination-domain discovery and routing mode: `ip`, `domain`, `domain+`, or `domain++`. See [Dial modes](#dial-modes). |
 | `allow_insecure` | `allow_insecure` | `false` | Compatibility global TLS-verification fallback. Current TLS connectors do not read it; certificate skipping is configured per node in its share link. |

--- a/doc/en/reference/nodes.md
+++ b/doc/en/reference/nodes.md
@@ -218,7 +218,7 @@ For VLESS URL links, `security=reality` enables TLS and maps the REALITY query f
 
 | Query | Meaning |
 | --- | --- |
-| `security=reality` | Select REALITY and enable TLS |
+| `security=reality` | Select REALITY and enable TLS. A node that selects REALITY without `pbk` is rejected at validation rather than degraded to plain TLS |
 | `pbk` | Base64url 32-byte X25519 server public key; invalid input fails closed |
 | `sid` | Even-length hexadecimal short ID, at most 8 bytes; empty is valid |
 | `spx` | Stored spider path; defaults to `/` when REALITY is selected |

--- a/doc/zh/reference/global.md
+++ b/doc/zh/reference/global.md
@@ -24,7 +24,7 @@
 | `tcp_check_url` | `tcp_check_url` | `["https://www.gstatic.com/generate_204"]` | TCP/HTTP 健康检查 URL，逗号分隔。当前健康检查循环使用第一个值；空列表退回普通 TCP 检查。 |
 | `tcp_check_http_method` | `tcp_check_http_method` | `"HEAD"` | URL 健康检查发送的 HTTP 方法；空值按 `HEAD` 处理。 |
 | `udp_check_dns` | `udp_check_dns` | `["dns.google:53", "8.8.8.8", "2001:4860:4860::8888"]` | UDP 健康检查的 DNS 目标，逗号分隔；省略端口时默认为 `53`。 |
-| `check_interval` | `check_interval_secs` | `30s` | 全局健康检查间隔。UDP 预热 coordinator 也使用该值，但实际下限为 10 秒。 |
+| `check_interval` | `check_interval_secs` | `30s` | 全局健康检查间隔。必须为正；解析失败的值会变成零并在校验时被拒绝。UDP 预热 coordinator 也使用该值，但实际下限为 10 秒。 |
 | `check_tolerance` | `check_tolerance_ms` | `50ms` | URLTest 切换所选成员前要求的延迟改善量。 |
 | `dial_mode` | `dial_mode` | `"domain"` | 目的域名发现和路由模式：`ip`、`domain`、`domain+` 或 `domain++`。参见[拨号模式](#拨号模式)。 |
 | `allow_insecure` | `allow_insecure` | `false` | 全局 TLS 校验回退兼容字段。当前 TLS connector 不读取该字段；跳过证书校验需在节点分享链接中按节点配置。 |

--- a/doc/zh/reference/nodes.md
+++ b/doc/zh/reference/nodes.md
@@ -218,7 +218,7 @@ mlkem768x25519plus.<native|xorpub|random>.<1rtt|0rtt>.<base64url-key>
 
 | Query | 含义 |
 | --- | --- |
-| `security=reality` | 选择 REALITY 并开启 TLS |
+| `security=reality` | 选择 REALITY 并开启 TLS。选择了 REALITY 却没有 `pbk` 的节点会在校验时被拒绝，而不是降级成普通 TLS |
 | `pbk` | Base64url 编码的 32 字节 X25519 服务端公钥；无效输入 fail-closed |
 | `sid` | 偶数长度十六进制 short ID，最多 8 字节；允许为空 |
 | `spx` | 存储 spider path；选择 REALITY 时默认为 `/` |


### PR DESCRIPTION
* A `check_interval` that fails to parse becomes zero, and a zero period panics
  `tokio::time::interval`, so the periodic health-check loop dies at startup and outbound state
  then changes only from real traffic. `reload/warm.rs` already floors the same value at 10s; the
  probe path does not. `ControlPlane::reload_runtime_config` has no validating caller, so it now
  validates its candidate there too. The check stays on that public entry rather than inside the
  shared reload transaction, because subscription merges reach the transaction directly and
  legitimately publish nodes a whole-config check would reject.
* `security=reality` without `pbk` leaves `reality_public_key` as `None`, and
  `parse_reality_config` reads that as "no REALITY", so the node dials ordinary TLS with the
  configured SNI. The invariant is enforced in `VlessConfig::validate`, so it covers structured
  TOML/YAML/JSON nodes as well as share links, and it keys on whether a REALITY field is present
  rather than non-empty — an empty `sid` is documented as valid and would otherwise slip through.
* `ProtoDecoder` guards a length-delimited field with `self.pos + len > self.data.len()`. The
  length is asset-supplied and the release profile has no overflow checks, so a ten-byte varint
  encoding `u64::MAX` wraps past the guard and panics on the slice. `read_varint` also shifted the
  tenth byte before its overflow check, so a value wider than `u64` arrived as a small length; it
  now rejects that byte instead.

Each commit carries its test and, where the behaviour is documented, both language references.

`cargo fmt --all --check` and `cargo clippy --workspace --all-targets` are clean;
`cargo test --workspace --no-fail-fast -- --skip test_routing_with_config_dae` is 941 passed,
2 failed. The two failures are `routing::tests::test_geosite_cn_route` and `test_geosite_route`,
which need a `geosite.dat` that this environment does not provide; they fail identically on `main`
here. `cargo bench -p honk-core --bench reload --no-default-features --features reload-alloc-bench`
reports `allocations=28 bytes_allocated=68285 flag_writes=0` against `18` and `683` on `main`:
the validation on the public reload entry costs about 67 KiB per call, bounded by the size of the
configuration being validated.
