### PR TITLE
fix(geo): warn when an asset carries a category code twice

### DIFF
--- a/crates/honk-core/src/routing/geo.rs
+++ b/crates/honk-core/src/routing/geo.rs
@@ -500,7 +500,16 @@ fn parse_geosite_index(
                 }
             }
         }
-        index.insert(code, IndexedGeosite { domains, attrs });
+        if let Some(previous) = index.insert(code.clone(), IndexedGeosite { domains, attrs }) {
+            // Same reason the zero-expansion paths warn: the earlier block's
+            // entries are gone, and which rules that changes is not something
+            // the operator can see from the asset.
+            tracing::warn!(
+                code,
+                dropped = previous.domains.len(),
+                "duplicate geosite code in asset; only the last block is used"
+            );
+        }
     }
 
     Ok(index)
@@ -619,8 +628,14 @@ fn parse_geoip_index(
             continue;
         }
         let entry = decoder.read_len_delimited()?;
-        if let Some((code, entry_nets)) = parse_geoip_entry(entry, codes)? {
-            index.insert(code, entry_nets);
+        if let Some((code, entry_nets)) = parse_geoip_entry(entry, codes)?
+            && let Some(previous) = index.insert(code.clone(), entry_nets)
+        {
+            tracing::warn!(
+                code,
+                dropped = previous.len(),
+                "duplicate geoip code in asset; only the last block is used"
+            );
         }
     }
 
@@ -1292,6 +1307,52 @@ mod scan_tests {
             geosite: Some(parse_geosite_index(dat, &set).unwrap()),
             geoip: None,
         }
+    }
+
+    #[test]
+    fn a_duplicate_category_code_warns_and_keeps_the_last_block() {
+        let output = tempfile::NamedTempFile::new().unwrap();
+        let subscriber = tracing_subscriber::fmt()
+            .without_time()
+            .with_ansi(false)
+            .with_writer(Arc::new(output.reopen().unwrap()))
+            .finish();
+        let site = geosite_dat(&[
+            ("DUP", vec![domain_msg(2, "first.example", &[])]),
+            ("DUP", vec![domain_msg(2, "second.example", &[])]),
+            ("ONCE", vec![domain_msg(2, "only.example", &[])]),
+        ]);
+        let ip = geoip_dat(&[
+            ("dup", vec![(&[1, 0, 0, 0], 8)]),
+            ("dup", vec![(&[2, 0, 0, 0], 8)]),
+        ]);
+        let site_codes: std::collections::HashSet<String> = ["dup".to_string(), "once".to_string()]
+            .into_iter()
+            .collect();
+        let ip_codes: std::collections::HashSet<String> = ["dup".to_string()].into_iter().collect();
+
+        let assets = tracing::subscriber::with_default(subscriber, || GeoAssets {
+            geosite: Some(parse_geosite_index(&site, &site_codes).unwrap()),
+            geoip: Some(parse_geoip_index(&ip, &ip_codes).unwrap()),
+        });
+
+        let output = std::fs::read_to_string(output.path()).unwrap();
+        assert!(output.contains("duplicate geosite code in asset"));
+        assert!(output.contains("duplicate geoip code in asset"));
+        assert!(
+            !output.contains("once"),
+            "a code that appears once must stay quiet: {output}"
+        );
+
+        let domains = assets.geosite_domains(&["dup".to_string()]);
+        assert_eq!(domains.len(), 1);
+        let matcher = GeositeMatcher::build(&domains);
+        assert!(matcher.matches("www.second.example"));
+        assert!(!matcher.matches("www.first.example"));
+        assert_eq!(
+            assets.geoip_nets(&["dup".into()]),
+            vec!["2.0.0.0/8".parse::<ipnet::IpNet>().unwrap()]
+        );
     }
 
     fn attr_fixture() -> Vec<u8> {


### PR DESCRIPTION
## Problem

Both geo indexes are built with a plain `HashMap::insert` keyed on the category code — `routing/geo.rs:503` for geosite and `:623` for geoip — and nothing in that file detects a repeat. An asset that carries the same code twice, which concatenated community builds do, silently keeps only the last block and discards the earlier one's entries. Which rules that changes depends on the blocks: a positive condition can match less, a negated one can match more, and identical blocks change nothing. The operator has nothing to look at either way. The module already takes the opposite position elsewhere: a code that expands to nothing warns, with a comment beside it saying never to stay silent about that.

## How I fixed it

Each insert now reports a replaced entry, naming the code and how many domains or networks were dropped. The last-block-wins behaviour is unchanged; whether duplicate blocks should merge is a separate question, and merging would change which rules match rather than only what is logged.

## Verified

A new test builds a geosite fixture of two duplicate blocks plus a single-occurrence control, and a geoip fixture of two duplicate blocks carrying different networks, then captures the log through the same tempfile subscriber `geoip_code_expanding_to_nothing_warns_like_geosite` already uses. Four negative controls were run against it: removing either warning fails its own assertion; making the geosite warning fire for every code fails the quiet-code assertion; and keeping the first geoip block instead of the last fails with `left: [1.0.0.0/8], right: [2.0.0.0/8]`. `cargo test -p honk-core --lib` passes 962 of 963 here; the one failure is `routing::tests::test_geosite_cn_route`, which fails the same way on an unmodified `45f1a8a` because it depends on a sibling test's environment override, and #160 is that fix. `cargo fmt --all -- --check` and `cargo clippy -p honk-core --all-targets -- -D warnings` are clean.

