### PR TITLE
test(routing): give both geosite tests their own asset location

### DIFF
--- a/crates/honk-core/src/routing/tests.rs
+++ b/crates/honk-core/src/routing/tests.rs
@@ -314,8 +314,25 @@ fn test_priority_ordering() {
     assert_eq!(router.route(&conn), "proxy2");
 }
 
+/// Both geosite route tests need `geosite.dat`. This override lived inside
+/// `test_geosite_route`, so on a checkout where the asset is reachable only
+/// through it, `test_geosite_cn_route` passed or failed by whichever ran
+/// first in the process.
+#[allow(clippy::let_unit_value)]
+fn use_repo_geo_assets() {
+    // FIXME: Audit that the environment access only happens in single-threaded code.
+    let _ = unsafe {
+        std::env::set_var(
+            "DAE_LOCATION_ASSET",
+            concat!(env!("CARGO_MANIFEST_DIR"), "/../.."),
+        )
+    };
+}
+
 #[test]
 fn test_geosite_cn_route() {
+    use_repo_geo_assets();
+
     let rules = vec![RoutingRule {
         name: "geosite-cn-direct".into(),
         condition: RoutingCondition {
@@ -790,15 +807,8 @@ fn test_geoip_private_route() {
 }
 
 #[test]
-#[allow(clippy::let_unit_value)]
 fn test_geosite_route() {
-    // FIXME: Audit that the environment access only happens in single-threaded code.
-    let _ = unsafe {
-        std::env::set_var(
-            "DAE_LOCATION_ASSET",
-            concat!(env!("CARGO_MANIFEST_DIR"), "/../.."),
-        )
-    };
+    use_repo_geo_assets();
 
     let rules = vec![RoutingRule {
         name: "geosite-cn".into(),


### PR DESCRIPTION
## Problem

`test_geosite_cn_route` never set `DAE_LOCATION_ASSET`; only `test_geosite_route` did, inside its own body. On a checkout where `geosite.dat` is reachable only through that override — not through `/etc/dae` or the other search locations `routing/geo.rs` falls back to — the first test passes or fails by whichever of the two runs first. Here it failed with `assertion left == right failed: failed for www.jd.com`, which reads as a missing asset rather than a test ordering dependency.

## How I fixed it

The environment setup moves into `use_repo_geo_assets()`, which both tests call. The `FIXME` about single-threaded environment access moves with it unchanged.

## Verified

On `45f1a8a`, with the assets present at the repository root, `cargo test -p honk-core --lib` failed `test_geosite_cn_route` while every geosite test passed when the three were run together. After this change the same full run passes 962 tests, and `test_geosite_cn_route` passes when run alone. `cargo fmt --all -- --check` and `cargo clippy -p honk-core --all-targets -- -D warnings` are clean.
