### PR TITLE
refactor(routing): simplify projection accounting and codegen

### DIFF
--- a/crates/honk-core/src/control/reload/transaction.rs
+++ b/crates/honk-core/src/control/reload/transaction.rs
@@ -12,21 +12,6 @@ impl Drop for PreDnsPublicationHookGuard<'_> {
     }
 }
 
-fn domain_routes_eq(
-    left: &[(crate::ebpf::maps::LpmKey, honk_ebpf_common::DomainRouting)],
-    right: &[(crate::ebpf::maps::LpmKey, honk_ebpf_common::DomainRouting)],
-) -> bool {
-    left.len() == right.len()
-        && left
-            .iter()
-            .zip(right)
-            .all(|((left_key, left), (right_key, right))| {
-                crate::ebpf::maps::lpm_key_bytes(left_key)
-                    == crate::ebpf::maps::lpm_key_bytes(right_key)
-                    && left.bitmap == right.bitmap
-            })
-}
-
 fn rebase_subscription_nodes(current: &Config, candidate: &mut Config) {
     let mut static_nodes = Vec::with_capacity(candidate.nodes.len());
     let mut candidate_subscription_nodes =
@@ -472,24 +457,18 @@ impl ControlPlane {
                 );
                 let new_connectivity =
                     group_connectivity_snapshot(&new_config, &new_group_manager, &self.alive_set);
-                let mut old_domain_routes = projection_publication
-                    .project(&old_projection_snapshot)
-                    .into_iter()
-                    .map(|(ip, bitmap)| (crate::ebpf::maps::ip_addr_to_lpm_key(ip), bitmap))
-                    .collect::<Vec<_>>();
+                let old_projection = projection_publication.project(&old_projection_snapshot);
                 let new_projection = projection_publication.project(&projection_snapshot);
-                let mut new_domain_routes = new_projection
-                    .iter()
-                    .map(|(ip, bitmap)| (crate::ebpf::maps::ip_addr_to_lpm_key(*ip), *bitmap))
-                    .collect::<Vec<_>>();
-                old_domain_routes
-                    .sort_unstable_by_key(|(key, _)| crate::ebpf::maps::lpm_key_bytes(key));
-                new_domain_routes
-                    .sort_unstable_by_key(|(key, _)| crate::ebpf::maps::lpm_key_bytes(key));
                 // Recover a degraded runtime with a complete generation before reopening admission.
                 let routing_publication_needed = !self.is_datapath_healthy()
                     || !old_plan.semantically_eq(&new_plan)
-                    || !domain_routes_eq(&old_domain_routes, &new_domain_routes);
+                    || !old_projection
+                        .iter()
+                        .map(|(ip, bitmap)| (ip, &bitmap.bitmap))
+                        .eq(new_projection
+                            .iter()
+                            .map(|(ip, bitmap)| (ip, &bitmap.bitmap)));
+                drop(old_projection);
                 let provider = self.dns_controller.runtime_provider();
                 let publication = provider.prepare_publication(new_runtime);
 
@@ -500,27 +479,33 @@ impl ControlPlane {
                     error!(%error, ?restore, "Failed to open group connectivity for reload transition");
                     break 'publication Err(());
                 }
-                if routing_publication_needed
-                    && let Err(error) = ebpf.publish_routing_plan(&new_plan, &new_domain_routes)
-                {
-                    match publish_group_connectivity(ebpf.as_mut(), &old_connectivity) {
-                        Ok(()) => error!(
-                            %error,
-                            "Compiled routing publication failed; active generation retained"
-                        ),
-                        Err(restore_error) => {
-                            error!(
+                if routing_publication_needed {
+                    let mut new_domain_routes = new_projection
+                        .iter()
+                        .map(|(ip, bitmap)| (crate::ebpf::maps::ip_addr_to_lpm_key(*ip), *bitmap))
+                        .collect::<Vec<_>>();
+                    new_domain_routes
+                        .sort_unstable_by_key(|(key, _)| crate::ebpf::maps::lpm_key_bytes(key));
+                    if let Err(error) = ebpf.publish_routing_plan(&new_plan, &new_domain_routes) {
+                        match publish_group_connectivity(ebpf.as_mut(), &old_connectivity) {
+                            Ok(()) => error!(
                                 %error,
-                                %restore_error,
-                                "Routing publication rejected but health restoration failed"
-                            );
-                            self.datapath_healthy
-                                .store(false, std::sync::atomic::Ordering::Release);
-                            self.drain_tracker.start_rejecting();
-                            drain.start_rejecting();
+                                "Compiled routing publication failed; active generation retained"
+                            ),
+                            Err(restore_error) => {
+                                error!(
+                                    %error,
+                                    %restore_error,
+                                    "Routing publication rejected but health restoration failed"
+                                );
+                                self.datapath_healthy
+                                    .store(false, std::sync::atomic::Ordering::Release);
+                                self.drain_tracker.start_rejecting();
+                                drain.start_rejecting();
+                            }
                         }
+                        break 'publication Err(());
                     }
-                    break 'publication Err(());
                 }
 
                 if let Err(error) = publish_group_connectivity(ebpf.as_mut(), &new_connectivity) {

--- a/crates/honk-core/src/control/routing_matcher/codegen.rs
+++ b/crates/honk-core/src/control/routing_matcher/codegen.rs
@@ -277,10 +277,6 @@ pub fn emit_routing_program(
     }
 
     asm.source(0, "fallback");
-    asm.st_imm(R7, OUTBOUND, plan.fallback as i32)?;
-    asm.st_imm(R7, MARK, 0)?;
-    asm.st_imm(R7, MUST, 0)?;
-    asm.st_imm(R7, RULE_ID, u32::MAX as i32)?;
     asm.mov_imm(R0, 0)?;
     asm.exit()?;
     asm.finish()
@@ -390,15 +386,11 @@ fn emit_condition(
     fail: Label,
     fds: &RoutingMapFds,
 ) -> anyhow::Result<()> {
-    let truth = asm.label();
     if condition.not {
-        emit_predicate(asm, &condition.predicate, fail, truth, fds)?;
+        emit_predicate(asm, &condition.predicate, fail, pass, fds)
     } else {
-        emit_predicate(asm, &condition.predicate, truth, fail, fds)?;
+        emit_predicate(asm, &condition.predicate, pass, fail, fds)
     }
-    asm.bind(truth);
-    asm.ja(pass)?;
-    Ok(())
 }
 
 fn emit_predicate(

--- a/crates/honk-core/src/dns/projection/reconcile.rs
+++ b/crates/honk-core/src/dns/projection/reconcile.rs
@@ -1,8 +1,9 @@
+use std::net::IpAddr;
 use std::time::Duration;
 
 use tokio::time::Instant;
 
-use super::state::{Batch, DesiredState, IP_CAPACITY, PendingRemove, PendingSet, RetryMetadata};
+use super::state::{Batch, DesiredState, IP_CAPACITY, PendingSet, RetryMetadata};
 
 const RETRY_MIN: Duration = Duration::from_millis(100);
 const RETRY_MAX: Duration = Duration::from_secs(5);
@@ -43,22 +44,15 @@ impl DesiredState {
                     sets.push(PendingSet {
                         ip,
                         bitmap: *desired,
-                        revision: self.revisions.get(&ip).copied().unwrap_or_default(),
                     });
                 }
                 None if self.applied.contains_key(&ip) => {
-                    removes.push(PendingRemove {
-                        ip,
-                        revision: self.revisions.get(&ip).copied().unwrap_or_default(),
-                    });
+                    removes.push(ip);
                 }
                 Some(_) | None => {
                     self.dirty_ips.remove(&ip);
                     self.retries.remove(&ip);
                 }
-            }
-            if sets.len() + removes.len() >= MAX_BATCH_ENTRIES {
-                break;
             }
         }
         Batch {
@@ -68,49 +62,29 @@ impl DesiredState {
         }
     }
 
-    pub(super) fn commit_success(
-        &mut self,
-        generation: u64,
-        sets: &[PendingSet],
-        removes: &[PendingRemove],
-    ) -> bool {
-        if generation != self.snapshot.generation() {
-            for set in sets {
-                self.applied.insert(set.ip, set.bitmap);
-            }
-            for remove in removes {
-                self.applied.remove(&remove.ip);
-            }
-            self.rebuild_all();
-            return false;
-        }
+    pub(super) fn commit_success(&mut self, sets: &[PendingSet], removes: &[IpAddr]) -> bool {
         let mut current = true;
         for set in sets {
             self.applied.insert(set.ip, set.bitmap);
-            if self.revisions.get(&set.ip) == Some(&set.revision)
-                && self
-                    .desired
-                    .get(&set.ip)
-                    .is_some_and(|desired| desired.bitmap == set.bitmap.bitmap)
+            self.retries.remove(&set.ip);
+            if self
+                .desired
+                .get(&set.ip)
+                .is_some_and(|desired| desired.bitmap == set.bitmap.bitmap)
             {
                 self.dirty_ips.remove(&set.ip);
-                self.retries.remove(&set.ip);
             } else {
                 self.dirty_ips.insert(set.ip);
-                self.retries.remove(&set.ip);
                 current = false;
             }
         }
-        for remove in removes {
-            self.applied.remove(&remove.ip);
-            if self.revisions.get(&remove.ip) == Some(&remove.revision)
-                && !self.desired.contains_key(&remove.ip)
-            {
-                self.dirty_ips.remove(&remove.ip);
-                self.retries.remove(&remove.ip);
+        for &ip in removes {
+            self.applied.remove(&ip);
+            self.retries.remove(&ip);
+            if !self.desired.contains_key(&ip) {
+                self.dirty_ips.remove(&ip);
             } else {
-                self.dirty_ips.insert(remove.ip);
-                self.retries.remove(&remove.ip);
+                self.dirty_ips.insert(ip);
                 current = false;
             }
         }

--- a/crates/honk-core/src/dns/projection/state.rs
+++ b/crates/honk-core/src/dns/projection/state.rs
@@ -71,20 +71,13 @@ pub(super) struct RetryMetadata {
 pub(super) struct Batch {
     pub(super) generation: u64,
     pub(super) sets: Vec<PendingSet>,
-    pub(super) removes: Vec<PendingRemove>,
+    pub(super) removes: Vec<IpAddr>,
 }
 
 #[derive(Debug, Clone, Copy)]
 pub(super) struct PendingSet {
     pub(super) ip: IpAddr,
     pub(super) bitmap: DomainRouting,
-    pub(super) revision: u64,
-}
-
-#[derive(Debug, Clone, Copy)]
-pub(super) struct PendingRemove {
-    pub(super) ip: IpAddr,
-    pub(super) revision: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -103,7 +96,6 @@ pub(super) struct DesiredState {
     pub(super) desired: BTreeMap<IpAddr, DomainRouting>,
     zero_ips: BTreeSet<IpAddr>,
     capacity_warning_emitted: bool,
-    pub(super) revisions: BTreeMap<IpAddr, u64>,
     pub(super) applied: BTreeMap<IpAddr, DomainRouting>,
     pub(super) dirty_ips: BTreeSet<IpAddr>,
     pub(super) retries: BTreeMap<IpAddr, RetryMetadata>,
@@ -122,7 +114,6 @@ impl DesiredState {
             desired: BTreeMap::new(),
             zero_ips: BTreeSet::new(),
             capacity_warning_emitted: false,
-            revisions: BTreeMap::new(),
             applied: BTreeMap::new(),
             dirty_ips: BTreeSet::new(),
             retries: BTreeMap::new(),
@@ -301,18 +292,12 @@ impl DesiredState {
                 self.capacity_warning_emitted = true;
             }
             if evicted != Some(ip) || self.applied.contains_key(&ip) {
-                self.mark_dirty(ip);
+                self.dirty_ips.insert(ip);
             }
             if let Some(evicted) = evicted.filter(|evicted| *evicted != ip) {
-                self.mark_dirty(evicted);
+                self.dirty_ips.insert(evicted);
             }
         }
-    }
-
-    fn mark_dirty(&mut self, ip: IpAddr) {
-        let revision = self.revisions.entry(ip).or_default();
-        *revision = revision.wrapping_add(1);
-        self.dirty_ips.insert(ip);
     }
 
     pub(super) fn rebuild_all(&mut self) {
@@ -329,7 +314,7 @@ impl DesiredState {
             if self.desired.get(&ip).map(|entry| entry.bitmap) != next
                 || self.applied.get(&ip).map(|entry| entry.bitmap) != next
             {
-                self.mark_dirty(ip);
+                self.dirty_ips.insert(ip);
             }
         }
         self.zero_ips = desired

--- a/crates/honk-core/src/dns/projection/tests.rs
+++ b/crates/honk-core/src/dns/projection/tests.rs
@@ -79,7 +79,7 @@ async fn shared_ip_clear_and_expiry_recompute_owner_or() {
     state.observe(positive("b.test", &[ip], Duration::from_secs(5)), now);
     let batch = state.batch(now);
     assert_eq!(batch.sets[0].bitmap.bitmap, [3, 0, 0, 0, 0, 0, 0, 0]);
-    assert!(state.commit_success(batch.generation, &batch.sets, &batch.removes));
+    assert!(state.commit_success(&batch.sets, &batch.removes));
 
     state.observe(ProjectionObservation::Clear { domain: "a.test" }, now);
     assert_eq!(
@@ -88,7 +88,7 @@ async fn shared_ip_clear_and_expiry_recompute_owner_or() {
     );
     tokio::time::advance(Duration::from_secs(5)).await;
     state.expire(tokio::time::Instant::now());
-    assert_eq!(state.batch(tokio::time::Instant::now()).removes[0].ip, ip);
+    assert_eq!(state.batch(tokio::time::Instant::now()).removes[0], ip);
 }
 
 #[tokio::test(start_paused = true)]
@@ -113,20 +113,6 @@ async fn positive_refresh_uses_advertised_ttl_and_retain_keeps_owner() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn generation_race_forces_full_recompute() {
-    let now = tokio::time::Instant::now();
-    let ip = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 3));
-    let mut state = DesiredState::new(snapshot(1, 1, 2), 10_000);
-    state.observe(positive("a.test", &[ip], Duration::from_secs(30)), now);
-    let stale = state.batch(now);
-    state.update_snapshot(snapshot(2, 4, 8));
-    assert!(!state.commit_success(stale.generation, &stale.sets, &stale.removes));
-    let rebuilt = state.batch(now);
-    assert_eq!(rebuilt.generation, 2);
-    assert_eq!(rebuilt.sets[0].bitmap.bitmap, [4, 0, 0, 0, 0, 0, 0, 0]);
-}
-
-#[tokio::test(start_paused = true)]
 async fn same_generation_update_after_batch_snapshot_stays_dirty() {
     let now = tokio::time::Instant::now();
     let ip = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 30));
@@ -136,7 +122,7 @@ async fn same_generation_update_after_batch_snapshot_stays_dirty() {
 
     state.observe(positive("b.test", &[ip], Duration::from_secs(30)), now);
 
-    assert!(!state.commit_success(stale.generation, &stale.sets, &stale.removes));
+    assert!(!state.commit_success(&stale.sets, &stale.removes));
     let repaired = state.batch(now);
     assert_eq!(repaired.sets[0].bitmap.bitmap, [3, 0, 0, 0, 0, 0, 0, 0]);
 }
@@ -271,7 +257,7 @@ async fn ip_capacity_prefers_matching_facts_and_bounds_reload_projection() {
     );
     while !state.dirty_ips.is_empty() {
         let batch = state.batch(now);
-        state.commit_success(batch.generation, &batch.sets, &batch.removes);
+        state.commit_success(&batch.sets, &batch.removes);
     }
     let earlier = IpAddr::V4(Ipv4Addr::from(99_999));
     state.observe(
@@ -283,8 +269,8 @@ async fn ip_capacity_prefers_matching_facts_and_bounds_reload_projection() {
         eviction.sets.is_empty(),
         "full projection must free a slot before admitting a new IP"
     );
-    assert_eq!(eviction.removes[0].ip, matching[IP_CAPACITY - 1]);
-    state.record_failure(eviction.removes[0].ip, now);
+    assert_eq!(eviction.removes[0], matching[IP_CAPACITY - 1]);
+    state.record_failure(eviction.removes[0], now);
     assert!(
         state.batch(now).sets.is_empty(),
         "failed eviction must retain the reservation"
@@ -293,11 +279,11 @@ async fn ip_capacity_prefers_matching_facts_and_bounds_reload_projection() {
         state.next_deadline().unwrap() > now,
         "blocked admission must not busy-loop"
     );
-    state.commit_success(eviction.generation, &[], &eviction.removes);
+    state.commit_success(&[], &eviction.removes);
     let admitted = state.batch(now);
     assert_eq!(admitted.sets[0].ip, earlier);
     assert_eq!(admitted.sets[0].bitmap.bitmap[0], 2);
-    state.commit_success(admitted.generation, &admitted.sets, &[]);
+    state.commit_success(&admitted.sets, &[]);
     assert_eq!(state.applied.len(), IP_CAPACITY);
     state.observe(ProjectionObservation::Clear { domain: "b.test" }, now);
     state.observe(positive("a.test", &matching, Duration::from_secs(300)), now);
@@ -339,7 +325,7 @@ async fn capacity_blocked_retry_waits_for_removal_without_spinning() {
             state.record_failure(ips[0], now);
             batch.sets.retain(|set| set.ip != ips[0]);
         }
-        state.commit_success(batch.generation, &batch.sets, &batch.removes);
+        state.commit_success(&batch.sets, &batch.removes);
     }
     assert_eq!(state.applied.len(), IP_CAPACITY - 1);
 
@@ -353,9 +339,9 @@ async fn capacity_blocked_retry_waits_for_removal_without_spinning() {
         later,
     );
     let batch = state.batch(later);
-    assert_eq!(batch.removes[0].ip, ips[IP_CAPACITY - 1]);
-    state.record_failure(batch.removes[0].ip, later);
-    state.commit_success(batch.generation, &batch.sets, &[]);
+    assert_eq!(batch.removes[0], ips[IP_CAPACITY - 1]);
+    state.record_failure(batch.removes[0], later);
+    state.commit_success(&batch.sets, &[]);
     assert_eq!(state.applied.len(), IP_CAPACITY);
 
     tokio::time::advance(Duration::from_millis(100)).await;
@@ -368,7 +354,7 @@ async fn capacity_blocked_retry_waits_for_removal_without_spinning() {
 
     tokio::time::advance(Duration::from_millis(10)).await;
     let removal = state.batch(tokio::time::Instant::now());
-    state.commit_success(removal.generation, &[], &removal.removes);
+    state.commit_success(&[], &removal.removes);
     let resumed = state.batch(tokio::time::Instant::now());
     assert_eq!(resumed.sets[0].ip, ips[0]);
 }
@@ -396,8 +382,52 @@ async fn mapped_ipv6_and_ipv4_share_one_projected_fact() {
     assert_eq!(projected[&IpAddr::V4(ip)].bitmap[0], 3);
 }
 
+#[test]
+fn retired_projection_ips_do_not_accumulate_memory() {
+    const CHILD: &str = "HONK_PROJECTION_ALLOCATION_CHILD";
+    if std::env::var_os(CHILD).is_none() {
+        let output = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "dns::projection::tests::retired_projection_ips_do_not_accumulate_memory",
+                "--nocapture",
+            ])
+            .env(CHILD, "1")
+            .output()
+            .expect("isolated projection allocation test");
+        assert!(
+            output.status.success(),
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        return;
+    }
+
+    let now = tokio::time::Instant::now();
+    let mut state = DesiredState::new(snapshot(1, 1, 2), 10_000);
+    let region = stats_alloc::Region::new(&stats_alloc::INSTRUMENTED_SYSTEM);
+    for index in 1..=10_000_u32 {
+        let ip = IpAddr::V4(Ipv4Addr::from(index));
+        state.observe(positive("a.test", &[ip], Duration::from_secs(30)), now);
+        let batch = state.batch(now);
+        assert!(state.commit_success(&batch.sets, &batch.removes));
+        state.observe(ProjectionObservation::Clear { domain: "a.test" }, now);
+        let batch = state.batch(now);
+        assert!(state.commit_success(&batch.sets, &batch.removes));
+    }
+    let stats = region.change();
+    let retained = stats
+        .bytes_allocated
+        .saturating_sub(stats.bytes_deallocated);
+    assert!(
+        retained <= 32_768,
+        "retired IPs retained {retained} bytes after 10,000 replacements"
+    );
+}
+
 #[tokio::test(start_paused = true)]
-async fn million_hot_owner_refreshes_keep_heaps_and_revision_bounded() {
+async fn million_hot_owner_refreshes_keep_heaps_bounded() {
     let now = tokio::time::Instant::now();
     let ip = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 55));
     let mut state = DesiredState::new(snapshot(1, 1, 2), 10_000);
@@ -405,7 +435,6 @@ async fn million_hot_owner_refreshes_keep_heaps_and_revision_bounded() {
         positive("a.test", &[ip], Duration::from_secs(2_000_000)),
         now,
     );
-    let revision = state.revisions[&ip];
 
     for update in 1..1_000_000_u64 {
         state.observe(
@@ -415,24 +444,21 @@ async fn million_hot_owner_refreshes_keep_heaps_and_revision_bounded() {
     }
 
     assert_eq!(state.owners.len(), 1);
-    assert_eq!(state.revisions[&ip], revision);
     assert!(state.expiry_deadlines.len() <= 65);
     assert!(state.eviction_order.len() <= 65);
 }
 
 #[tokio::test(start_paused = true)]
-async fn refresh_and_ip_replacement_preserve_ttl_and_exact_revisions() {
+async fn refresh_and_ip_replacement_preserve_ttl() {
     let now = tokio::time::Instant::now();
     let old_ip = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 56));
     let new_ip = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 57));
     let mut state = DesiredState::new(snapshot(1, 1, 2), 10_000);
     state.observe(positive("a.test", &[old_ip], Duration::from_secs(10)), now);
     let initial = state.batch(now);
-    assert!(state.commit_success(initial.generation, &initial.sets, &initial.removes));
-    let old_revision = state.revisions[&old_ip];
+    assert!(state.commit_success(&initial.sets, &initial.removes));
 
     state.observe(positive("a.test", &[old_ip], Duration::from_secs(20)), now);
-    assert_eq!(state.revisions[&old_ip], old_revision);
     assert!(state.batch(now).sets.is_empty());
     state.expire(now + Duration::from_secs(11));
     assert_eq!(state.owner_domains(), vec!["a.test".to_owned()]);
@@ -447,14 +473,7 @@ async fn refresh_and_ip_replacement_preserve_ttl_and_exact_revisions() {
             .collect::<Vec<_>>(),
         vec![new_ip]
     );
-    assert_eq!(
-        replacement
-            .removes
-            .iter()
-            .map(|remove| remove.ip)
-            .collect::<Vec<_>>(),
-        vec![old_ip]
-    );
+    assert_eq!(replacement.removes, vec![old_ip]);
     assert!(!state.reverse.contains_key(&old_ip));
     assert!(state.reverse[&new_ip].contains("a.test"));
     state.expire(now + Duration::from_secs(29));

--- a/crates/honk-core/src/dns/projection/tests/worker_tests.rs
+++ b/crates/honk-core/src/dns/projection/tests/worker_tests.rs
@@ -70,19 +70,19 @@ async fn stale_remove_is_repaired_by_new_same_generation_owner() {
     backend
         .set_domain_ip_bitmap(&key, &initial.sets[0].bitmap)
         .expect("initial write");
-    assert!(state.commit_success(initial.generation, &initial.sets, &[]));
+    assert!(state.commit_success(&initial.sets, &[]));
 
     state.observe(ProjectionObservation::Clear { domain: "a.test" }, now);
     let stale_remove = state.batch(now);
     state.observe(positive("b.test", &[ip], Duration::from_secs(30)), now);
     backend.remove_domain_ip_bitmap(&key).expect("stale remove");
-    assert!(!state.commit_success(stale_remove.generation, &[], &stale_remove.removes));
+    assert!(!state.commit_success(&[], &stale_remove.removes));
 
     let repaired = state.batch(now);
     backend
         .set_domain_ip_bitmap(&key, &repaired.sets[0].bitmap)
         .expect("repair write");
-    assert!(state.commit_success(repaired.generation, &repaired.sets, &repaired.removes));
+    assert!(state.commit_success(&repaired.sets, &repaired.removes));
     assert!(state.dirty_ips.is_empty());
     assert_eq!(
         backend.projection_map_snapshot()[0].1.bitmap,

--- a/crates/honk-core/src/dns/projection/worker.rs
+++ b/crates/honk-core/src/dns/projection/worker.rs
@@ -105,10 +105,10 @@ async fn flush_after_snapshot(
             }
         }
         for remove in &batch.removes {
-            let key = maps::ip_addr_to_lpm_key(remove.ip);
+            let key = maps::ip_addr_to_lpm_key(*remove);
             match backend.remove_domain_ip_bitmap(&key) {
                 Ok(()) => successful_removes.push(*remove),
-                Err(error) => failures.push((remove.ip, error)),
+                Err(error) => failures.push((*remove, error)),
             }
         }
 
@@ -117,7 +117,7 @@ async fn flush_after_snapshot(
         for (ip, _) in &failures {
             state.record_failure(*ip, now);
         }
-        state.commit_success(batch.generation, &successful_sets, &successful_removes)
+        state.commit_success(&successful_sets, &successful_removes)
     };
     if !writes_current {
         crate::stats::record_dns_event(crate::stats::DnsStatEvent::ProjectionRetry);

--- a/doc/en/design/dns.md
+++ b/doc/en/design/dns.md
@@ -226,6 +226,8 @@ The worker reconciles generation-tagged desired state in batches of at most 256 
 
 Retry wakeups and batch admission use the same capacity-aware per-IP deadline; an overdue insertion blocked by a full projection cannot spin while a deletion backs off. A successful reload records the exact IP slice installed in the new map as applied state before reconciling current owners, including any that expired during loading. Worker writes and their acknowledgements remain under one generation fence, so an old completion cannot overwrite that published accounting. Reloads that keep the physical map also keep its existing applied state.
 
+Incremental acknowledgement compares the successful write with the current desired bitmap or absence, without retaining historical per-IP revisions. Owner TTL sequences and policy generations remain independent guards.
+
 ## Generations and reload
 
 One `DnsRuntime` contains the forwarder and policy, immutable hosts table, routing and group snapshots, transport manager, routing projection, bootstrap resolver capture, and generation-local query/UDP admission. Each newly constructed forwarder owns its singleflight and background refresh/prefetch workers; clones remain within that generation. Each DNS pool owns a fresh outbound runtime fork, independent of both traffic session reuse and predecessor DNS sessions. The DNS registry shares its source configuration generation's dial semaphore and the process-wide physical-dial ceiling, not its retirement flag or protocol pools.

--- a/doc/zh/design/dns.md
+++ b/doc/zh/design/dns.md
@@ -210,6 +210,8 @@ worker 以最多 256 个 set/remove 为一批，协调带 generation 的 desired
 
 重试唤醒与批次准入共用同一个带容量判断的逐 IP deadline；投影已满时，过期但无法准入的新增项不会在删除退避期间空转。成功 reload 会先把新 map 实际安装的完整 IP 集合记为 applied，再协调当前 owner，包括加载期间已到期的 owner。worker 的 map 写入与确认保持在同一个 generation fence 内，旧完成事件不能覆盖新发布的记账。保留物理 map 的 reload 也保留原有 applied 状态。
 
+增量确认将成功写入与当前期望位图或缺失状态比较，不保留历史 IP revision 账本。owner 的 TTL sequence 与策略 generation 仍分别保护各自的边界。
+
 ## Generation 与 reload
 
 一个 `DnsRuntime` 包含 forwarder 与 policy、不可变 hosts 表、路由与组快照、transport manager、路由投影、捕获的 bootstrap resolver，以及代内 query/UDP 准入。新构建的 forwarder 独占 singleflight 和 refresh/prefetch worker；clone 仍属于同一代。DNS 代理 transport 使用全新的 outbound runtime registry，不复用普通流量或旧 DNS 代的 session。该 DNS registry 与来源配置代共享 dial semaphore，并保留进程级 physical-dial 上限，但不共享退役标志或协议连接池。


### PR DESCRIPTION
## Problem

Following #181, DNS projection still retains a [historical per-IP revision ledger](https://github.com/daeuniverse/honk/blob/517fe04b0624259c7d8ebae5dcac03e224a8de74/crates/honk-core/src/dns/projection/state.rs#L312-L315). The [expanded write/acknowledgement fence](https://github.com/daeuniverse/honk/blob/517fe04b0624259c7d8ebae5dcac03e224a8de74/crates/honk-core/src/dns/projection/worker.rs#L85-L120) also makes the old post-write generation recovery unnecessary.

## How I fixed it

Remove revision bookkeeping, obsolete generation recovery and the removal wrapper; compare canonical projections without converting and sorting the old snapshot; remove redundant generated jumps and fallback stores. Preserve TTL, capacity, pre-write generation checks and publication fencing. Add an isolated retained-allocation regression and update both DNS design documents; keep the native BPF architecture unchanged.

## Verified

Validated the identical source tree at [1e70a7b](https://github.com/daeuniverse/honk/commit/1e70a7baaaef58810147ea3acacddfb03e5367ee): fmt, `dns-ci`, workspace/eBPF clippy, 1,951 workspace tests, 992 eBPF-library tests and all 15 `just test-netns` checks. The allocation regression failed before removal and passes afterward; the no-op reload comparison passed with unchanged allocations. The known routing exclusion and existing ignored tests remain; no new gateway traffic A/B or cross-build. This branch contains only the follow-up commit atop the squash merge of #181.
