### PR TITLE
chore(github): add a pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+<!-- The three sections are required; AGENTS.md has the rules for them. -->
+
+## Problem
+
+## How I fixed it
+
+## Verified
+
+---
+
+- [ ] `just fmt`, `just lint` and `just test-ci` pass.
+- [ ] I updated `doc/en/` and `doc/zh/` if I changed documented behaviour.
+- [ ] If I used AI: it followed `CONTRIBUTING.md` and `AGENTS.md`, and Verified shows what I ran, not guesses.


### PR DESCRIPTION
## Problem

The three sections a body needs live only in `AGENTS.md`, so they get missed — several of my own pull requests used invented headings after reading that file hours earlier.

## How I fixed it

`.github/pull_request_template.md` carries those headings and three boxes. Nothing else: of the large projects that ship a template, none asks the author to tick that the tests ran, because CI attests that; the boxes here cover the gates, the bilingual docs rule, and the LLM condition `CONTRIBUTING.md` is adding in #86.

## Verified

The three headings match what `AGENTS.md` requires, in order, and the boxes sit below a rule so a filled-in body still has exactly three sections. One file, thirteen lines. Merge after #86 so the third box names a file that exists.
