### PR TITLE
Rename README_CN.md, match the Justfile to CI, note the geosite test assets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ cargo +nightly build --release -Zbuild-std=core --target bpfel-unknown-none
 
 | Recipe                                                                          | Purpose                                                                                                                                                                                                                                      |
 | ------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `build` / `check` / `lint` / `fmt`                                              | `cargo build --release` / `check` / `clippy --all -D warnings` / `fmt --all`                                                                                                                                                                 |
+| `build` / `check` / `lint` / `fmt` / `fmt-check`                                              | `cargo build --release` / `check` / `clippy --all --all-targets -- -D warnings` / `fmt --all` / `fmt --all -- --check`                                                                                                                                                                 |
 | `test-routing` | Root-gated compiled-policy check: builds the `routing-test` eBPF object and exercises the real object against independent goldens plus failed root-publication preservation (Linux 6.12+) |
 | `test` / `test-ci` / `test-core` / `test-config` / `test-ebpf`                  | Test suites (`test` = full workspace; `test-ci` = CI gate with the known legacy routing failure skipped; `test-ebpf` = honk-ebpf-common only)                                                                                                |
 | `test-netns`                                                                    | Depends on `test-routing`; root-gated real-kernel tests for production NFQUEUE/nftables IPv4+IPv6 held-verdict contract, eBPF netlink/netns roundtrips, link ownership/rebind lifecycle, and pinned allocator rollback compatibility (`--features ebpf --ignored`, serial) |
