### PR TITLE
fix(anytls): let a cancelled write release its unqueued payload

### DIFF
--- a/crates/honk-outbound/src/proxy/anytls/mod.rs
+++ b/crates/honk-outbound/src/proxy/anytls/mod.rs
@@ -2472,10 +2472,10 @@ pub(crate) struct AnyTlsStream {
     /// first, then the error — never silently merge them).
     read_err: Option<std::io::Error>,
     /// Outbound frame slot: the payload is owned by the stream until it
-    /// is enqueued — cancelling the caller's write future can neither
-    /// lose it nor enqueue it twice. `poll_write` only returns `Ok(n)`
-    /// after exactly these `n` bytes were queued (never a number derived
-    /// from a different call's buffer).
+    /// is enqueued, so a resumed write cannot enqueue it twice, and a
+    /// cancelled one queued nothing to lose. `poll_write` only returns
+    /// `Ok(n)` after exactly these `n` bytes were queued (never a number
+    /// derived from a different call's buffer).
     out_slot: Option<(bytes::Bytes, usize)>,
     /// Waiter for a writer-queue data permit while `out_slot` is occupied.
     permit_fut: Option<
@@ -2556,8 +2556,14 @@ impl tokio::io::AsyncWrite for AnyTlsStream {
         }
         let this = self.as_mut().get_mut();
 
-        if this.out_slot.is_none() {
-            this.out_slot = Some((bytes::Bytes::copy_from_slice(&buf[..chunk]), chunk));
+        // A payload sits here only while it is still unqueued — a successful
+        // enqueue takes it — and a write that returned Pending accepted no
+        // bytes, so a cancelled call's payload belongs to nobody and this
+        // call's buffer replaces it. Equal bytes need no replacement, which
+        // keeps a resumed write from reallocating on every poll.
+        match &this.out_slot {
+            Some((payload, _)) if payload.as_ref() == &buf[..chunk] => {}
+            _ => this.out_slot = Some((bytes::Bytes::copy_from_slice(&buf[..chunk]), chunk)),
         }
 
         if let Some((payload, n)) = this.out_slot.take() {

--- a/crates/honk-outbound/src/proxy/anytls/tests/streams.rs
+++ b/crates/honk-outbound/src/proxy/anytls/tests/streams.rs
@@ -311,6 +311,56 @@ async fn test_poll_write_cancel_safety() {
 }
 
 #[tokio::test]
+async fn a_cancelled_write_does_not_send_or_count_its_bytes() {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let (session, mut server) = establish_test_session("127.0.0.1:444").await;
+    expect_handshake(&mut server).await;
+    let mut addr_rx = spawn_echo_server(server);
+    let target = vec![0x01, 127, 0, 0, 1, 0x01, 0xbb];
+    let permit = session.try_reserve().unwrap();
+    let mut stream = session.open_stream_direct(target, permit).await.unwrap();
+    let _ = tokio::time::timeout(Duration::from_secs(2), addr_rx.recv())
+        .await
+        .unwrap();
+
+    let sem = Arc::clone(&session.writer_q.data_permits);
+    let mut hog = Vec::new();
+    while let Ok(p) = Arc::clone(&sem).try_acquire_owned() {
+        hog.push(p);
+    }
+    assert!(!hog.is_empty());
+
+    let old = b"old-payload".to_vec();
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), stream.write(&old))
+            .await
+            .is_err()
+    );
+
+    // The cancelled write queued nothing, so the next call must send its own
+    // buffer and report its own length.
+    drop(hog);
+    let new = b"new".to_vec();
+    let written = tokio::time::timeout(Duration::from_secs(2), stream.write(&new))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        written,
+        new.len(),
+        "count must describe the buffer passed in"
+    );
+
+    let mut echoed = vec![0u8; new.len()];
+    tokio::time::timeout(Duration::from_secs(2), stream.read_exact(&mut echoed))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(echoed, new, "the cancelled payload must not reach the peer");
+}
+
+#[tokio::test]
 async fn test_pool_offer_reuses_and_invalidates() {
     let pool = crate::session::SessionPool::new(crate::session::SessionPoolConfig::default());
     let addr = "127.0.0.1:1234";


### PR DESCRIPTION
## Problem

`AnyTlsStream::out_slot` documents that `poll_write` "only returns `Ok(n)` after exactly these `n` bytes were queued (never a number derived from a different call's buffer)". It takes the current buffer only when the slot is empty, so after a `write(b"AAAA")` is polled to `Pending` and cancelled, a following `write(b"B")` ignores its own buffer, queues `AAAA`, and returns `Ok(4)`. `AsyncWriteExt::write_all` advances by that count and panics slicing a one-byte buffer, and the bytes the caller passed are never sent. `test_poll_write_cancel_safety` retries with the identical buffer, so it does not reach this.

## How I fixed it

A payload sits in the slot only while it is still unqueued — a successful enqueue takes it out and returns `Ready` — and a write that returned `Pending` accepted no bytes, so a cancelled call's payload belongs to nobody and the next call's buffer replaces it. Equal bytes need no replacement, which keeps a resumed write from reallocating on every poll; double enqueue is prevented by that ownership transfer, not by the comparison. The permit wait is unaffected: it is not bound to a payload.

## Verified

The new test cancels `write(b"old-payload")` under a starved writer, then writes `b"new"`; without the change it returns `Ok(11)` for a three-byte buffer, and with it returns `Ok(3)` and the peer echoes only `new`. `cargo test -p honk-outbound` passes 652 tests, and `cargo fmt --all -- --check` and `cargo clippy -p honk-outbound --all-targets -- -D warnings` are clean. I did not find a caller in this tree that cancels a write on one of these streams and then writes different bytes — the relay abandons a direction rather than writing to it again — so this restores a documented contract rather than fixing an observed failure. `proxy/vless_cool.rs` keeps the same guarantee by holding only the reservation across `Pending`.

One hole this does not close: `poll_flush` takes whatever is in the slot and enqueues it, and `poll_shutdown` delegates to it, so a cancelled write followed by a flush or a shutdown still puts the abandoned bytes on the wire. `relay/mod.rs:236-250` drops its copy futures and then calls shutdown, so that sequence is reachable. Closing it means deciding whether an unaccepted payload should survive into flush at all, which changes more than the wrong-count bug this fixes, so I left it and am naming it rather than implying it is covered.


