### PR TITLE
fix(quic): reset an expired reassembly buffer before extending it

### DIFF
--- a/crates/honk-outbound/src/quic/defrag.rs
+++ b/crates/honk-outbound/src/quic/defrag.rs
@@ -83,7 +83,7 @@ impl Defragmenter {
             bytes: 0,
             updated: Instant::now(),
         });
-        if entry.frags.len() != frag_total {
+        if entry.updated.elapsed() >= DEFRAG_MAX_AGE || entry.frags.len() != frag_total {
             entry.frags = (0..frag_total).map(|_| None).collect();
             entry.count = 0;
             entry.bytes = 0;
@@ -154,6 +154,17 @@ mod tests {
         assert!(defrag.feed(65_500, 0, 2, vec![4]).is_none());
         assert_eq!(defrag.feed(0, 1, 2, vec![5]), Some(vec![3, 5]));
         assert_eq!(defrag.feed(65_500, 1, 2, vec![6]), Some(vec![4, 6]));
+    }
+
+    #[test]
+    fn an_expired_buffer_does_not_absorb_a_new_packet() {
+        let mut defrag = Defragmenter::new(8);
+        assert!(defrag.feed(7, 0, 2, vec![1]).is_none());
+        let key = defrag.packet_key(7);
+        defrag.map.get_mut(&key).expect("buffer pending").updated =
+            Instant::now() - DEFRAG_MAX_AGE - Duration::from_secs(1);
+        assert!(defrag.feed(7, 1, 2, vec![3]).is_none());
+        assert_eq!(defrag.feed(7, 0, 2, vec![2]), Some(vec![2, 3]));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`Defragmenter::feed` expires pending buffers only on the path that admits a new key into a full map, so a buffer reached by an existing key is extended however old it is. A UDP packet whose first fragment never completed leaves its slot occupied; when the peer reuses that packet ID within the same epoch, the new fragment fills a different slot, the count reaches the total, and `recv_packet` returns the old fragment joined to the new one as a successful reply. `DEFRAG_MAX_AGE` is ten seconds and nothing on that path consults it.

## How I fixed it

The existing reset for a changed fragment count now also fires when the buffer has aged past `DEFRAG_MAX_AGE`, so a stale buffer is cleared and the arriving fragment starts a fresh assembly rather than joining someone else's. The guard cannot tell a reused packet id from a very late fragment of the same packet, so this is a loss policy: `updated` is refreshed on every accepted fragment, and an assembly whose fragments are more than ten seconds apart now drops its earlier fragments instead of completing. That is the same staleness bound the capacity path already applies to these buffers.

## Verified

The new test parks a buffer past the age limit and feeds a second packet reusing the id; it fails without the guard by returning the mixed payload and passes with it. `cargo test -p honk-outbound` passes 652 tests, and `cargo fmt --all -- --check` and `cargo clippy -p honk-outbound --all-targets -- -D warnings` are clean. I also looked at whether an unfragmented message should advance the packet epoch and left that alone: `reassembly_is_bounded_and_packet_id_wrap_is_distinct` documents the current behaviour as intended.

