### PR TITLE
fix(group): keep the URLTest group in a retry plan selection chain

### DIFF
--- a/crates/honk-outbound/src/group/score/selection.rs
+++ b/crates/honk-outbound/src/group/score/selection.rs
@@ -182,6 +182,10 @@ impl super::GroupManager {
             .into_iter()
             .filter(|candidate| seen.insert(candidate.node.id))
             .take(3)
+            .map(|mut candidate| {
+                candidate.selection_chain.insert(0, group.name.as_str());
+                candidate
+            })
             .collect();
         self.score_selection_plan(candidates, super::SelectionPlanMode::Authoritative, context)
     }

--- a/crates/honk-outbound/src/group/score/tests/attribution.rs
+++ b/crates/honk-outbound/src/group/score/tests/attribution.rs
@@ -783,3 +783,23 @@ fn final_outbound_late_completion_keeps_extant_leaf_and_drops_deleted_leaf() {
     assert!(state.has_exact("outer", &context, leaves[0].id));
     assert!(!state.has_exact("outer", &context, leaves[1].id));
 }
+
+#[test]
+fn urltest_retry_plan_keeps_the_group_in_the_selection_chain() {
+    let nodes = [node("a"), node("b")];
+    let mut auto = group("auto", &nodes);
+    auto.policy = honk_config::group::GroupPolicy::URLTest;
+    let manager = super::super::super::GroupManager::new(std::slice::from_ref(&auto), &nodes);
+
+    let context = context("retry.example", IpVersion::V4);
+    let ordinary = manager.selection_plan_for_target("auto", &context);
+    let retry = manager.urltest_retry_plan_for_target("auto", &context);
+
+    assert_eq!(ordinary.entries[0].selection_chain[0], "auto");
+    for entry in &retry.entries {
+        assert_eq!(
+            entry.selection_chain[0], "auto",
+            "the retry plan promises the same chain as an ordinary plan"
+        );
+    }
+}


### PR DESCRIPTION
## Problem

`urltest_retry_plan_for_target` says it returns entries that "keep the same Honk attribution and selection chain as an ordinary target-aware plan" (`group/score/selection.rs:138-140`). It does not. Direct candidates start with `selection_chain: vec![node.name]` (`:516`), and `selection_plan_for_target` prepends the group at `:355`; the retry builder passes its candidates straight to `score_selection_plan` without that step. A URLTest group `auto` whose first dial fails and whose retry succeeds on leaf `b` therefore reports the chain as `["b"]` where the ordinary plan reports `["b", "auto"]`, which is what Clash `/connections` shows.

## How I fixed it

The retry builder prepends the group name to each candidate's chain, the same insert the ordinary plan already does.

## Verified

The new test builds one URLTest group and compares the two plans for the same target; it fails without the change with `left: "a", right: "auto"` and passes with it. `cargo test -p honk-outbound` passes 653 tests, and `cargo fmt --all -- --check` and `cargo clippy -p honk-outbound --all-targets -- -D warnings` are clean. Attribution is left alone: the ordinary plan prepends the group there only for a Score group, and this builder returns early for any policy but URLTest.
