### PR TITLE
fix(dns): drop the duplicate geosite expansion warning

### DIFF
--- a/crates/honk-core/src/dns/routing.rs
+++ b/crates/honk-core/src/dns/routing.rs
@@ -8,7 +8,6 @@ mod compiler {
         DnsCond, DnsDomainMatcher, DnsRequestAction, DnsRequestRouting, DnsResponseAction,
         DnsResponseRouting,
     };
-    use tracing::warn;
 
     use super::matcher::{CompiledCond, CompiledDomainMatcher};
     use crate::routing::{
@@ -168,13 +167,8 @@ mod compiler {
                 })?)
             }
             DnsDomainMatcher::Geosite(code) => {
+                // `geosite_domains` already warns when a code expands to nothing.
                 let domains = assets.geosite_domains(std::slice::from_ref(code));
-                if domains.is_empty() {
-                    warn!(
-                        "geosite code '{}' expanded to 0 domains; matcher will never match",
-                        code
-                    );
-                }
                 CompiledDomainMatcher::Geosite(GeositeMatcher::build(&domains))
             }
         })


### PR DESCRIPTION
## Problem

`compile_domain_matcher` warns when a geosite code expands to nothing, but `geosite_domains` already warns for that condition inside its own per-code loop, so a DNS rule naming an unknown code logs it twice in two different wordings.

## How I fixed it

The caller-side warning and the `use tracing::warn` it was the only user of are removed; the shared function keeps reporting, so every caller — the traffic rule, its negation, and this DNS site — still gets one line. The `code` field survives in all three log layers, since both `fmt::layer()` instances render structured fields by default and the Clash API layer writes non-message fields into its payload.

## Verified

Compiling a geosite matcher against assets without the code emitted two warnings before and one after; the measurement needed a temporary visibility change that is not in this branch. No test was added: an assertion that the removed wording is absent would pass trivially forever. `cargo fmt --all -- --check`, `cargo clippy -p honk-core --all-targets`, and `cargo test -p honk-core --lib dns::routing` are clean.
