### PR TITLE
fix(core): unlink only the BPF pins this instance created

### DIFF
--- a/crates/honk-core/src/ebpf/real/attach.rs
+++ b/crates/honk-core/src/ebpf/real/attach.rs
@@ -123,6 +123,7 @@ impl RealEbpfBackend {
         }
         let mut bpf = loader.load(obj)?;
         syscall::validate_loaded_udp_decision_sequence(&bpf)?;
+        let mut pinned_maps = Vec::new();
         for (name, map) in bpf.maps() {
             // aya exposes ELF internal sections (.rodata, .bss, etc.) as maps.
             // These cannot be pinned to bpffs; skip them to avoid noisy warnings.
@@ -134,6 +135,9 @@ impl RealEbpfBackend {
                 continue;
             }
             let pin_path = pin_root.join(name);
+            // Recorded before the attempt, not after it: a stale pin whose unlink and re-pin both
+            // fail still belongs to us, and cleanup is the next chance to remove it.
+            pinned_maps.push(name.to_owned());
             if let Err(error) = std::fs::remove_file(&pin_path)
                 && error.kind() != std::io::ErrorKind::NotFound
             {
@@ -581,6 +585,7 @@ impl RealEbpfBackend {
         Ok(Self {
             bpf: Some(bpf),
             pin_root: pin_root.to_path_buf(),
+            pinned_maps,
             tproxy_port,
             tproxy_mark,
             interface_links,

--- a/crates/honk-core/src/ebpf/real/mod.rs
+++ b/crates/honk-core/src/ebpf/real/mod.rs
@@ -48,6 +48,9 @@ fn kernel_version() -> Option<(u32, u32, u32)> {
 pub struct RealEbpfBackend {
     bpf: Option<Ebpf>,
     pin_root: PathBuf,
+    /// Map names this instance claimed at attach, so cleanup unlinks what it owns instead of
+    /// everything under a pin root that is shared with every other BPF consumer.
+    pinned_maps: Vec<String>,
     tproxy_port: u16,
     tproxy_mark: u32,
     /// Every TC link attached to a configured interface, including the four
@@ -501,24 +504,15 @@ impl RealEbpfBackend {
         })
     }
 
+    /// The pin root defaults to `/sys/fs/bpf`, which every other BPF consumer on the host also
+    /// pins into, so cleanup unlinks the names this instance claimed rather than sweeping the
+    /// directory. `UDP_DECISION_SEQUENCE` is never in that list — attach pins it through
+    /// `map_pin_path` and skips the loop — so the persistent allocator survives by construction.
+    /// A name the current object no longer contains is no longer swept; the sweep used to remove
+    /// it, and nothing else does now.
     fn remove_nonpersistent_pins(&self) -> std::io::Result<()> {
-        let entries = match std::fs::read_dir(&self.pin_root) {
-            Ok(entries) => entries,
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-            Err(error) => return Err(error),
-        };
-        for entry in entries {
-            let entry = entry?;
-            if entry.file_name() == std::ffi::OsStr::new(UDP_DECISION_SEQUENCE_MAP) {
-                continue;
-            }
-            let path = entry.path();
-            let result = if entry.file_type()?.is_dir() {
-                std::fs::remove_dir_all(path)
-            } else {
-                std::fs::remove_file(path)
-            };
-            if let Err(error) = result
+        for name in &self.pinned_maps {
+            if let Err(error) = std::fs::remove_file(self.pin_root.join(name))
                 && error.kind() != std::io::ErrorKind::NotFound
             {
                 return Err(error);

--- a/crates/honk-core/src/ebpf/real/tests.rs
+++ b/crates/honk-core/src/ebpf/real/tests.rs
@@ -168,6 +168,52 @@ async fn link_lifecycle_holds_links_and_rebinds_primary_wan() {
 
 #[tokio::test]
 #[ignore = "requires root; run via just test-netns"]
+async fn cleanup_leaves_foreign_pins_under_a_shared_pin_root() {
+    let pin_root =
+        Path::new("/sys/fs/bpf").join(format!("honk-pin-ownership-test-{}", std::process::id()));
+    std::fs::create_dir_all(&pin_root).expect("pin root");
+    let foreign = pin_root.join("FOREIGN_MAP");
+    aya::maps::Array::<_, u32>::create(1, 0)
+        .expect("create foreign map")
+        .pin(&foreign)
+        .expect("pin foreign map");
+    let foreign_id = aya::maps::MapInfo::from_pin(&foreign)
+        .expect("foreign map info")
+        .id();
+
+    let mut backend = RealEbpfBackend::load(
+        crate::DEFAULT_BPF_OBJECT,
+        &pin_root,
+        12345,
+        0x0800_0000,
+        None,
+        "lo",
+        false,
+    )
+    .await
+    .expect("backend load");
+    backend.detach_hooks().expect("detach hooks");
+    backend.cleanup().await.expect("cleanup");
+
+    assert_eq!(
+        aya::maps::MapInfo::from_pin(&foreign)
+            .expect("cleanup removed a pin this instance did not create")
+            .id(),
+        foreign_id
+    );
+    assert!(
+        pin_root
+            .join(UDP_DECISION_SEQUENCE_MAP)
+            .try_exists()
+            .expect("allocator pin readable"),
+        "cleanup removed the persistent allocator"
+    );
+
+    let _ = std::fs::remove_dir_all(&pin_root);
+}
+
+#[tokio::test]
+#[ignore = "requires root; run via just test-netns"]
 async fn pinned_raw_udp_decision_sequence_survives_reload() {
     let pin_root =
         Path::new("/sys/fs/bpf").join(format!("honk-sequence-reload-test-{}", std::process::id()));


### PR DESCRIPTION
`remove_nonpersistent_pins` enumerated the whole pin root and deleted every entry except
`UDP_DECISION_SEQUENCE`, with `remove_dir_all` for directories. The root defaults to
`/sys/fs/bpf`, which every other BPF consumer on the host also pins into, so an orderly honk
shutdown — and `Drop` — removed pins belonging to Docker, CNI, systemd or anything else there.

The backend now records the map names it pinned during attach and unlinks exactly those. Crash
recovery is unaffected: attach already removes a stale pin by name before re-pinning each map, and
removes `LISTEN_SOCKET_MAP` explicitly, so a successor reclaims its own names without the sweep.
`UDP_DECISION_SEQUENCE` is pinned through `map_pin_path` and skipped by that loop, so it is absent
from the recorded list and survives by construction rather than by a name comparison in cleanup.

One trade-off worth stating: a pin whose name the current object no longer contains — renamed,
removed, or behind a disabled feature — is no longer swept away and lingers until something removes
it. The sweep used to catch that. Names are recorded when the attach loop claims them rather than
after a successful pin, so a stale pin whose unlink and re-pin both fail is still cleaned up later;
what is lost is only the names this build does not know about. Leaving a stale pin of our own is
visible and recoverable; deleting another program's pin is not.

Three adjacent hazards are pre-existing and deliberately untouched here: attach still unlinks a
foreign pin that collides with one of our map names, the `Justfile` recipes still operate on the
flat root, and `eject` unlinks without detaching hooks and currently has no caller.

This does not change the pin layout, the `--bpf-pin-root` contract, or the documented cleanup
behaviour — `AGENTS.md` already describes cleanup as removing ephemeral pins while preserving the
rollback-compatible allocator, which is what this now does precisely. An owned `<root>/honk`
subtree would be the stronger boundary, but it changes the CLI meaning and the allocator's
rollback path, so it is left as a separate decision.

Verified with `cargo fmt --all --check`, `cargo clippy --workspace --all-targets` (clean), and
`cargo test --workspace --no-fail-fast -- --skip test_routing_with_config_dae` at 942 passed,
2 failed — the two geosite tests that need an asset this environment does not provide, failing
identically on `main`. The behaviour itself is proved by a root-gated test rather than the mock,
which does not touch bpffs: `cleanup_leaves_foreign_pins_under_a_shared_pin_root` pins a foreign
map in a shared root, records its map id, runs load and cleanup, and asserts the foreign id and the
allocator pin are still there. Run under `--features ebpf --ignored`, it passes alongside the other
root-only eBPF tests; `control::tests::nfqueue_tc_netns_direct_proxy_contract` fails here with a
bare `No such file or directory` on an unmodified tree as well.
