### PR TITLE
fix(config): strip unquoted comments from group filter lines

### DIFF
--- a/crates/honk-config/src/parser/mod.rs
+++ b/crates/honk-config/src/parser/mod.rs
@@ -447,7 +447,8 @@ pub fn resolve_group_filters(groups: &mut [Group], nodes: &[Node], subscriptions
             .filters
             .iter()
             .map(|filter| filter.trim())
-            .filter(|filter| !filter.starts_with("group("))
+            // Unterminated group filters must not trigger the all-nodes fallback.
+            .filter(|filter| !filter.starts_with("group(") || !filter.contains(')'))
             .collect();
 
         if filters.is_empty() {
@@ -1005,7 +1006,10 @@ fn parse_group_section(section: &Section) -> Result<Vec<Group>, crate::ConfigErr
             .filter(|l| l.trim().starts_with("filter:"))
             .collect();
         for line in filter_lines {
-            let val = line.split_once(':').map(|(_, v)| v.trim()).unwrap_or("");
+            let val = line
+                .split_once(':')
+                .map(|(_, v)| strip_unquoted_comment(v.trim()).trim())
+                .unwrap_or("");
             // separated by commas or pipes: `group('hk', 'jp')`, `group('hk|jp')`.
             if let Some(tags) = extract_fn_args(val, "group") {
                 for tag in tags

--- a/crates/honk-config/src/parser/tests.rs
+++ b/crates/honk-config/src/parser/tests.rs
@@ -499,6 +499,18 @@ group {
 
         let hk1 = config.nodes.iter().find(|n| n.name == "hk1").unwrap();
         assert_eq!(group("hk").nodes, vec![hk1.id]);
+
+        let mut structured: crate::group::Group =
+            serde_json::from_str(r#"{"name":"p","filters":["group('hk')"]}"#).unwrap();
+        crate::parser::resolve_group_filters(
+            std::slice::from_mut(&mut structured),
+            &config.nodes,
+            &config.subscriptions,
+        );
+        assert_eq!(
+            structured.nodes,
+            config.nodes.iter().map(|node| node.id).collect::<Vec<_>>()
+        );
     }
 
     #[test]
@@ -903,6 +915,101 @@ group {
     assert_eq!(g.final_outbound.as_deref(), Some("direct"));
     let plain = config.groups.iter().find(|g| g.name == "plain").unwrap();
     assert_eq!(plain.check_url, None);
+}
+
+#[test]
+fn test_group_filter_trailing_comment() {
+    let input = r#"
+node {
+    edge: 'socks5://127.0.0.1:1080'
+    other: 'socks5://127.0.0.1:1081'
+}
+group {
+    proxy {
+        filter: name('edge') # comment
+    }
+}
+"#;
+    let config = parse_dae_config(input).unwrap();
+    let edge = config
+        .nodes
+        .iter()
+        .find(|node| node.name == "edge")
+        .unwrap();
+    assert_eq!(config.groups[0].nodes, vec![edge.id]);
+
+    let input = r#"
+node {
+    'edge#1': 'socks5://127.0.0.1:1080'
+}
+group {
+    proxy {
+        filter: name('edge#1')
+    }
+}
+"#;
+    let config = parse_dae_config(input).unwrap();
+    assert_eq!(config.groups[0].nodes.len(), 1, "a quoted `#` is data");
+}
+
+#[test]
+fn test_group_filter_unterminated_group() {
+    let input = r#"
+node {
+    edge: 'socks5://127.0.0.1:1080'
+}
+group {
+    proxy {
+        filter: group('hk'
+    }
+}
+"#;
+    let mut config = parse_dae_config(input).unwrap();
+    assert!(
+        config.groups[0].nodes.is_empty(),
+        "unterminated group filter must not select all nodes"
+    );
+    config
+        .nodes
+        .push(crate::node::Node::from_share_link("socks5://127.0.0.1:1081#new").unwrap());
+    crate::parser::resolve_group_filters(&mut config.groups, &config.nodes, &config.subscriptions);
+    assert!(
+        config.groups[0].nodes.is_empty(),
+        "unterminated group filter must remain empty after adding a node"
+    );
+}
+
+// Stripping turns `group(hk#suffix)` into `group(hk`; the failed extraction must
+// neither select every node nor leave the comment behind as a subgroup name.
+#[test]
+fn test_group_filter_unquoted_hash() {
+    let input = r#"
+node {
+    edge: 'socks5://127.0.0.1:1080'
+}
+group {
+    proxy {
+        filter: group(hk#suffix)
+    }
+}
+"#;
+    let mut config = parse_dae_config(input).unwrap();
+    assert!(
+        config.groups[0].groups.is_empty(),
+        "the comment must not survive as a nested group name"
+    );
+    assert!(
+        config.groups[0].nodes.is_empty(),
+        "comment-truncated group filter must not select all nodes"
+    );
+    config
+        .nodes
+        .push(crate::node::Node::from_share_link("socks5://127.0.0.1:1081#new").unwrap());
+    crate::parser::resolve_group_filters(&mut config.groups, &config.nodes, &config.subscriptions);
+    assert!(
+        config.groups[0].nodes.is_empty(),
+        "comment-truncated group filter must remain empty after adding a node"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Problem

`parse_group_section` reads filter lines with `split_once(':')` at `crates/honk-config/src/parser/mod.rs:1005` and never strips a trailing comment, unlike `parse_kv_pair` at `:701`. So `filter: name('edge') # comment` fails `strip_suffix(')')` at `:528`, is dropped by the `filter_map` at `:465`, and — because the emptiness guard at `:452` tests the pre-parse vector — the group silently ends up with no members. `doc/en/configuration.md:26` already says `#` starts an unquoted trailing comment.

## How I fixed it

The filter value now goes through the existing `strip_unquoted_comment` (`:716`). That truncation opens a second hole, so the same commit closes it: `filter: group(hk#suffix)` becomes `group(`, `extract_fn_args` returns `None` (`:878`), the value lands in `group.filters`, `:449` drops it for starting with `group(`, and `:452-459` then hands the group every node. A `group(`-shaped value whose extraction failed now stays in the vector the guard tests, so the group stays empty instead. Retention is limited to failed extraction — `Group.filters` is public and deserializable (`node.rs:339-361`), and a caller supplying a working `group('hk')` must keep reaching the all-nodes path; a test pins that. Three inputs change behaviour, each following `configuration.md:23-26`: `filter: group('hk'` goes from every node to none; `filter: group(hk#suffix)` no longer names a subgroup and yields no members; an unquoted `filter: name(edge#1)` stops matching a node literally named `edge#1`. A quoted `#` inside an argument stays data.

## Verified

`cargo fmt --all -- --check`, `cargo clippy --all --all-targets -- -D warnings` and `cargo test --workspace --no-fail-fast -- --skip test_routing_with_config_dae` all pass. Each hunk has a test that fails without it: `test_group_filter_trailing_comment` fails without the stripping; `test_group_filter_unterminated_group` fails on `main` (the pre-existing hole) and without the retention; `test_group_filter_unquoted_hash` fails on `main` because the comment survives as the subgroup name `hk#suffix`, and fails with stripping alone because the group then takes every node, so it covers the interaction of the two. I also diffed parsed configs against `origin/main` over the three shipped `.dae` files and eight boundary inputs, normalising ids, timestamps and HashMap order: only the three intended cases differ. I did not run the root-only `just test-netns` gate, which this change does not reach.