### PR TITLE
fix(config): refuse share-link credentials that percent-decode to invalid UTF-8

### DIFF
--- a/crates/honk-config/src/share_link.rs
+++ b/crates/honk-config/src/share_link.rs
@@ -100,35 +100,41 @@ fn node_from_url(url: &url::Url) -> Result<Node, ConfigError> {
         ..Default::default()
     };
     if let Some(config) = node.shadowsocks_mut() {
-        apply_ss_userinfo(config, url);
+        apply_ss_userinfo(config, url)?;
     } else {
-        let username = (!url.username().is_empty()).then(|| percent_decode_str(url.username()));
-        let password = url.password().map(percent_decode_str);
+        // Decode only the components a protocol keeps: `password.or(username)`
+        // discards the other one, and a discarded component must not decide
+        // whether the link loads.
+        let raw_username = (!url.username().is_empty()).then(|| url.username());
+        let raw_password = url.password();
+        let username = || percent_decode_credential(raw_username, "username");
+        let password = || percent_decode_credential(raw_password, "password");
+        let single = |field| percent_decode_credential(raw_password.or(raw_username), field);
         match &mut node.outbound {
             OutboundConfig::Socks5(config) => {
-                config.username = username;
-                config.password = password;
+                config.username = username()?;
+                config.password = password()?;
             }
-            OutboundConfig::Trojan(config) => config.password = password.or(username),
-            OutboundConfig::Vless(config) => config.uuid = password.or(username),
+            OutboundConfig::Trojan(config) => config.password = single("password")?,
+            OutboundConfig::Vless(config) => config.uuid = single("uuid")?,
             OutboundConfig::Hysteria2(config) => {
-                config.auth = match (username, password) {
+                config.auth = match (username()?, password()?) {
                     (Some(username), Some(password)) => Some(format!("{username}:{password}")),
                     (username, None) => username,
                     (None, Some(password)) => Some(format!(":{password}")),
                 };
             }
             OutboundConfig::Tuic(config) => {
-                config.uuid = username;
-                config.password = password;
+                config.uuid = username()?;
+                config.password = password()?;
             }
             OutboundConfig::Juicity(config) => {
-                config.uuid = username;
-                config.password = password;
+                config.uuid = username()?;
+                config.password = password()?;
             }
-            OutboundConfig::AnyTls(config) => config.password = password.or(username),
+            OutboundConfig::AnyTls(config) => config.password = single("password")?,
             OutboundConfig::Vmess(config) => {
-                config.uuid = password.or(username);
+                config.uuid = single("uuid")?;
                 config.encryption = Some("auto".into());
             }
             OutboundConfig::Shadowsocks(_) | OutboundConfig::Direct | OutboundConfig::Block => {}
@@ -259,17 +265,20 @@ fn json_port(value: Option<serde_json::Value>) -> Option<u16> {
 /// decoded method lands in `encryption` and the password in `password`.
 /// Note: the `url` crate percent-encodes `=` in userinfo, so the raw parts
 /// are percent-decoded before any base64 decoding happens.
-fn apply_ss_userinfo(config: &mut crate::node::ShadowsocksConfig, url: &url::Url) {
+fn apply_ss_userinfo(
+    config: &mut crate::node::ShadowsocksConfig,
+    url: &url::Url,
+) -> Result<(), ConfigError> {
     let userinfo = match url.password() {
         Some(pw) => format!(
             "{}:{}",
-            percent_decode_str(url.username()),
-            percent_decode_str(pw)
+            percent_decode_credential(Some(url.username()), "username")?.unwrap_or_default(),
+            percent_decode_credential(Some(pw), "password")?.unwrap_or_default()
         ),
-        None => percent_decode_str(url.username()),
+        None => percent_decode_credential(Some(url.username()), "username")?.unwrap_or_default(),
     };
     if userinfo.is_empty() {
-        return;
+        return Ok(());
     }
 
     match decode_ss_userinfo(&userinfo) {
@@ -282,6 +291,7 @@ fn apply_ss_userinfo(config: &mut crate::node::ShadowsocksConfig, url: &url::Url
             config.password = Some(userinfo);
         }
     }
+    Ok(())
 }
 
 /// Decode a SIP002 userinfo string into `(method, password)`.
@@ -466,6 +476,26 @@ fn base64_decode_flexible(input: &str) -> Option<Vec<u8>> {
 
 /// Percent-decode a string into bytes, then lossily into UTF-8.
 fn percent_decode_str(s: &str) -> String {
+    String::from_utf8_lossy(&percent_decode_bytes(s)).into_owned()
+}
+
+/// Percent-decode a credential, refusing bytes that are not UTF-8.
+///
+/// RFC 1929 makes the SOCKS5 username and password byte strings. Substituting
+/// U+FFFD for an undecodable byte sends a credential the operator never wrote,
+/// and the substitution is invisible in the loaded configuration.
+fn percent_decode_credential(s: Option<&str>, field: &str) -> Result<Option<String>, ConfigError> {
+    s.map(|s| {
+        String::from_utf8(percent_decode_bytes(s)).map_err(|_| {
+            ConfigError::Parse(format!(
+                "share link {field} is not UTF-8 after percent-decoding"
+            ))
+        })
+    })
+    .transpose()
+}
+
+fn percent_decode_bytes(s: &str) -> Vec<u8> {
     let bytes = s.as_bytes();
     let mut out = Vec::with_capacity(bytes.len());
     let mut i = 0;
@@ -481,7 +511,7 @@ fn percent_decode_str(s: &str) -> String {
         out.push(bytes[i]);
         i += 1;
     }
-    String::from_utf8_lossy(&out).into_owned()
+    out
 }
 
 fn hex_to_byte(h: u8, l: u8) -> Result<u8, ()> {

--- a/crates/honk-config/tests/share_link.rs
+++ b/crates/honk-config/tests/share_link.rs
@@ -1322,3 +1322,46 @@ fn shadowrocket_vmess_rejects_bad_authorities_and_conflicts() {
     }
     assert!(Node::from_share_link("vmess://!!!").is_err());
 }
+
+#[test]
+fn test_credential_bytes_are_not_replaced() {
+    // RFC 1929 makes the SOCKS5 password a byte string. A lossy decode would
+    // turn 0xFF into U+FFFD and authenticate with three bytes the operator
+    // never wrote, failing at dial time with nothing pointing back here.
+    for link in [
+        "socks5://user:p%FFss@1.2.3.4:1080#n",
+        "socks5://u%FFser:pass@1.2.3.4:1080#n",
+        "trojan://%FF%FE@1.2.3.4:443#t",
+        "ss://aes-256-gcm:p%FFss@1.2.3.4:8388#s",
+    ] {
+        assert!(
+            Node::from_share_link(link).is_err(),
+            "{link} must be refused rather than silently re-encoded"
+        );
+    }
+
+    // A component the protocol discards must not decide whether the link loads:
+    // Trojan, VLESS and AnyTLS all take `password.or(username)`.
+    let node = Node::from_share_link("trojan://%FF:correct-password@1.2.3.4:443#t").unwrap();
+    assert_eq!(
+        node.trojan().unwrap().password.as_deref(),
+        Some("correct-password")
+    );
+    let node = Node::from_share_link("anytls://%FF:correct-password@1.2.3.4:443#a").unwrap();
+    assert_eq!(
+        node.anytls().unwrap().password.as_deref(),
+        Some("correct-password")
+    );
+
+    // Multibyte UTF-8 survives byte for byte.
+    let node = Node::from_share_link("socks5://user:p%C3%A4ss@1.2.3.4:1080#n").unwrap();
+    assert_eq!(node.socks5().unwrap().password.as_deref(), Some("päss"));
+
+    let node = Node::from_share_link("socks5://user:p%40ss@1.2.3.4:1080#n").unwrap();
+    let socks5 = node.socks5().unwrap();
+    assert_eq!(socks5.password.as_deref(), Some("p@ss"));
+
+    // A name is cosmetic, so an undecodable fragment must not lose the node.
+    let node = Node::from_share_link("socks5://user:pass@1.2.3.4:1080#n%FFm").unwrap();
+    assert!(node.name.contains('\u{FFFD}'), "{}", node.name);
+}


### PR DESCRIPTION
## Problem

`percent_decode_str` in `crates/honk-config/src/share_link.rs:468-485` ends in `String::from_utf8_lossy`, so a percent-encoded credential byte that is not UTF-8 is replaced rather than carried. Measured on `origin/main`, `socks5://user:p%FFss@1.2.3.4:1080` produces the password bytes `[112, 239, 191, 189, 115, 115]` instead of `[112, 255, 115, 115]` — one byte becomes the three-byte U+FFFD sequence. RFC 1929 makes the SOCKS5 username and password byte strings, and the same userinfo feeds Trojan, VLESS, Hysteria2, TUIC, Juicity and AnyTLS. The substitution is invisible in the loaded configuration.

## How I fixed it

The percent-decoding scan is now `percent_decode_bytes`; `percent_decode_str` keeps the lossy conversion and serves only the node display name, where a replacement character costs nothing. Credentials go through `percent_decode_credential`, which returns `ConfigError::Parse` instead of substituting. Only the components a protocol keeps are decoded: Trojan, VLESS, AnyTLS and VMess take `password.or(username)`, so a discarded component still cannot decide whether the link loads. `parse_node_section` (`crates/honk-config/src/parser/mod.rs:963`) prints the error and skips the entry; subscriptions skip it with their generic node warning instead (`crates/honk-core/src/subscription.rs:545`).

## Verified

`cargo fmt --all -- --check`, `cargo clippy --all --all-targets -- -D warnings` and `cargo test --workspace --no-fail-fast -- --skip test_routing_with_config_dae` all pass with no failures. `test_credential_bytes_are_not_replaced` covers SOCKS5 username and password, Trojan, and the shadowsocks plain userinfo form; asserts that `trojan://%FF:correct-password@...` and the AnyTLS equivalent still load with the right password; and checks that `%C3%A4` survives byte for byte and that an undecodable fragment still yields a node. Reverting the production change to the lossy conversion makes it fail. Not covered, and not claimed: base64 shadowsocks userinfo whose decoded bytes are not UTF-8 still falls back to storing the raw text (`share_link.rs:280`), and `obfs-password` comes from the lossy `url.query_pairs()` decoder — both pre-existing. I did not run the root-only `just test-netns` gate.