### PR TITLE
feat(config): return parser diagnostics instead of logging them

### DIFF
--- a/crates/honk-config/src/config.rs
+++ b/crates/honk-config/src/config.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+use crate::ConfigDiagnostic;
 use crate::dns::DnsConfig;
 use crate::experimental::ExperimentalConfig;
 use crate::group::Group;
@@ -488,6 +489,20 @@ impl Config {
     }
 
     pub fn from_file(path: &str) -> Result<Self, crate::ConfigError> {
+        let mut diagnostics = Vec::new();
+        let result = Self::from_file_with_diagnostics(path, &mut diagnostics);
+        crate::diagnostic::report_diagnostics(&diagnostics);
+        result
+    }
+
+    /// Load a config, appending diagnostics as encountered on success or failure.
+    /// A successful structured fallback discards only the abandoned dae diagnostics.
+    /// The plain entry point logs them instead. Values must be safe to display;
+    /// see [`ConfigDiagnostic`] for stderr warnings not captured by this vector.
+    pub fn from_file_with_diagnostics(
+        path: &str,
+        diagnostics: &mut Vec<ConfigDiagnostic>,
+    ) -> Result<Self, crate::ConfigError> {
         let content = std::fs::read_to_string(path)?;
 
         let ext = std::path::Path::new(path)
@@ -498,6 +513,7 @@ impl Config {
         // A recognized extension picks its format first and falls back to the
         // other structured formats.  Unknown or missing extensions keep the
         // historical dae -> TOML -> YAML -> JSON fallback chain.
+        let diagnostics_start = diagnostics.len();
         let mut config = match ext.as_deref() {
             Some("json") => Self::from_json_str(&content)
                 .or_else(|_| parse_toml(&content))
@@ -508,7 +524,7 @@ impl Config {
             Some("toml") => parse_toml(&content)
                 .or_else(|_| parse_yaml(&content))
                 .or_else(|_| Self::from_json_str(&content)),
-            _ => match crate::parser::parse_dae_config_file(path) {
+            _ => match crate::parser::parse_dae_config_file_with_diagnostics(path, diagnostics) {
                 Ok(config) => Ok(config),
                 // These errors identify recognized dae syntax; structured
                 // fallbacks would hide their actionable cause.
@@ -516,7 +532,8 @@ impl Config {
                 | Err(err @ crate::ConfigError::UnsupportedPolicy(_)) => Err(err),
                 Err(_) => parse_toml(&content)
                     .or_else(|_| parse_yaml(&content))
-                    .or_else(|_| Self::from_json_str(&content)),
+                    .or_else(|_| Self::from_json_str(&content))
+                    .inspect(|_| diagnostics.truncate(diagnostics_start)),
             },
         }?;
         config.derive_node_ids();

--- a/crates/honk-config/src/diagnostic.rs
+++ b/crates/honk-config/src/diagnostic.rs
@@ -1,0 +1,21 @@
+use tracing::warn;
+
+/// A non-fatal configuration diagnostic, appended as encountered even if loading fails.
+/// Plain entry points log diagnostics instead of returning them.
+/// Node skips and legacy NFQUEUE migration still print to stderr; an empty vector
+/// does not imply a warning-free load.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConfigDiagnostic {
+    pub setting: String,
+    /// Safe-to-display input: currently timer strings only, never share links or secrets.
+    pub value: String,
+    pub message: String,
+}
+
+/// Log each diagnostic as a structured warning. The plain entry points call this
+/// at parse time; the daemon calls it once its subscriber is installed.
+pub fn report_diagnostics(diagnostics: &[ConfigDiagnostic]) {
+    for d in diagnostics {
+        warn!(setting = %d.setting, value = %d.value, "{}", d.message);
+    }
+}

--- a/crates/honk-config/src/lib.rs
+++ b/crates/honk-config/src/lib.rs
@@ -6,6 +6,7 @@
 //! (`global { ... } node { ... } routing { ... }`), parsed by [`parser`].
 
 pub mod config;
+pub mod diagnostic;
 pub mod dns;
 pub mod error;
 pub mod experimental;
@@ -19,4 +20,5 @@ pub mod subscription;
 pub mod types;
 
 pub use config::Config;
+pub use diagnostic::ConfigDiagnostic;
 pub use error::ConfigError;

--- a/crates/honk-config/src/parser/mod.rs
+++ b/crates/honk-config/src/parser/mod.rs
@@ -7,14 +7,13 @@ mod tests;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
-use crate::Config;
 use crate::config::GlobalConfig;
 use crate::experimental::ExperimentalConfig;
 use crate::group::Group;
 use crate::node::Node;
 use crate::subscription::Subscription;
+use crate::{Config, ConfigDiagnostic};
 use regex::Regex;
-use tracing::warn;
 #[derive(Debug, Clone)]
 struct Section {
     name: String,
@@ -27,6 +26,19 @@ struct Section {
 /// when they occur in a nested included file.  Included files must remain
 /// below that directory after symlink resolution.
 pub fn parse_dae_config_file(path: impl AsRef<Path>) -> Result<Config, crate::ConfigError> {
+    let mut diagnostics = Vec::new();
+    let result = parse_dae_config_file_with_diagnostics(path, &mut diagnostics);
+    crate::diagnostic::report_diagnostics(&diagnostics);
+    result
+}
+
+/// Load dae with includes, appending diagnostics as encountered on success or failure.
+/// The plain entry point logs them instead. Values must be safe to display;
+/// see [`ConfigDiagnostic`] for stderr warnings not captured by this vector.
+pub fn parse_dae_config_file_with_diagnostics(
+    path: impl AsRef<Path>,
+    diagnostics: &mut Vec<ConfigDiagnostic>,
+) -> Result<Config, crate::ConfigError> {
     let entry = std::fs::canonicalize(path.as_ref())?;
     let entry_dir = entry.parent().map(Path::to_path_buf).ok_or_else(|| {
         crate::ConfigError::Include(format!(
@@ -42,7 +54,7 @@ pub fn parse_dae_config_file(path: impl AsRef<Path>) -> Result<Config, crate::Co
     };
     let input = loader.expand_file(&entry)?;
 
-    match parse_dae_config(&input) {
+    match parse_dae_config_with_diagnostics(&input, diagnostics) {
         Ok(config) => Ok(config),
         Err(err @ crate::ConfigError::UnsupportedPolicy(_)) => Err(err),
         Err(err) if loader.saw_include => Err(crate::ConfigError::Include(format!(
@@ -372,6 +384,19 @@ fn is_ident_continue(byte: u8) -> bool {
 }
 
 pub fn parse_dae_config(input: &str) -> Result<Config, crate::ConfigError> {
+    let mut diagnostics = Vec::new();
+    let result = parse_dae_config_with_diagnostics(input, &mut diagnostics);
+    crate::diagnostic::report_diagnostics(&diagnostics);
+    result
+}
+
+/// Parse dae, appending diagnostics as encountered on success or failure.
+/// The plain entry point logs them instead. Values must be safe to display;
+/// see [`ConfigDiagnostic`] for stderr warnings not captured by this vector.
+pub fn parse_dae_config_with_diagnostics(
+    input: &str,
+    diagnostics: &mut Vec<ConfigDiagnostic>,
+) -> Result<Config, crate::ConfigError> {
     let input = strip_comments(input);
     if !input.contains('{') || !input.contains('}') {
         return Err(crate::ConfigError::Parse("not a dae config file".into()));
@@ -386,7 +411,7 @@ pub fn parse_dae_config(input: &str) -> Result<Config, crate::ConfigError> {
 
     for section in &sections {
         match section.name.as_str() {
-            "global" => config.global = parse_global_section(section)?,
+            "global" => config.global = parse_global_section(section, diagnostics)?,
             "dns" => config.dns = dns::parse_section(section)?,
             "routing" => config.routing = routing::parse_section(section)?,
             "node" => {
@@ -735,7 +760,10 @@ fn strip_unquoted_comment(line: &str) -> &str {
     line
 }
 
-fn parse_global_section(section: &Section) -> Result<GlobalConfig, crate::ConfigError> {
+fn parse_global_section(
+    section: &Section,
+    diagnostics: &mut Vec<ConfigDiagnostic>,
+) -> Result<GlobalConfig, crate::ConfigError> {
     let mut cfg = GlobalConfig::default();
     let kv = parse_kv_pairs(&section.body);
 
@@ -804,8 +832,12 @@ fn parse_global_section(section: &Section) -> Result<GlobalConfig, crate::Config
         cfg.check_interval_secs = parse_duration_secs(v);
     }
     if let Some(v) = kv.get("check_tolerance") {
-        cfg.check_tolerance_ms =
-            lenient_duration_ms(v, "global.check_tolerance", cfg.check_tolerance_ms);
+        cfg.check_tolerance_ms = lenient_duration_ms(
+            v,
+            "global.check_tolerance",
+            cfg.check_tolerance_ms,
+            diagnostics,
+        );
     }
     if let Some(v) = kv.get("dial_mode") {
         cfg.dial_mode = v.clone();
@@ -817,8 +849,12 @@ fn parse_global_section(section: &Section) -> Result<GlobalConfig, crate::Config
         cfg.allow_insecure = parse_bool(v);
     }
     if let Some(v) = kv.get("sniffing_timeout") {
-        cfg.sniffing_timeout_ms =
-            lenient_duration_ms(v, "global.sniffing_timeout", cfg.sniffing_timeout_ms);
+        cfg.sniffing_timeout_ms = lenient_duration_ms(
+            v,
+            "global.sniffing_timeout",
+            cfg.sniffing_timeout_ms,
+            diagnostics,
+        );
     }
     if let Some(v) = kv.get("tls_implementation") {
         cfg.tls_implementation = v.clone();
@@ -1220,18 +1256,25 @@ fn parse_duration_secs(s: &str) -> u64 {
     crate::types::parse_duration_secs(s).unwrap_or(0)
 }
 
-/// Keep the documented default for a timer the grammar cannot read. Guessing
-/// wrong here only changes how eagerly URLTest switches member, which does not
-/// justify refusing the whole configuration. Non-finite and negative values
-/// stay unreadable because `as u64` would saturate them to `u64::MAX`.
-fn lenient_duration_ms(value: &str, setting: &str, default: u64) -> u64 {
+// Invalid URLTest tolerance or compatibility sniffing timeout does not justify
+// rejecting the configuration; keep the documented default. Refuse non-finite
+// and negative values rather than letting `as u64` saturate to `u64::MAX` or zero.
+fn lenient_duration_ms(
+    value: &str,
+    setting: &str,
+    default: u64,
+    diagnostics: &mut Vec<ConfigDiagnostic>,
+) -> u64 {
     match crate::types::parse_duration_ms(value) {
         Some(milliseconds) => milliseconds,
         None => {
-            warn!(
-                setting,
-                value, default, "duration is not milliseconds, `ms` or `s`; keeping the default"
-            );
+            diagnostics.push(ConfigDiagnostic {
+                setting: setting.to_string(),
+                value: value.to_string(),
+                message: format!(
+                    "duration is not milliseconds, `ms` or `s`; keeping the default ({default}ms)"
+                ),
+            });
             default
         }
     }

--- a/crates/honk-config/src/parser/tests.rs
+++ b/crates/honk-config/src/parser/tests.rs
@@ -3,7 +3,7 @@ use crate::parser::parse_dae_config;
 
 #[cfg(test)]
 mod parser_tests {
-    use crate::parser::parse_dae_config;
+    use crate::parser::{parse_dae_config, parse_dae_config_with_diagnostics};
 
     #[test]
     fn test_parse_example_dae() {
@@ -40,11 +40,16 @@ global {
     }
 
     #[test]
-    fn test_millisecond_durations_keep_the_default_and_warn() {
+    fn test_millisecond_durations_keep_the_default_and_return_diagnostics() {
         for (value, expected) in [("50ms", 50), ("0ms", 0), ("0.5s", 500), ("50", 50)] {
-            let input = format!("global {{\n    check_tolerance: {value}\n}}");
-            let config = parse_dae_config(&input).unwrap();
+            let input = format!(
+                "global {{\n    check_tolerance: {value}\n    sniffing_timeout: {value}\n}}"
+            );
+            let mut diagnostics = Vec::new();
+            let config = parse_dae_config_with_diagnostics(&input, &mut diagnostics).unwrap();
             assert_eq!(config.global.check_tolerance_ms, expected, "{value}");
+            assert_eq!(config.global.sniffing_timeout_ms, expected, "{value}");
+            assert!(diagnostics.is_empty(), "{value}: {diagnostics:?}");
         }
 
         for value in [
@@ -55,41 +60,127 @@ global {
                 ("global.sniffing_timeout", "sniffing_timeout", 30),
             ] {
                 let input = format!("global {{\n    {key}: {value}\n}}");
-                let output = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
-                let writer = std::sync::Arc::clone(&output);
-                let subscriber = tracing_subscriber::fmt()
-                    .without_time()
-                    .with_ansi(false)
-                    .with_writer(move || LogWriter(std::sync::Arc::clone(&writer)))
-                    .finish();
-                let config = tracing::subscriber::with_default(subscriber, || {
-                    parse_dae_config(&input).unwrap()
-                });
+                let mut diagnostics = Vec::new();
+                let config = parse_dae_config_with_diagnostics(&input, &mut diagnostics).unwrap();
                 let observed = match key {
                     "check_tolerance" => config.global.check_tolerance_ms,
                     _ => config.global.sniffing_timeout_ms,
                 };
                 assert_eq!(observed, default, "{setting} for {value}");
-                let logged = String::from_utf8(output.lock().unwrap().clone()).unwrap();
-                assert!(
-                    logged.contains(setting),
-                    "warning must identify {setting} for {value}: {logged}"
-                );
+                assert_eq!(diagnostics.len(), 1, "{setting} for {value}");
+                assert_eq!(diagnostics[0].setting, setting);
+                assert_eq!(diagnostics[0].value, value);
+                assert!(diagnostics[0].message.contains(&format!("{default}ms")));
             }
         }
     }
 
-    struct LogWriter(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+    #[test]
+    fn test_millisecond_duration_compat_entry_logs_warning() {
+        #[derive(Clone)]
+        struct Writer(std::sync::Arc<parking_lot::Mutex<Vec<u8>>>);
 
-    impl std::io::Write for LogWriter {
-        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-            self.0.lock().unwrap().extend_from_slice(buf);
-            Ok(buf.len())
+        impl std::io::Write for Writer {
+            fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().extend_from_slice(bytes);
+                Ok(bytes.len())
+            }
+
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
         }
 
-        fn flush(&mut self) -> std::io::Result<()> {
-            Ok(())
-        }
+        let output = Writer(Default::default());
+        let writer = output.clone();
+        let subscriber = tracing_subscriber::fmt()
+            .with_ansi(false)
+            .without_time()
+            .with_max_level(tracing::Level::WARN)
+            .with_writer(move || writer.clone())
+            .finish();
+        tracing::subscriber::with_default(subscriber, || {
+            parse_dae_config("global {\n    check_tolerance: abc\n}").unwrap();
+        });
+        let bytes = output.0.lock();
+        let log = String::from_utf8_lossy(&bytes);
+        assert!(log.contains("global.check_tolerance"), "{log}");
+    }
+
+    #[test]
+    fn test_timer_diagnostic_survives_later_parse_error() {
+        let mut diagnostics = Vec::new();
+        let result = parse_dae_config_with_diagnostics(
+            "global {\n check_tolerance: abc\n nfqueue_enable: invalid\n}",
+            &mut diagnostics,
+        );
+        assert!(result.is_err());
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].setting, "global.check_tolerance");
+        assert_eq!(diagnostics[0].value, "abc");
+        assert!(diagnostics[0].message.contains("50ms"));
+    }
+
+    #[test]
+    fn test_from_file_preserves_timer_diagnostics() {
+        let file = tempfile::Builder::new().suffix(".dae").tempfile().unwrap();
+        std::fs::write(file.path(), "global {\n    check_tolerance: abc\n}").unwrap();
+
+        let mut diagnostics = Vec::new();
+        let config = crate::Config::from_file_with_diagnostics(
+            file.path().to_str().unwrap(),
+            &mut diagnostics,
+        )
+        .unwrap();
+        assert_eq!(config.global.check_tolerance_ms, 50);
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].setting, "global.check_tolerance");
+        assert_eq!(diagnostics[0].value, "abc");
+        assert!(diagnostics[0].message.contains("50ms"));
+    }
+
+    #[test]
+    fn test_structured_fallback_discards_only_abandoned_dae_diagnostics() {
+        let file = tempfile::Builder::new().suffix(".dae").tempfile().unwrap();
+        std::fs::write(
+            file.path(),
+            "ignored: |\n  global {\n    check_tolerance: abc\n    nfqueue_enable: invalid\n  }\n\
+             global:\n  check_tolerance_ms: 75\n",
+        )
+        .unwrap();
+        let mut diagnostics = Vec::new();
+        parse_dae_config_with_diagnostics("global {\n sniffing_timeout: 2h\n}", &mut diagnostics)
+            .unwrap();
+        let previous = diagnostics.clone();
+        let config = crate::Config::from_file_with_diagnostics(
+            file.path().to_str().unwrap(),
+            &mut diagnostics,
+        )
+        .unwrap();
+        assert_eq!(config.global.check_tolerance_ms, 75);
+        assert_eq!(diagnostics, previous);
+    }
+
+    #[test]
+    fn test_include_preserves_timer_diagnostics() {
+        let dir = tempfile::tempdir().unwrap();
+        let entry = dir.path().join("config.dae");
+        std::fs::write(&entry, "include {\n    timers.dae\n}").unwrap();
+        std::fs::write(
+            dir.path().join("timers.dae"),
+            "global {\n    sniffing_timeout: 1m\n}",
+        )
+        .unwrap();
+
+        let mut diagnostics = Vec::new();
+        let config =
+            crate::Config::from_file_with_diagnostics(entry.to_str().unwrap(), &mut diagnostics)
+                .unwrap();
+        assert_eq!(config.global.sniffing_timeout_ms, 30);
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].setting, "global.sniffing_timeout");
+        assert_eq!(diagnostics[0].value, "1m");
+        assert!(diagnostics[0].message.contains("30ms"));
     }
 
     #[test]

--- a/crates/honk-core/Cargo.toml
+++ b/crates/honk-core/Cargo.toml
@@ -122,6 +122,7 @@ anyhow.workspace = true
 
 [dev-dependencies]
 aya-ebpf-bindings.workspace = true
+nix = { workspace = true, features = ["signal"] }
 # Test utilities
 tokio = { workspace = true, features = ["test-util"] }
 tempfile.workspace = true

--- a/crates/honk-core/src/lib.rs
+++ b/crates/honk-core/src/lib.rs
@@ -542,7 +542,9 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
     // Load the configuration before initializing logging so `log_level` in
     // the config file is honored (previously only --debug/RUST_LOG had any
     // effect and config log_level was silently ignored).
-    let mut config = Config::from_file(cli.config.to_str().unwrap())?;
+    let mut diagnostics = Vec::new();
+    let mut config =
+        Config::from_file_with_diagnostics(cli.config.to_str().unwrap(), &mut diagnostics)?;
     config.validate()?;
     subscription::validate_subscription_ids(&config.subscriptions)?;
     let requested_data_dir = PathBuf::from(&config.global.data_dir);
@@ -613,6 +615,7 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
             "Runtime data directory is unusable; using process working directory"
         );
     }
+    honk_config::diagnostic::report_diagnostics(&diagnostics);
     info!(directory = %honk_config::paths::data_dir().display(), "Runtime data directory configured");
     if let Some(path) = log_file_path.as_ref() {
         info!(path = %path.display(), "File logging enabled");
@@ -1188,8 +1191,13 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
             sighup.recv().await;
             request_id = request_id.wrapping_add(1).max(1);
             info!("SIGHUP reload request {request_id} received");
-            match Config::from_file(config_path.to_str().unwrap_or("/etc/honk/config.dae")) {
+            let mut diagnostics = Vec::new();
+            match Config::from_file_with_diagnostics(
+                config_path.to_str().unwrap_or("/etc/honk/config.dae"),
+                &mut diagnostics,
+            ) {
                 Ok(mut new_config) => {
+                    honk_config::diagnostic::report_diagnostics(&diagnostics);
                     if let Err(error) = new_config.validate() {
                         warn!(
                             "SIGHUP reload request {request_id} rejected: invalid config: {error}"
@@ -1220,6 +1228,7 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
                     }
                 }
                 Err(e) => {
+                    honk_config::diagnostic::report_diagnostics(&diagnostics);
                     warn!("SIGHUP reload request {request_id} rejected: config load failed: {e}")
                 }
             }

--- a/crates/honk-core/tests/integration_test.rs
+++ b/crates/honk-core/tests/integration_test.rs
@@ -1012,6 +1012,114 @@ protocol = "udp"
     }
 
     #[test]
+    fn test_daemon_reports_timer_diagnostics_on_startup_and_sighup() {
+        use std::io::{BufRead, BufReader, Read};
+        use std::process::{Command, Stdio};
+        use std::time::{Duration, Instant};
+
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("config.dae");
+        let port = std::net::TcpListener::bind("[::]:0")
+            .unwrap()
+            .local_addr()
+            .unwrap()
+            .port();
+        let data_dir = directory.path().join("data");
+        let source = |tolerance| {
+            format!(
+                "global {{\n data_dir: '{}'\n tproxy_port: {port}\n nfqueue_enable: false\n \
+                 check_tolerance: {tolerance}\n preconnect_node_count: 0\n}}\n \
+                 routing {{\n fallback: direct\n}}\n",
+                data_dir.display()
+            )
+        };
+        std::fs::write(&path, source("1m")).unwrap();
+        let mut child = Command::new(env!("CARGO_BIN_EXE_honk-core"))
+            .arg("--config")
+            .arg(&path)
+            .arg("--mock-ebpf")
+            .env("RUST_LOG", "info")
+            .env("NO_COLOR", "1")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn mock daemon");
+        let output = Arc::new(parking_lot::Mutex::new(String::new()));
+        let pipes: [Box<dyn Read + Send>; 2] = [
+            Box::new(child.stdout.take().unwrap()),
+            Box::new(child.stderr.take().unwrap()),
+        ];
+        let readers = pipes.map(|pipe| {
+            let output = output.clone();
+            std::thread::spawn(move || {
+                for line in BufReader::new(pipe).lines() {
+                    let mut output = output.lock();
+                    match line {
+                        Ok(line) => {
+                            output.push_str(&line);
+                            output.push('\n');
+                        }
+                        Err(error) => {
+                            output.push_str(&format!("output read failed: {error}\n"));
+                            break;
+                        }
+                    }
+                }
+            })
+        });
+        let wait_for = |description: &str, predicate: &dyn Fn(&str) -> bool| {
+            let deadline = Instant::now() + Duration::from_secs(10);
+            loop {
+                if predicate(&output.lock()) {
+                    return Ok(());
+                }
+                if Instant::now() >= deadline {
+                    return Err(format!("timed out waiting for {description}"));
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+        };
+        let diagnostic = |log: &str, value: &str| {
+            log.lines().any(|line| {
+                line.contains("WARN")
+                    && line.contains("global.check_tolerance")
+                    && line.contains(value)
+            })
+        };
+        let result = (|| -> Result<(), String> {
+            wait_for("startup diagnostic (1m)", &|log| diagnostic(log, "1m"))?;
+            wait_for("Router ready", &|log| log.contains("Router ready"))?;
+            // Router construction precedes the spawned SIGHUP handler; do not
+            // deliver a terminating default-action signal during that window.
+            wait_for("SIGHUP handler registration", &|_| {
+                std::fs::read_to_string(format!("/proc/{}/status", child.id()))
+                    .ok()
+                    .and_then(|status| {
+                        status.lines().find_map(|line| {
+                            line.strip_prefix("SigCgt:")
+                                .and_then(|mask| u64::from_str_radix(mask.trim(), 16).ok())
+                        })
+                    })
+                    .is_some_and(|mask| mask & (1 << (libc::SIGHUP - 1)) != 0)
+            })?;
+            std::fs::write(&path, source("2h")).map_err(|error| error.to_string())?;
+            nix::sys::signal::kill(
+                nix::unistd::Pid::from_raw(child.id() as libc::pid_t),
+                nix::sys::signal::Signal::SIGHUP,
+            )
+            .map_err(|error| error.to_string())?;
+            wait_for("SIGHUP diagnostic (2h)", &|log| diagnostic(log, "2h"))
+        })();
+        let _ = child.kill();
+        let status = child.wait();
+        for reader in readers {
+            reader.join().expect("join daemon output reader");
+        }
+        assert!(result.is_ok(), "{}\n{}", result.unwrap_err(), output.lock());
+        status.expect("reap mock daemon");
+    }
+
+    #[test]
     fn test_mode_command_rejects_dae_without_rewriting() {
         let directory = tempfile::tempdir().expect("create temporary directory");
         let path = directory.path().join("config.dae");


### PR DESCRIPTION
## Problem

The parser's lenient paths have no visible voice. `crates/honk-config/src/parser/mod.rs` has nine `ConfigError::Parse` sites and, since #179, one `warn!` in `lenient_duration_ms` — and that warning is never printed at startup, because `run` loads the config at `crates/honk-core/src/lib.rs:545` and installs the tracing subscriber at `lib.rs:596-604`, deliberately (`lib.rs:541-543`: the config's own `log_level` has to be read first). So "keep the default and warn" has been "keep the default" in practice, while the tree already carries the data-directory diagnostic across that same gap and reports it at `lib.rs:608-613`.

## How I fixed it

Parsing appends `ConfigDiagnostic { setting, value, message }` into a caller-owned vector instead of logging: `parse_dae_config_with_diagnostics`, `parse_dae_config_file_with_diagnostics` and `Config::from_file_with_diagnostics` take `&mut Vec` and append as encountered whether or not the load succeeds, so a fallback recorded before a later hard error survives. The existing three entry points keep their signatures and log the vector themselves on both outcomes, which is what a caller with a subscriber saw before. When the dae attempt fails and a structured format parses instead, the abandoned dae diagnostics are truncated. The daemon uses the new entry point at startup and reports after `registry.init()` beside the data-directory warning, and on both SIGHUP arms, through the same honk-config helper. `Config` gains no field, so equality and serialization are untouched; the `clash` subcommands and `resolve_group_filters` are unchanged. The only producer wired up is the timer fallback #179 added; the remaining lenient sites are a follow-up.

## Verified

`cargo fmt --all -- --check`, `cargo clippy --all --all-targets -- -D warnings`, `cargo test -p honk-config` (190), `cargo test -p honk-core --test integration_test` (27) and `cargo test --workspace --no-fail-fast -- --skip test_routing_with_config_dae` (1957, 0 failures) all pass. Each hunk has a test that fails without it: removing the push fails the parser test (`left: 0, right: 1`); removing the startup report fails the new lifecycle test at "timed out waiting for startup diagnostic (1m)"; removing the SIGHUP report fails it at "SIGHUP diagnostic (2h)". That lifecycle test runs the real binary with `--mock-ebpf` on a `bind(0)` port and an isolated `data_dir`, waits for the startup warning, checks SigCgt in `/proc/<pid>/status` before sending SIGHUP, rewrites the timer, and waits for the second warning. Also covered: the `from_file` and `include` paths, the plain entry points still emitting a subscriber-visible warning, a diagnostic surviving a later parse error, and the fallback truncation. Not covered: the SIGHUP `Err`-arm report. I did not run the root-only `just test-netns` gate, which this change does not reach.
