### PR TITLE
fix(ci): keep the mechanical review working on fork pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,9 +209,21 @@ jobs:
               lines.push("", "No structural issues detected.");
             }
 
+            const body = lines.join("\n");
+            await core.summary.addRaw(body).write();
+
+            // A pull_request run from a fork gets a read-only token whatever
+            // `permissions:` asks for, so commenting there fails the job and
+            // hides the review that was just written to the step summary.
+            const head = pr.head.repo?.full_name;
+            if (head !== `${context.repo.owner}/${context.repo.repo}`) {
+              core.info("fork pull request: review written to the step summary");
+              return;
+            }
+
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: pr.number,
-              body: lines.join("\n"),
+              body,
             });


### PR DESCRIPTION
## Problem

`mechanical PR review` fails on every pull request from a fork:

```
POST /repos/daeuniverse/honk/issues/148/comments - 403
Resource not accessible by integration
x-accepted-github-permissions: issues=write; pull_requests=write
```

The workflow already asks for `pull-requests: write`, but a `pull_request` run whose head is a fork gets a read-only `GITHUB_TOKEN` regardless of what `permissions:` requests. The review is computed correctly and then thrown away when the comment fails, and the failing check is the only thing left on the PR.

## Change

Write the review to the step summary first, then post the comment only when the head repository is this repository.

The token is not escalated and the trigger is unchanged. `pull_request_target` would restore commenting on forks, but it runs with a write token against the base repository, and this job would be the only thing standing between that token and any future step that checks out PR code. The step summary is where this output is still readable on a fork PR, and the check stops failing.

## Verification

- The workflow parses (`yaml.safe_load`) and the embedded script passes `node --check`.
- The branch condition was exercised directly, since a fork run cannot be produced before merge:

```
same-repository PR   -> comment
fork PR              -> summary-only
fork deleted (null)  -> summary-only
```

`pr.head.repo?.full_name` rather than `pr.head.repo.full_name`: the third case throws otherwise, which is the same failure this change is removing.
