### PR TITLE
fix(config): keep the documented default for unreadable timer durations

### DIFF
--- a/crates/honk-config/src/parser/mod.rs
+++ b/crates/honk-config/src/parser/mod.rs
@@ -14,6 +14,7 @@ use crate::group::Group;
 use crate::node::Node;
 use crate::subscription::Subscription;
 use regex::Regex;
+use tracing::warn;
 #[derive(Debug, Clone)]
 struct Section {
     name: String,
@@ -803,7 +804,8 @@ fn parse_global_section(section: &Section) -> Result<GlobalConfig, crate::Config
         cfg.check_interval_secs = parse_duration_secs(v);
     }
     if let Some(v) = kv.get("check_tolerance") {
-        cfg.check_tolerance_ms = parse_checked_duration_ms(v, "global.check_tolerance")?;
+        cfg.check_tolerance_ms =
+            lenient_duration_ms(v, "global.check_tolerance", cfg.check_tolerance_ms);
     }
     if let Some(v) = kv.get("dial_mode") {
         cfg.dial_mode = v.clone();
@@ -815,7 +817,8 @@ fn parse_global_section(section: &Section) -> Result<GlobalConfig, crate::Config
         cfg.allow_insecure = parse_bool(v);
     }
     if let Some(v) = kv.get("sniffing_timeout") {
-        cfg.sniffing_timeout_ms = parse_checked_duration_ms(v, "global.sniffing_timeout")?;
+        cfg.sniffing_timeout_ms =
+            lenient_duration_ms(v, "global.sniffing_timeout", cfg.sniffing_timeout_ms);
     }
     if let Some(v) = kv.get("tls_implementation") {
         cfg.tls_implementation = v.clone();
@@ -1217,10 +1220,21 @@ fn parse_duration_secs(s: &str) -> u64 {
     crate::types::parse_duration_secs(s).unwrap_or(0)
 }
 
-fn parse_checked_duration_ms(s: &str, setting: &str) -> Result<u64, crate::ConfigError> {
-    crate::types::parse_duration_ms(s).ok_or_else(|| {
-        crate::ConfigError::Parse(format!("invalid millisecond duration for {setting}: {s}"))
-    })
+/// Keep the documented default for a timer the grammar cannot read. Guessing
+/// wrong here only changes how eagerly URLTest switches member, which does not
+/// justify refusing the whole configuration. Non-finite and negative values
+/// stay unreadable because `as u64` would saturate them to `u64::MAX`.
+fn lenient_duration_ms(value: &str, setting: &str, default: u64) -> u64 {
+    match crate::types::parse_duration_ms(value) {
+        Some(milliseconds) => milliseconds,
+        None => {
+            warn!(
+                setting,
+                value, default, "duration is not milliseconds, `ms` or `s`; keeping the default"
+            );
+            default
+        }
+    }
 }
 
 fn parse_ip_prefer(s: &str) -> crate::dns::DnsStrategy {

--- a/crates/honk-config/src/parser/tests.rs
+++ b/crates/honk-config/src/parser/tests.rs
@@ -40,7 +40,7 @@ global {
     }
 
     #[test]
-    fn test_millisecond_durations_reject_values_they_cannot_read() {
+    fn test_millisecond_durations_keep_the_default_and_warn() {
         for (value, expected) in [("50ms", 50), ("0ms", 0), ("0.5s", 500), ("50", 50)] {
             let input = format!("global {{\n    check_tolerance: {value}\n}}");
             let config = parse_dae_config(&input).unwrap();
@@ -50,18 +50,45 @@ global {
         for value in [
             "1m", "2h", "1min", "abc", "-5ms", "-0.5s", "1.5ms", "inf", "nan", "",
         ] {
-            for (setting, key) in [
-                ("global.check_tolerance", "check_tolerance"),
-                ("global.sniffing_timeout", "sniffing_timeout"),
+            for (setting, key, default) in [
+                ("global.check_tolerance", "check_tolerance", 50),
+                ("global.sniffing_timeout", "sniffing_timeout", 30),
             ] {
                 let input = format!("global {{\n    {key}: {value}\n}}");
-                let error = parse_dae_config(&input).unwrap_err();
-                assert!(matches!(error, crate::ConfigError::Parse(_)), "{value}");
+                let output = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+                let writer = std::sync::Arc::clone(&output);
+                let subscriber = tracing_subscriber::fmt()
+                    .without_time()
+                    .with_ansi(false)
+                    .with_writer(move || LogWriter(std::sync::Arc::clone(&writer)))
+                    .finish();
+                let config = tracing::subscriber::with_default(subscriber, || {
+                    parse_dae_config(&input).unwrap()
+                });
+                let observed = match key {
+                    "check_tolerance" => config.global.check_tolerance_ms,
+                    _ => config.global.sniffing_timeout_ms,
+                };
+                assert_eq!(observed, default, "{setting} for {value}");
+                let logged = String::from_utf8(output.lock().unwrap().clone()).unwrap();
                 assert!(
-                    error.to_string().contains(setting),
-                    "error must identify {setting} for {value}: {error}"
+                    logged.contains(setting),
+                    "warning must identify {setting} for {value}: {logged}"
                 );
             }
+        }
+    }
+
+    struct LogWriter(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl std::io::Write for LogWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
         }
     }
 

--- a/doc/en/reference/global.md
+++ b/doc/en/reference/global.md
@@ -25,10 +25,10 @@ Compatibility-only keys are accepted by the dae parser and stored in `GlobalConf
 | `tcp_check_http_method` | `tcp_check_http_method` | `"HEAD"` | HTTP method sent by the URL health check. An empty value is treated as `HEAD`. |
 | `udp_check_dns` | `udp_check_dns` | `["dns.google:53", "8.8.8.8", "2001:4860:4860::8888"]` | Comma-separated DNS targets for UDP health checks; a missing port defaults to `53`. |
 | `check_interval` | `check_interval_secs` | `30s` | Global health-check interval. Must be positive; a value that fails to parse becomes zero and is rejected at validation. The UDP warm coordinator also uses it, with an effective minimum of 10 seconds. |
-| `check_tolerance` | `check_tolerance_ms` | `50ms` | Latency improvement required before URLTest changes its selected member. Accepts bare milliseconds, `ms`, or `s`; anything else is rejected when the configuration loads. |
+| `check_tolerance` | `check_tolerance_ms` | `50ms` | Latency improvement required before URLTest changes its selected member. Accepts bare milliseconds, `ms`, or `s`; anything else keeps this default and logs a warning. |
 | `dial_mode` | `dial_mode` | `"domain"` | Destination-domain discovery and routing mode: `ip`, `domain`, `domain+`, or `domain++`. See [Dial modes](#dial-modes). |
 | `allow_insecure` | `allow_insecure` | `false` | Compatibility global TLS-verification fallback. Current TLS connectors do not read it; certificate skipping is configured per node in its share link. |
-| `sniffing_timeout` | `sniffing_timeout_ms` | `30ms` | Compatibility sniffing timeout. The dae parser stores the duration, but the current control plane does not read it. Accepts bare milliseconds, `ms`, or `s`; anything else is rejected when the configuration loads. |
+| `sniffing_timeout` | `sniffing_timeout_ms` | `30ms` | Compatibility sniffing timeout. The dae parser stores the duration, but the current control plane does not read it. Accepts bare milliseconds, `ms`, or `s`; anything else keeps this default and logs a warning. |
 | `tls_implementation` | `tls_implementation` | `"tls"` | `tls` uses the regular BoringSSL client profile; `utls` enables honk's real Chrome ClientHello profile. |
 | `utls_imitate` | `utls_imitate` | `"chrome_auto"` | Fingerprint profile requested with `utls`. Only `chrome*` is implemented; other values warn and still use Chrome. |
 | `tls_fragment` | `tls_fragment` | `false` | Compatibility TLS ClientHello-fragmentation switch. The current TLS connector does not read it. |

--- a/doc/zh/reference/global.md
+++ b/doc/zh/reference/global.md
@@ -25,10 +25,10 @@
 | `tcp_check_http_method` | `tcp_check_http_method` | `"HEAD"` | URL 健康检查发送的 HTTP 方法；空值按 `HEAD` 处理。 |
 | `udp_check_dns` | `udp_check_dns` | `["dns.google:53", "8.8.8.8", "2001:4860:4860::8888"]` | UDP 健康检查的 DNS 目标，逗号分隔；省略端口时默认为 `53`。 |
 | `check_interval` | `check_interval_secs` | `30s` | 全局健康检查间隔。必须为正；解析失败的值会变成零并在校验时被拒绝。UDP 预热 coordinator 也使用该值，但实际下限为 10 秒。 |
-| `check_tolerance` | `check_tolerance_ms` | `50ms` | URLTest 切换所选成员前要求的延迟改善量。接受裸毫秒数、`ms` 或 `s`，其余写法在配置加载时被拒绝。 |
+| `check_tolerance` | `check_tolerance_ms` | `50ms` | URLTest 切换所选成员前要求的延迟改善量。接受裸毫秒数、`ms` 或 `s`，其余写法沿用此默认值并记录一条警告。 |
 | `dial_mode` | `dial_mode` | `"domain"` | 目的域名发现和路由模式：`ip`、`domain`、`domain+` 或 `domain++`。参见[拨号模式](#拨号模式)。 |
 | `allow_insecure` | `allow_insecure` | `false` | 全局 TLS 校验回退兼容字段。当前 TLS connector 不读取该字段；跳过证书校验需在节点分享链接中按节点配置。 |
-| `sniffing_timeout` | `sniffing_timeout_ms` | `30ms` | 嗅探超时兼容字段。dae 解析器会保存该时长，但当前控制面不读取它。接受裸毫秒数、`ms` 或 `s`，其余写法在配置加载时被拒绝。 |
+| `sniffing_timeout` | `sniffing_timeout_ms` | `30ms` | 嗅探超时兼容字段。dae 解析器会保存该时长，但当前控制面不读取它。接受裸毫秒数、`ms` 或 `s`，其余写法沿用此默认值并记录一条警告。 |
 | `tls_implementation` | `tls_implementation` | `"tls"` | `tls` 使用常规 BoringSSL 客户端 profile；`utls` 启用 honk 的真实 Chrome ClientHello profile。 |
 | `utls_imitate` | `utls_imitate` | `"chrome_auto"` | 使用 `utls` 时请求的指纹 profile。当前只实现 `chrome*`；其他值会告警并仍使用 Chrome。 |
 | `tls_fragment` | `tls_fragment` | `false` | TLS ClientHello 分片兼容开关；当前 TLS connector 不读取该字段。 |


### PR DESCRIPTION
## Problem

#159 made `global.check_tolerance` and `global.sniffing_timeout` refuse the whole configuration when the value is not bare milliseconds, `ms` or `s` (`crates/honk-config/src/parser/mod.rs:806` and `:818` on `origin/main`). That is stricter than these two settings warrant: both are timers whose worst case is that URLTest switches member a little more or less eagerly, so a `1m` or a typo now costs an operator the entire config rather than one field. It is also the only strictness in that file with no way to see it — `parser/mod.rs` has nine `ConfigError::Parse` sites and zero log lines, while `tracing` has been a dependency since `crates/honk-config/Cargo.toml:23`.

## How I fixed it

Both settings now keep the documented default (50ms and 30ms, `crates/honk-config/src/config.rs:267` and `:273`) and emit a `warn!` naming the setting, the value and the default. The grammar itself is unchanged, so `inf`, `nan` and negatives are still not accepted as durations — `as u64` would saturate them to `u64::MAX` — they just fall back instead of failing the load. Both language references are updated.

## Verified

`cargo fmt --all -- --check`, `cargo clippy --all --all-targets -- -D warnings` and `cargo test --workspace --no-fail-fast -- --skip test_routing_with_config_dae` all pass. The rewritten `test_millisecond_durations_keep_the_default_and_warn` asserts both the retained default and the warning text; with the `parser/mod.rs` hunk reverted it fails on `Parse("invalid millisecond duration for global.check_tolerance: 1m")`. I did not run the root-only `just test-netns` gate, which this change does not reach.