### PR TITLE
fix(config): reject millisecond durations the parser cannot read

### DIFF
--- a/crates/honk-config/src/parser/mod.rs
+++ b/crates/honk-config/src/parser/mod.rs
@@ -803,7 +803,7 @@ fn parse_global_section(section: &Section) -> Result<GlobalConfig, crate::Config
         cfg.check_interval_secs = parse_duration_secs(v);
     }
     if let Some(v) = kv.get("check_tolerance") {
-        cfg.check_tolerance_ms = parse_duration_ms(v);
+        cfg.check_tolerance_ms = parse_checked_duration_ms(v, "global.check_tolerance")?;
     }
     if let Some(v) = kv.get("dial_mode") {
         cfg.dial_mode = v.clone();
@@ -815,7 +815,7 @@ fn parse_global_section(section: &Section) -> Result<GlobalConfig, crate::Config
         cfg.allow_insecure = parse_bool(v);
     }
     if let Some(v) = kv.get("sniffing_timeout") {
-        cfg.sniffing_timeout_ms = parse_duration_ms(v);
+        cfg.sniffing_timeout_ms = parse_checked_duration_ms(v, "global.sniffing_timeout")?;
     }
     if let Some(v) = kv.get("tls_implementation") {
         cfg.tls_implementation = v.clone();
@@ -1217,19 +1217,10 @@ fn parse_duration_secs(s: &str) -> u64 {
     crate::types::parse_duration_secs(s).unwrap_or(0)
 }
 
-fn parse_duration_ms(s: &str) -> u64 {
-    let s = s.trim();
-    if s.ends_with("ms") {
-        return s.trim_end_matches("ms").parse().unwrap_or(0);
-    }
-    if s.ends_with('s') {
-        return s
-            .trim_end_matches('s')
-            .parse::<f64>()
-            .map(|v| (v * 1000.0) as u64)
-            .unwrap_or(0);
-    }
-    s.parse::<f64>().map(|v| v as u64).unwrap_or(0)
+fn parse_checked_duration_ms(s: &str, setting: &str) -> Result<u64, crate::ConfigError> {
+    crate::types::parse_duration_ms(s).ok_or_else(|| {
+        crate::ConfigError::Parse(format!("invalid millisecond duration for {setting}: {s}"))
+    })
 }
 
 fn parse_ip_prefer(s: &str) -> crate::dns::DnsStrategy {

--- a/crates/honk-config/src/parser/tests.rs
+++ b/crates/honk-config/src/parser/tests.rs
@@ -40,6 +40,32 @@ global {
     }
 
     #[test]
+    fn test_millisecond_durations_reject_values_they_cannot_read() {
+        for (value, expected) in [("50ms", 50), ("0ms", 0), ("0.5s", 500), ("50", 50)] {
+            let input = format!("global {{\n    check_tolerance: {value}\n}}");
+            let config = parse_dae_config(&input).unwrap();
+            assert_eq!(config.global.check_tolerance_ms, expected, "{value}");
+        }
+
+        for value in [
+            "1m", "2h", "1min", "abc", "-5ms", "-0.5s", "1.5ms", "inf", "nan", "",
+        ] {
+            for (setting, key) in [
+                ("global.check_tolerance", "check_tolerance"),
+                ("global.sniffing_timeout", "sniffing_timeout"),
+            ] {
+                let input = format!("global {{\n    {key}: {value}\n}}");
+                let error = parse_dae_config(&input).unwrap_err();
+                assert!(matches!(error, crate::ConfigError::Parse(_)), "{value}");
+                assert!(
+                    error.to_string().contains(setting),
+                    "error must identify {setting} for {value}: {error}"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn test_parse_store_subscribe() {
         assert!(
             parse_dae_config("global {}")

--- a/crates/honk-config/src/types.rs
+++ b/crates/honk-config/src/types.rs
@@ -148,3 +148,25 @@ pub fn parse_duration_secs(s: &str) -> Option<u64> {
     }
     s.parse().ok()
 }
+
+/// Parse a millisecond duration like `500ms`, `0.5s` or a bare `500`. The
+/// minute and hour suffixes `parse_duration_secs` accepts are deliberately
+/// not part of this grammar. `as u64` saturates, so a non-finite or negative
+/// value is refused rather than becoming `u64::MAX` or zero.
+pub fn parse_duration_ms(s: &str) -> Option<u64> {
+    let s = s.trim();
+    if let Some(v) = s.strip_suffix("ms") {
+        return v.parse().ok();
+    }
+    if let Some(v) = s.strip_suffix('s') {
+        return v
+            .parse::<f64>()
+            .ok()
+            .filter(|v| v.is_finite() && *v >= 0.0)
+            .map(|v| (v * 1000.0) as u64);
+    }
+    s.parse::<f64>()
+        .ok()
+        .filter(|v| v.is_finite() && *v >= 0.0)
+        .map(|v| v as u64)
+}

--- a/doc/en/reference/global.md
+++ b/doc/en/reference/global.md
@@ -25,10 +25,10 @@ Compatibility-only keys are accepted by the dae parser and stored in `GlobalConf
 | `tcp_check_http_method` | `tcp_check_http_method` | `"HEAD"` | HTTP method sent by the URL health check. An empty value is treated as `HEAD`. |
 | `udp_check_dns` | `udp_check_dns` | `["dns.google:53", "8.8.8.8", "2001:4860:4860::8888"]` | Comma-separated DNS targets for UDP health checks; a missing port defaults to `53`. |
 | `check_interval` | `check_interval_secs` | `30s` | Global health-check interval. Must be positive; a value that fails to parse becomes zero and is rejected at validation. The UDP warm coordinator also uses it, with an effective minimum of 10 seconds. |
-| `check_tolerance` | `check_tolerance_ms` | `50ms` | Latency improvement required before URLTest changes its selected member. |
+| `check_tolerance` | `check_tolerance_ms` | `50ms` | Latency improvement required before URLTest changes its selected member. Accepts bare milliseconds, `ms`, or `s`; anything else is rejected when the configuration loads. |
 | `dial_mode` | `dial_mode` | `"domain"` | Destination-domain discovery and routing mode: `ip`, `domain`, `domain+`, or `domain++`. See [Dial modes](#dial-modes). |
 | `allow_insecure` | `allow_insecure` | `false` | Compatibility global TLS-verification fallback. Current TLS connectors do not read it; certificate skipping is configured per node in its share link. |
-| `sniffing_timeout` | `sniffing_timeout_ms` | `30ms` | Compatibility sniffing timeout. The dae parser stores the duration, but the current control plane does not read it. |
+| `sniffing_timeout` | `sniffing_timeout_ms` | `30ms` | Compatibility sniffing timeout. The dae parser stores the duration, but the current control plane does not read it. Accepts bare milliseconds, `ms`, or `s`; anything else is rejected when the configuration loads. |
 | `tls_implementation` | `tls_implementation` | `"tls"` | `tls` uses the regular BoringSSL client profile; `utls` enables honk's real Chrome ClientHello profile. |
 | `utls_imitate` | `utls_imitate` | `"chrome_auto"` | Fingerprint profile requested with `utls`. Only `chrome*` is implemented; other values warn and still use Chrome. |
 | `tls_fragment` | `tls_fragment` | `false` | Compatibility TLS ClientHello-fragmentation switch. The current TLS connector does not read it. |

--- a/doc/zh/reference/global.md
+++ b/doc/zh/reference/global.md
@@ -25,10 +25,10 @@
 | `tcp_check_http_method` | `tcp_check_http_method` | `"HEAD"` | URL 健康检查发送的 HTTP 方法；空值按 `HEAD` 处理。 |
 | `udp_check_dns` | `udp_check_dns` | `["dns.google:53", "8.8.8.8", "2001:4860:4860::8888"]` | UDP 健康检查的 DNS 目标，逗号分隔；省略端口时默认为 `53`。 |
 | `check_interval` | `check_interval_secs` | `30s` | 全局健康检查间隔。必须为正；解析失败的值会变成零并在校验时被拒绝。UDP 预热 coordinator 也使用该值，但实际下限为 10 秒。 |
-| `check_tolerance` | `check_tolerance_ms` | `50ms` | URLTest 切换所选成员前要求的延迟改善量。 |
+| `check_tolerance` | `check_tolerance_ms` | `50ms` | URLTest 切换所选成员前要求的延迟改善量。接受裸毫秒数、`ms` 或 `s`，其余写法在配置加载时被拒绝。 |
 | `dial_mode` | `dial_mode` | `"domain"` | 目的域名发现和路由模式：`ip`、`domain`、`domain+` 或 `domain++`。参见[拨号模式](#拨号模式)。 |
 | `allow_insecure` | `allow_insecure` | `false` | 全局 TLS 校验回退兼容字段。当前 TLS connector 不读取该字段；跳过证书校验需在节点分享链接中按节点配置。 |
-| `sniffing_timeout` | `sniffing_timeout_ms` | `30ms` | 嗅探超时兼容字段。dae 解析器会保存该时长，但当前控制面不读取它。 |
+| `sniffing_timeout` | `sniffing_timeout_ms` | `30ms` | 嗅探超时兼容字段。dae 解析器会保存该时长，但当前控制面不读取它。接受裸毫秒数、`ms` 或 `s`，其余写法在配置加载时被拒绝。 |
 | `tls_implementation` | `tls_implementation` | `"tls"` | `tls` 使用常规 BoringSSL 客户端 profile；`utls` 启用 honk 的真实 Chrome ClientHello profile。 |
 | `utls_imitate` | `utls_imitate` | `"chrome_auto"` | 使用 `utls` 时请求的指纹 profile。当前只实现 `chrome*`；其他值会告警并仍使用 Chrome。 |
 | `tls_fragment` | `tls_fragment` | `false` | TLS ClientHello 分片兼容开关；当前 TLS connector 不读取该字段。 |


### PR DESCRIPTION
## Problem

`parse_duration_ms` returned 0 for anything it could not read, so `check_tolerance: 1m`, `1min`, a typo, an empty value or a negative one loaded without complaint as zero — the configuration reads as intended while URLTest runs on its effective minimum of 1 ms (`group/policy.rs:220`, documented at `doc/en/reference/groups.md:42`) instead of the threshold the operator set. `inf` was worse: `as u64` saturates, so it became `u64::MAX`. Reported as #157.

## How I fixed it

The grammar moves to `types::parse_duration_ms`, beside `types::parse_duration_secs`, which already owns duration parsing and already returns `Option`; non-finite and negative values are filtered there before the cast. `parser/mod.rs` keeps only the wrapping into `ConfigError::Parse` naming the setting, which is the shape `parse_checked_bool` already has. The two callers, `global.check_tolerance` and `global.sniffing_timeout`, propagate it. Accepted forms are unchanged: bare milliseconds, `ms`, and `s`. The new function mirrors its neighbour's shape — a chain of `strip_suffix` early returns — so the two read the same way. Both language references state that anything else is rejected. A deployed configuration carrying one of these values stops loading instead of running with zero, which is the same trade `check_interval` took in #134.

## Verified

The new test is red on the old parser — `check_tolerance: 1m` loads with `check_tolerance_ms: 0` — and green after. `cargo test -p honk-config` passes 173 tests, `cargo fmt --all -- --check` and `cargo clippy --all --all-targets -- -D warnings` are clean, and the workspace gate passes apart from `routing::tests::test_geosite_cn_route`, which fails the same way on an unmodified `45f1a8a` for an unrelated reason.

One limit worth naming: through `Config::from_file` this error is replaced by the structured-format fallback, so a `.dae` file without an `include` reports `Parse error: expected value at line 1 column 1` rather than the setting name. That is pre-existing — `parse_checked_bool` behaves identically today — and I left it alone rather than widen this change.