@@ -233,7 +233,7 @@ JA4 was verified on .70 with `/usr/local/bin/ja4probe` (`ja4probe`, source
 - Use `tracing` macros for logging; prefer structured fields (`info!(network = "tcp", outbound = %name, ...)`).
 - Use `tokio` async/await and `tokio::select!` for long-lived loops.
 - Kernel/userspace structs belong in `honk-ebpf-common`; follow its stable `#[repr(C)]` layout and coordinated `honk-ebpf`/`honk-core` map-writer change rules.
-- Follow `cargo fmt --all` and keep `cargo clippy --all -- -D warnings` clean.
+- Follow `cargo fmt --all` and keep `cargo clippy --all --all-targets -- -D warnings` clean.
 - **Claims need their line.** A consequence stated in a PR or an issue names the code producing it, or is narrowed until it can; say what you did not check. Line numbers come from `origin/main`, not your working tree.
 - **Read to the end of the path before describing a defect.** The trigger, the consequence, and the absence of a thing are each bounded by code you have not opened yet: the callee, the caller, the consumer that clamps the value, the search that would have settled it.
 - **Fix where the paths converge**, not where you first saw the failure: a guard on one loader leaves its siblings failing open.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,7 +204,7 @@ only the ignored root NFQUEUE test proves real nftables/queue/verdict semantics,
 not the unprivileged suite. Deployment A/B needs real eBPF/netns/upstreams and the
 `bench` lab harness. Production BoringSSL versus test rustls: Technology stack.
 
-`routing::tests::test_geosite_*` needs `/etc/dae/geosite.dat` and `geoip.dat`.
+`routing::tests::test_geosite_*` need `geosite.dat`/`geoip.dat`. Both tests call `use_repo_geo_assets()`, which points `DAE_LOCATION_ASSET` at the checkout root, so files at the top of the checkout are the quickest local setup; otherwise the loader falls through the documented geo asset search order, which is how CI's `/etc/dae` install works, and the tests fail for a reason unrelated to the change under test.
 Unset `HTTP_PROXY`/`HTTPS_PROXY` so reqwest does not proxy Clash UI loopback fetches.
 Install boring-sys prerequisites (Technology stack) and its REALITY-hooks checkout
 at pinned `/root/code/boring-rprx/boring-sys`. Cross-build with `ci/zig*`, not containers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Re-read it when a conversation grows long or context is trimmed: a rule read onc
 - `honk-config` provides shared types/parsers for original dae `{ section { ... } }`, the primary and only documented config syntax.
 - Status: **experimental alpha** (`v0.0.1-alpha`). Expect breaking changes.
 - License: **GPL-3.0-only**. Repository: <https://github.com/daeuniverse/honk>
-- Docs: `README.md` / `README_CN.md` (bilingual overview, feature checklist, TODO list); matching `doc/en/` / `doc/zh/` trees under `doc/`, indexed by bilingual `doc/README.md`. Each has `configuration.md`, `design/` (overview/datapath/routing/nfqueue/control-plane/dns/outbound/groups), `reference/` (global/nodes/groups/routing/dns/subscription/experimental/api/cli), and `operations/` runbooks. Lab benchmark tooling, evidence, and bilingual docs live only on `bench`.
+- Docs: `README.md` / `README.zh.md` (bilingual overview, feature checklist, TODO list); matching `doc/en/` / `doc/zh/` trees under `doc/`, indexed by bilingual `doc/README.md`. Each has `configuration.md`, `design/` (overview/datapath/routing/nfqueue/control-plane/dns/outbound/groups), `reference/` (global/nodes/groups/routing/dns/subscription/experimental/api/cli), and `operations/` runbooks. Lab benchmark tooling, evidence, and bilingual docs live only on `bench`.
 
 ## Repository layout
 
@@ -20,7 +20,7 @@ Re-read it when a conversation grows long or context is trimmed: a rule read onc
 .
 ├── Cargo.toml / Cargo.lock   # Workspace manifest (release + release-musl profiles)
 ├── Justfile                  # Day-to-day dev tasks (build, test, run, debug via clash API, cleanup)
-├── README.md / README_CN.md  # Bilingual project overview
+├── README.md / README.zh.md  # Bilingual project overview
 ├── AGENTS.md                 # This file
 ├── LICENSE                   # GPL-3.0-only
 ├── config.dae                # Full-featured example config (production-leaning)
@@ -240,7 +240,7 @@ JA4 was verified on .70 with `/usr/local/bin/ja4probe` (`ja4probe`, source
 - **A check that could not run did not pass.** If a gate is missing, errors, or produces no output, say so; empty output reads exactly like a clean run.
 - Stop before touching an area `CONTRIBUTING.md` reserves, before anything leaves the machine, and before discarding work someone else may want; otherwise continue.
 - Match the surrounding file's idioms; make minimal, scoped changes (no opportunistic cleanups).
-- Documentation language: code comments and `doc/en/` docs are English; user docs are bilingual (`README_CN.md`, `doc/zh/`) — update both when you change documented behavior.
+- Documentation language: code comments and `doc/en/` docs are English; user docs are bilingual (`README.zh.md`, `doc/zh/`) — update both when you change documented behavior.
 
 ## Testing instructions
 

--- a/Justfile
+++ b/Justfile
@@ -58,11 +58,15 @@ check:
 
 # Clippy lint all
 lint:
-    cargo clippy --all -- -D warnings
+    cargo clippy --all --all-targets -- -D warnings
 
 # Format all
 fmt:
     cargo fmt --all
+
+# Check formatting
+fmt-check:
+    cargo fmt --all -- --check
 
 # ── Test ─────────────────────────────────────────────────
 
@@ -70,7 +74,7 @@ fmt:
 test:
     cargo test --all
 
-# CI-equivalent gate: full suite minus the known pre-existing routing failure.
+# Workspace test gate: full suite minus the known pre-existing routing failure.
 test-ci:
     cargo test --workspace --no-fail-fast -- --skip test_routing_with_config_dae
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # honk
 
-[English](./README.md) | [中文](./README_CN.md)
+English | [中文](./README.zh.md)
 
 ---
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,6 +1,6 @@
 # honk
 
-[English](./README.md) | [中文](./README_CN.md)
+[English](./README.md) | 中文
 
 ---
 
@@ -60,7 +60,7 @@ VLESS 分享链接通过 `vless_mode=legacy|uot-v2|h2mux|h2mux-padded|xudp|mux-c
 - [x] 通过出站 `PacketTransport` 上的 quinn `AsyncUdpSocket` adapter 添加代理 DoQ/DoH3
 - [ ] 评估 AF_XDP 与 XDP 路径以进一步提升性能
 - [ ] 添加 honk REST API
-- [ ] 添加 inbound 支持
+- [ ] 添加入站支持
 - [ ] 通过 GitHub [Issues](https://github.com/Glassyiris/honk/issues) 和 [Discussions](https://github.com/Glassyiris/honk/discussions) 跟踪其他工作
 
 > 在所有当前尚未 review 的代码完成 review，并处理所有未经验证的 AI 生成实现前，不会发布 `test.1` release tag。


### PR DESCRIPTION
## Problem

Three small mismatches. `README_CN.md` does not follow the `README.<lang>.md` convention. `just lint` runs `clippy --all -- -D warnings` while CI runs `--all --all-targets` (`.github/workflows/ci.yml:30`), and there is no recipe for CI's `cargo fmt --all -- --check` (`ci.yml:29`), so a passing `just lint` does not imply a passing CI. `AGENTS.md:207` says the geosite tests need `/etc/dae/geosite.dat`, but both tests now call `use_repo_geo_assets()` (`crates/honk-core/src/routing/tests.rs:322-329`), which points `DAE_LOCATION_ASSET` at the checkout root — the quicker local path, and it is not mentioned.

## How I fixed it

Three atomic commits. The rename carries its own self-link and the three `AGENTS.md` references, so no intermediate tree mentions the old name. The Justfile commit adds `--all-targets` to `lint`, adds `fmt-check`, and updates the recipe table and the clippy line in `AGENTS.md` with it. The geosite commit amends line 207 in place. Dropped from the earlier version of this PR: a one-owner engineering rule and a `delay test` → `延迟测试` wording change, both unrelated to these three fixes. The rename does break external links to `README_CN.md`; that is the cost of the convention and is intentional.

## Verified

No `README_CN` reference remains in the tree of any of the three commits. The `lint` and `fmt-check` recipe bodies match `ci.yml:29-30` character for character. Docs and Justfile only, no Rust change, so no cargo gate is affected; `just` is not installed here, so the recipes were checked textually rather than executed.