### PR TITLE
fix: close the two reload lock cycles

### DIFF
--- a/crates/honk-core/src/clash_api.rs
+++ b/crates/honk-core/src/clash_api.rs
@@ -623,9 +623,10 @@ async fn put_proxy(
 
     // cache.db persistence runs through the group manager's persist
     // callback, wired by ControlPlane::init_cache_db.
-    s.group_manager
-        .read()
-        .set_selector_choice(&group_name, &body.name);
+    // The setter runs its callbacks synchronously and interrupt handling
+    // reacquires this lock, so the guard is released before the call.
+    let group_manager = s.group_manager.read().clone();
+    group_manager.set_selector_choice(&group_name, &body.name);
     StatusCode::NO_CONTENT.into_response()
 }
 

--- a/crates/honk-core/src/control/cache.rs
+++ b/crates/honk-core/src/control/cache.rs
@@ -19,14 +19,15 @@ impl ControlPlane {
         // callback so restoration does not rewrite the same values.
         {
             let config = self.config.read().await;
+            // The setter runs its callbacks synchronously and interrupt handling
+            // reacquires this lock, so the guard is released before the calls.
+            let group_manager = self.group_manager.read().clone();
             for group in &config.groups {
                 if group.policy == GroupPolicy::Selector
                     && let Some(node) = db.load_selector_choice(&group.name)
                 {
                     info!("cache.db: restored selector '{}' = '{}'", group.name, node);
-                    self.group_manager
-                        .read()
-                        .set_selector_choice(&group.name, &node);
+                    group_manager.set_selector_choice(&group.name, &node);
                 }
             }
         }

--- a/crates/honk-core/tests/clash_api_test.rs
+++ b/crates/honk-core/tests/clash_api_test.rs
@@ -375,6 +375,37 @@ routing {
 }
 
 #[tokio::test]
+async fn test_selector_switch_releases_the_group_manager_lock() {
+    // The callbacks must run without the shared-manager guard: interrupt
+    // handling reacquires it, which wedges behind a waiting reload writer.
+    let app = spawn_app("", "").await;
+    let observed = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    {
+        let manager = app.state.group_manager.read().clone();
+        let cell = Arc::clone(&app.state.group_manager);
+        let observed = Arc::clone(&observed);
+        manager.set_selector_change_callback(Some(Arc::new(move || {
+            observed.store(
+                cell.try_write().is_some(),
+                std::sync::atomic::Ordering::SeqCst,
+            );
+        })));
+    }
+
+    let resp = http_client()
+        .put(app.url("/proxies/proxy"))
+        .json(&serde_json::json!({"name": "node-b"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 204);
+    assert!(
+        observed.load(std::sync::atomic::Ordering::SeqCst),
+        "the handler held the group manager lock across the selector callbacks"
+    );
+}
+
+#[tokio::test]
 async fn test_proxies_structure_and_selector_switch() {
     let app = spawn_app("", "").await;
     let client = http_client();

--- a/crates/honk-outbound/src/alive/mod.rs
+++ b/crates/honk-outbound/src/alive/mod.rs
@@ -1530,11 +1530,13 @@ impl AliveDialerSet {
     /// URLTest group it belongs to is idle. Nodes outside URLTest groups
     /// are never suspended.
     pub fn is_probe_suspended(&self, node_id: Uuid) -> bool {
-        let groups = self.node_urltest_groups.read();
-        match groups.get(&node_id) {
-            Some(gs) if !gs.is_empty() => gs.iter().all(|g| self.is_urltest_group_idle(g)),
-            _ => false,
-        }
+        // Reload takes `urltest_group_timeout` first and this map last, so the
+        // names are copied out rather than held across the idle checks.
+        let groups = match self.node_urltest_groups.read().get(&node_id) {
+            Some(groups) if !groups.is_empty() => groups.clone(),
+            _ => return false,
+        };
+        groups.iter().all(|group| self.is_urltest_group_idle(group))
     }
 
     /// Number of consecutive TCP failures for this node.

--- a/crates/honk-outbound/src/alive/tests.rs
+++ b/crates/honk-outbound/src/alive/tests.rs
@@ -285,6 +285,49 @@ async fn test_recovery_cycle_probes_due_dead_udp_nodes() {
     assert!(set.is_alive_for(node_id, ProbeDomain::DnsUdp, IpVersion::V6));
 }
 
+#[test]
+fn test_suspension_check_releases_node_groups_before_reading_timeouts() {
+    // Reload takes urltest_group_timeout first and node_urltest_groups last.
+    // A suspension check reads them in the opposite order, so it must release
+    // the node groups before consulting the timeouts or the two orders form a
+    // cycle. With the timeouts held here the check cannot finish; the node
+    // groups must still be free for reload's next acquisition.
+    let set = std::sync::Arc::new(AliveDialerSet::new());
+    set.register_node(id(1), "n1".into(), "127.0.0.1:1".into());
+    set.register_urltest_group("g", &[id(1)], Some(Duration::from_millis(50)));
+
+    let timeouts = set.urltest_group_timeout.write();
+    let (entered, started) = std::sync::mpsc::channel();
+    let prober = {
+        let set = std::sync::Arc::clone(&set);
+        std::thread::spawn(move || {
+            let _ = entered.send(());
+            set.is_probe_suspended(id(1))
+        })
+    };
+    started.recv().unwrap();
+    std::thread::sleep(Duration::from_millis(10));
+
+    // The check cannot finish while the timeouts are held, so a map that is
+    // never free within the deadline is one held across the idle lookup.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let mut node_groups_free = false;
+    while std::time::Instant::now() < deadline {
+        if set.node_urltest_groups.try_write().is_some() {
+            node_groups_free = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(5));
+    }
+    drop(timeouts);
+    prober.join().unwrap();
+
+    assert!(
+        node_groups_free,
+        "the suspension check held node_urltest_groups while waiting for urltest_group_timeout"
+    );
+}
+
 #[tokio::test]
 async fn test_urltest_idle_suspension() {
     let set = AliveDialerSet::new();


### PR DESCRIPTION
## Summary

- `is_probe_suspended` copies the group names out of `node_urltest_groups` instead of holding that guard across `is_urltest_group_idle`, which takes `urltest_group_timeout`. Reload acquires the timeouts first and the node map last, so the two orders formed a cycle.
- `set_selector_choice` runs its persist, selector-change, and interrupt callbacks synchronously, and interrupt handling reacquires the shared group manager. The three callers that invoked the setter through a live read guard now clone the `Arc` first, as the neighbouring read handlers in `clash_api.rs` already do.

Closes #146.

## Sites changed

`clash_api.rs` `put_proxy` is the one the issue reported. `control/cache.rs` restores stored selector choices through the same shape and is fixed with it; leaving it would close the issue with the pattern still present.

## Observed but not changed

`control/connection/udp.rs:287` and `dns/upstream_pool/routing.rs:95` hold the manager guard across target selection, which can reach `maybe_interrupt` through URLTest and Fallback policies. Neither is an established deadlock on the ordinary SIGHUP path: UDP holds the config read guard while transactional reload takes the config write before the group write, and production DNS installs a pinned snapshot. They are reported here rather than changed, because the fix would be speculative surgery on a hot path. The guard audit is not clean; these two are what remains.

## Verification

Both tests were written to fail first. Each was run against the tree with the production fix reverted and again with it restored:

- `test_suspension_check_releases_node_groups_before_reading_timeouts` — without the fix, "the suspension check held node_urltest_groups while waiting for urltest_group_timeout" after the 5s deadline; with it, passes. It holds the timeouts, waits for the prober to enter, and then requires the node map to become free.
- `test_selector_switch_releases_the_group_manager_lock` — without the fix, "the handler held the group manager lock across the selector callbacks"; with it, passes. The probe runs inside a selector-change callback and reports whether a writer could acquire the lock.

An earlier version of the first test ran 200 concurrent iterations and passed against the unfixed code, so it was replaced: the race window is too small to hit by repetition, and a test that cannot go red is not a gate.

- `cargo clippy -p honk-core -p honk-outbound --all-targets` — clean.
- `cargo fmt --all --check` — clean.
- `cargo test --workspace` — the only failures are `routing::tests::test_geosite_*`, which need local geo assets and fail identically without this change.

No live reload or datapath run: both fixes are lock-lifetime changes and the tests assert that property directly.
