### PR TITLE
fix(geo): warn when a geoip code expands to nothing

### DIFF
--- a/crates/honk-core/src/routing/geo.rs
+++ b/crates/honk-core/src/routing/geo.rs
@@ -368,8 +368,17 @@ impl GeoAssets {
             }
             match &self.geoip {
                 Some(index) => {
+                    let before = nets.len();
                     if let Some(v) = index.get(&code.to_lowercase()) {
                         nets.extend(v.iter().cloned());
+                    }
+                    if nets.len() == before {
+                        // Same reason as the geosite path: a code that expands
+                        // to nothing silently disables its rule.
+                        tracing::warn!(
+                            code,
+                            "geoip code expanded to zero networks; rule will never match"
+                        );
                     }
                 }
                 None => {
@@ -1074,6 +1083,33 @@ fn split_geoip_entry(data: &[u8]) -> anyhow::Result<(Option<String>, Vec<&[u8]>)
 #[cfg(test)]
 mod scan_tests {
     use super::*;
+
+    #[test]
+    fn geoip_code_expanding_to_nothing_warns_like_geosite() {
+        let output = tempfile::NamedTempFile::new().unwrap();
+        let subscriber = tracing_subscriber::fmt()
+            .without_time()
+            .with_ansi(false)
+            .with_writer(Arc::new(output.reopen().unwrap()))
+            .finish();
+        let dat = geoip_dat(&[("cn", vec![(&[1, 0, 0, 0], 8)])]);
+        let codes: std::collections::HashSet<String> =
+            ["cn".to_string(), "zz".to_string()].into_iter().collect();
+        let assets = GeoAssets {
+            geosite: None,
+            geoip: Some(parse_geoip_index(&dat, &codes).unwrap()),
+        };
+        tracing::subscriber::with_default(subscriber, || {
+            assert_eq!(assets.geoip_nets(&["cn".into()]).len(), 1);
+            assert!(assets.geoip_nets(&["zz".into()]).is_empty());
+        });
+        let output = std::fs::read_to_string(output.path()).unwrap();
+        assert!(output.contains("geoip code expanded to zero networks"));
+        assert!(
+            !output.contains("code=cn"),
+            "a matching code must stay quiet"
+        );
+    }
 
     #[test]
     fn missing_geo_asset_warns_only_when_required() {


### PR DESCRIPTION
## Problem

`geoip_nets` says nothing when a code matches no network, while the geosite path in the same file warns for the same situation and its comment gives the reason — a code that expands to nothing silently disables its rule. The geoip `None` arm already warns when the index is unavailable, so the gap is narrow: an asset that loaded fine, and a code inside it that resolves to nothing. `dip(geoip:typo)` disables its rule and the log stays empty.

## How I fixed it

The expansion records the network count before the lookup and warns when nothing was added, matching the geosite wording and placement. It sits inside the shared expansion function rather than at a call site, so all four callers are covered at once.

## Verified

`geoip_code_expanding_to_nothing_warns_like_geosite` fails without the warning and passes with it, and asserts that a code which does match stays quiet so the warning cannot fire on the ordinary path. Only the diagnostic changes: a code that expands to nothing still contributes no networks, and whether that should instead fail the load is a separate question this does not answer. `cargo fmt --all -- --check`, `cargo clippy -p honk-core --all-targets`, and `cargo test -p honk-core --lib routing::geo` are clean.
