### PR TITLE
fix(pool): one lock for the connection pool, and ready streams that stay with their generation

### DIFF
--- a/crates/honk-core/src/control/bootstrap.rs
+++ b/crates/honk-core/src/control/bootstrap.rs
@@ -315,17 +315,20 @@ impl ControlPlane {
         let pool = self.connection_pool.clone();
         let udp_pool = self.udp_pool.clone();
         let config_for_purge = self.config.clone();
+        let runtime_registry = self.runtime_registry.clone();
         self.alive_set.set_death_callback(Some(Box::new(
             move |node_id: uuid::Uuid, _name: &str| {
                 udp_pool.remove_by_node(node_id);
                 let node_addr = config_for_purge.try_read().ok().and_then(|c| {
-                    c.nodes
-                        .iter()
-                        .find(|n| n.id == node_id)
-                        .map(|n| format!("{}:{}", n.host(), n.port))
+                    c.nodes.iter().find(|n| n.id == node_id).map(|n| {
+                        (
+                            format!("{}:{}", n.host(), n.port),
+                            runtime_registry.read().generation(),
+                        )
+                    })
                 });
-                if let Some(addr) = node_addr {
-                    pool.purge_node(&addr);
+                if let Some((addr, generation)) = node_addr {
+                    pool.purge_node(&addr, generation, node_id);
                 }
             },
         )));

--- a/crates/honk-core/src/control/connection/dial_permit_scope_tests.rs
+++ b/crates/honk-core/src/control/connection/dial_permit_scope_tests.rs
@@ -25,8 +25,9 @@ async fn ready_pool_hit_does_not_wait_for_physical_dial_permit() {
     );
     let _held = generation.acquire_dial_permit().await;
     let pool = ConnectionPool::new();
-    let key = ConnectionPool::ready_key(&format!("{}:{}", node.host(), node.port), target, None);
+    let key = ConnectionPool::ready_key(generation.generation(), node.id, target, None);
     pool.deposit_ready(
+        generation.generation(),
         &key,
         crate::proxy::ProxyStream {
             stream: Box::new(tcp),

--- a/crates/honk-core/src/control/connection/tcp.rs
+++ b/crates/honk-core/src/control/connection/tcp.rs
@@ -559,13 +559,14 @@ impl ControlPlaneHandle {
                             .unwrap_or((false, false));
                         if ready_capable {
                             let key = ConnectionPool::ready_key(
-                                &node_addr,
+                                generation.generation(),
+                                node.id,
                                 original_dst,
                                 target_domain.as_deref(),
                             );
                             // Only hot targets earn a speculative ready
                             // dial; a one-off flow gets none.
-                            if !pool.note_target(&key) {
+                            if !pool.note_target(generation.generation(), &key) {
                                 return;
                             }
                             let pool_reporter =
@@ -591,7 +592,8 @@ impl ControlPlaneHandle {
                                         reporter.setup_succeeded();
                                         reporter.finish_setup_only();
                                     }
-                                    pool.deposit_ready(&key, stream).await;
+                                    pool.deposit_ready(generation.generation(), &key, stream)
+                                        .await;
                                 }
                                 Err(e) => {
                                     if let Some(reporter) = &pool_reporter {
@@ -913,11 +915,16 @@ impl ControlPlaneHandle {
                         })
                         .unwrap_or((false, false));
                     if ready_capable {
-                        let key =
-                            ConnectionPool::ready_key(&node_addr, target, target_domain.as_deref());
+                        let key = ConnectionPool::ready_key(
+                            generation.generation(),
+                            node.id,
+                            target,
+                            target_domain.as_deref(),
+                        );
                         // Only hot targets earn a speculative ready
                         // dial; a one-off flow gets none.
-                        let Some(_warm_guard) = pool.try_begin_warm(&key) else {
+                        let Some(_warm_guard) = pool.try_begin_warm(generation.generation(), &key)
+                        else {
                             return;
                         };
                         let pool_reporter = pool_feedback.as_ref().map(|feedback| feedback.start());
@@ -942,7 +949,8 @@ impl ControlPlaneHandle {
                                     reporter.setup_succeeded();
                                     reporter.finish_setup_only();
                                 }
-                                pool.deposit_ready(&key, stream).await;
+                                pool.deposit_ready(generation.generation(), &key, stream)
+                                    .await;
                             }
                             Err(e) => {
                                 if let Some(reporter) = &pool_reporter {
@@ -1089,7 +1097,8 @@ impl ControlPlaneHandle {
             .ok_or_else(|| anyhow::anyhow!("No handler for protocol {:?}", protocol))?;
 
         if !pool_disabled && (entry.descriptor.pool_ready_streams)(node) {
-            let key = ConnectionPool::ready_key(&addr, target, target_domain);
+            let key =
+                ConnectionPool::ready_key(generation.generation(), node.id, target, target_domain);
             if let Some(stream) = pool.acquire_ready(&key).await {
                 tracing::debug!(
                     "Pooled ready stream via {} acquired for {} (handshake skipped)",

--- a/crates/honk-core/src/control/reload/transaction.rs
+++ b/crates/honk-core/src/control/reload/transaction.rs
@@ -571,6 +571,8 @@ impl ControlPlane {
         // DNS runtime still owns it until old leases and transports retire;
         // only then do the pools enter graceful session drain.
         old_registry.begin_retirement();
+        self.connection_pool
+            .retire_generation(old_registry.generation());
         self.stop_udp_warm_coordinator().await;
         self.stop_selector_warm_coordinator().await;
         self.start_udp_warm_coordinator(Arc::clone(&new_runtime_registry))

--- a/crates/honk-core/src/control/reload_tests.rs
+++ b/crates/honk-core/src/control/reload_tests.rs
@@ -2245,3 +2245,107 @@ async fn reload_retires_only_the_old_warm_generation_and_starts_the_new_one() {
     cp.stop_udp_warm_coordinator().await;
     new_generation.shutdown().await;
 }
+
+async fn ready_pool_reload_fixture() -> (
+    ControlPlane,
+    Config,
+    Arc<honk_outbound::runtime::OutboundRuntimeRegistry>,
+    String,
+    tokio::net::TcpStream,
+) {
+    let cp = test_cp().await;
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let node = Node::from_share_link(&format!("socks5://a:a@{address}#ready-reload")).unwrap();
+    let mut config = Config::default();
+    config.nodes.push(node.clone());
+    assert!(
+        cp.apply_runtime_config(config.clone(), &DrainTracker::new())
+            .await
+    );
+    let generation = cp.runtime_registry.read().clone();
+    let target = "192.0.2.1:443".parse().unwrap();
+    let key = ConnectionPool::ready_key(generation.generation(), node.id, target, None);
+    let client = tokio::net::TcpStream::connect(address).await.unwrap();
+    let (peer, _) = listener.accept().await.unwrap();
+    cp.connection_pool
+        .deposit_ready(
+            generation.generation(),
+            &key,
+            crate::proxy::ProxyStream {
+                stream: Box::new(client),
+                target_addr: target,
+                target_domain: None,
+            },
+        )
+        .await;
+    cp.connection_pool.check_invariants();
+    assert_eq!(cp.connection_pool.ready_metrics().entries, 1);
+    (cp, config, generation, key, peer)
+}
+
+#[tokio::test]
+async fn ready_pool_reload_recredentials_retire_old_stream() {
+    let (cp, mut config, generation, key, _peer) = ready_pool_reload_fixture().await;
+    let node = &mut config.nodes[0];
+    let socks = node.socks5_mut().unwrap();
+    socks.username = Some("b".into());
+    socks.password = Some("b".into());
+    node.id = node.derive_id();
+    assert!(cp.apply_runtime_config(config, &DrainTracker::new()).await);
+    assert_ne!(
+        generation.generation(),
+        cp.runtime_registry.read().generation()
+    );
+    cp.connection_pool.check_invariants();
+    assert!(cp.connection_pool.acquire_ready(&key).await.is_none());
+    cp.connection_pool.check_invariants();
+}
+
+#[tokio::test]
+async fn ready_pool_reload_protocol_replacement_retires_old_stream() {
+    let (cp, mut config, generation, key, _peer) = ready_pool_reload_fixture().await;
+    let node = &config.nodes[0];
+    config.nodes[0] = Node::from_share_link(&format!(
+        "trojan://secret@{}:{}?sni=reload.example#ready-reload",
+        node.host(),
+        node.port,
+    ))
+    .unwrap();
+    assert!(cp.apply_runtime_config(config, &DrainTracker::new()).await);
+    assert_ne!(
+        generation.generation(),
+        cp.runtime_registry.read().generation()
+    );
+    cp.connection_pool.check_invariants();
+    assert!(cp.connection_pool.acquire_ready(&key).await.is_none());
+    cp.connection_pool.check_invariants();
+}
+
+#[tokio::test]
+async fn ready_pool_reload_routing_change_retires_unchanged_node_stream() {
+    let (cp, mut config, generation, key, _peer) = ready_pool_reload_fixture().await;
+    config.routing = changed_routing_config().routing;
+    assert!(cp.apply_runtime_config(config, &DrainTracker::new()).await);
+    assert_ne!(
+        generation.generation(),
+        cp.runtime_registry.read().generation()
+    );
+    cp.connection_pool.check_invariants();
+    assert!(cp.connection_pool.acquire_ready(&key).await.is_none());
+    cp.connection_pool.check_invariants();
+}
+
+#[tokio::test]
+async fn ready_pool_reload_rejection_preserves_stream() {
+    let (cp, mut config, generation, key, _peer) = ready_pool_reload_fixture().await;
+    config.nodes[0].name = "direct".into();
+    assert!(!cp.reload_runtime_config(config).await);
+    assert_eq!(
+        generation.generation(),
+        cp.runtime_registry.read().generation()
+    );
+    cp.connection_pool.check_invariants();
+    assert!(cp.connection_pool.acquire_ready(&key).await.is_some());
+    cp.connection_pool.check_invariants();
+}

--- a/crates/honk-core/src/pool.rs
+++ b/crates/honk-core/src/pool.rs
@@ -26,14 +26,23 @@
 //! call site (multiplexed handlers never deposit ready entries — their
 //! session pool already owns reuse). Hit/miss/entry counters feed the
 //! clash API `/stats`.
+//!
+//! One mutex keeps the stream total equal to the sum of non-empty entry
+//! vectors and ready-target counts equal to the present ready keys. Entry,
+//! target, warm-claim and hotness changes are synchronous transactions; the
+//! lock is never held across an await. Removed streams are dropped after
+//! unlocking, so socket teardown cannot extend the critical section.
+//! Hotness is bounded to 4,096 keys; warm claims remain one per in-flight
+//! dial, without a separate cardinality cap.
 
-use dashmap::DashMap;
-use dashmap::mapref::entry::Entry;
 use parking_lot::Mutex;
+use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
 use std::os::fd::AsRawFd;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+#[cfg(test)]
+use std::sync::{Barrier, Mutex as StdMutex};
 use std::time::{Duration, Instant};
 use tokio::net::TcpStream;
 use tracing::{debug, trace};
@@ -75,26 +84,76 @@ struct TimedStream {
     last_used: Instant,
 }
 
+#[cfg(test)]
+#[derive(Clone)]
+struct PauseHook {
+    name: &'static str,
+    reached: Arc<Barrier>,
+    resume: Arc<Barrier>,
+}
+
+#[cfg(test)]
+impl PauseHook {
+    fn new(name: &'static str) -> Self {
+        Self {
+            name,
+            reached: Arc::new(Barrier::new(2)),
+            resume: Arc::new(Barrier::new(2)),
+        }
+    }
+}
+
 pub struct ConnectionPool {
-    entries: DashMap<String, Arc<Mutex<Vec<TimedStream>>>>,
-    total_entries: AtomicU64,
+    state: Mutex<PoolState>,
     capacity_limit: u64,
-    /// Ready-key cardinality per node, updated only when a ready key enters
-    /// or leaves `entries`; no deposit scans every shard.
-    ready_targets: DashMap<String, Arc<AtomicU64>>,
-    /// One background warmer per ready key. Followers retain the existing
-    /// ready entry or wait for the next flow rather than duplicate a dial.
-    warm_dials: DashMap<String, ()>,
     idle_timeout: Duration,
     ready_idle_timeout: Duration,
     max_age: Duration,
-    /// Target hotness for ready-deposit gating (`ready|node|target` →
-    /// (flow count, window start)). This remains strictly bounded: stale
-    /// entries are reset on their next access, never reclaimed by a scan.
-    hot: DashMap<String, (u32, Instant)>,
-    hot_entries: AtomicU64,
     ready_hits: AtomicU64,
     ready_misses: AtomicU64,
+    #[cfg(test)]
+    pause_hook: StdMutex<Option<PauseHook>>,
+}
+
+#[derive(Default)]
+struct PoolState {
+    entries: HashMap<String, Vec<TimedStream>>,
+    total: u64,
+    ready_targets: HashMap<String, u32>,
+    warm_dials: HashSet<String>,
+    hot: HashMap<String, (u32, Instant)>,
+}
+
+impl PoolState {
+    fn decrement_ready_target(targets: &mut HashMap<String, u32>, key: &str) {
+        if key.starts_with("ready|") {
+            let node = ConnectionPool::ready_node(key);
+            let count = targets.get_mut(node).expect("present ready target");
+            *count -= 1;
+            if *count == 0 {
+                targets.remove(node);
+            }
+        }
+    }
+
+    fn remove_empty_key(&mut self, key: &str) {
+        if self.entries.get(key).is_some_and(Vec::is_empty) {
+            self.entries.remove(key);
+            Self::decrement_ready_target(&mut self.ready_targets, key);
+        }
+    }
+
+    fn remove_matching(
+        &mut self,
+        mut matches: impl FnMut(&str) -> bool,
+        removed: &mut Vec<TimedStream>,
+    ) {
+        for (key, mut list) in self.entries.extract_if(|key, _| matches(key)) {
+            self.total -= list.len() as u64;
+            Self::decrement_ready_target(&mut self.ready_targets, &key);
+            removed.append(&mut list);
+        }
+    }
 }
 
 pub(crate) struct WarmDialGuard<'a> {
@@ -104,7 +163,7 @@ pub(crate) struct WarmDialGuard<'a> {
 
 impl Drop for WarmDialGuard<'_> {
     fn drop(&mut self) {
-        self.pool.warm_dials.remove(&self.key);
+        self.pool.state.lock().warm_dials.remove(&self.key);
     }
 }
 
@@ -144,18 +203,39 @@ impl ConnectionPool {
 
     pub(crate) fn with_capacity_limit(capacity_limit: usize) -> Self {
         Self {
-            entries: DashMap::new(),
-            total_entries: AtomicU64::new(0),
+            state: Mutex::new(PoolState::default()),
             capacity_limit: capacity_limit.min(MAX_TOTAL_ENTRIES) as u64,
             idle_timeout: DEFAULT_IDLE_TIMEOUT,
             ready_idle_timeout: READY_IDLE_TIMEOUT,
-            ready_targets: DashMap::new(),
-            warm_dials: DashMap::new(),
             max_age: DEFAULT_MAX_AGE,
-            hot: DashMap::new(),
-            hot_entries: AtomicU64::new(0),
             ready_hits: AtomicU64::new(0),
             ready_misses: AtomicU64::new(0),
+            #[cfg(test)]
+            pause_hook: StdMutex::new(None),
+        }
+    }
+    #[cfg(test)]
+    fn install_pause_hook(&self, name: &'static str) -> PauseHook {
+        let hook = PauseHook::new(name);
+        *self.pause_hook.lock().expect("pause hook mutex poisoned") = Some(hook.clone());
+        hook
+    }
+
+    #[cfg(test)]
+    fn pause_at(&self, name: &'static str) {
+        let hook = {
+            let mut configured = self.pause_hook.lock().expect("pause hook mutex poisoned");
+            if configured.as_ref().is_some_and(|hook| hook.name == name) {
+                configured.take()
+            } else {
+                None
+            }
+        };
+        if let Some(hook) = hook {
+            self.check_invariants();
+            hook.reached.wait();
+            hook.resume.wait();
+            self.check_invariants();
         }
     }
 
@@ -164,52 +244,42 @@ impl ConnectionPool {
     /// ([`HOT_THRESHOLD`] flows within [`HOT_WINDOW`]).
     pub(crate) fn note_target(&self, key: &str) -> bool {
         const MAX_HOT_TARGETS: u64 = 4096;
-        match self.hot.entry(key.to_owned()) {
-            Entry::Occupied(mut entry) => {
-                let value = entry.get_mut();
-                if value.1.elapsed() > HOT_WINDOW {
-                    *value = (0, Instant::now());
-                }
-                value.0 += 1;
-                value.0 >= HOT_THRESHOLD
+        let mut state = self.state.lock();
+        if let Some(value) = state.hot.get_mut(key) {
+            if value.1.elapsed() > HOT_WINDOW {
+                *value = (0, Instant::now());
             }
-            Entry::Vacant(entry) => {
-                if self
-                    .hot_entries
-                    .try_update(Ordering::AcqRel, Ordering::Acquire, |current| {
-                        (current < MAX_HOT_TARGETS).then_some(current + 1)
-                    })
-                    .is_err()
-                {
-                    return false;
-                }
-                entry.insert((1, Instant::now()));
-                false
+            value.0 += 1;
+            value.0 >= HOT_THRESHOLD
+        } else {
+            if (state.hot.len() as u64) < MAX_HOT_TARGETS {
+                state.hot.insert(key.to_owned(), (1, Instant::now()));
             }
+            false
         }
     }
 
     /// Claim one background warming dial for this ready key. The returned
     /// guard clears the claim on drop, including cancellation and failures.
     pub(crate) fn try_begin_warm(&self, key: &str) -> Option<WarmDialGuard<'_>> {
-        match self.warm_dials.entry(key.to_owned()) {
-            Entry::Vacant(entry) => {
-                entry.insert(());
-                Some(WarmDialGuard {
-                    pool: self,
-                    key: key.to_owned(),
-                })
-            }
-            Entry::Occupied(_) => None,
+        let mut state = self.state.lock();
+        if state.warm_dials.contains(key) {
+            return None;
         }
+        state.warm_dials.insert(key.to_owned());
+        Some(WarmDialGuard {
+            pool: self,
+            key: key.to_owned(),
+        })
     }
 
     #[cfg(any(test, feature = "clash-api"))]
     pub(crate) fn ready_metrics(&self) -> ReadyPoolMetrics {
+        let state = self.state.lock();
         ReadyPoolMetrics {
             hits: self.ready_hits.load(Ordering::Relaxed),
             misses: self.ready_misses.load(Ordering::Relaxed),
-            entries: self.total_entries.load(Ordering::Relaxed),
+            entries: state.total,
         }
     }
 
@@ -257,60 +327,41 @@ impl ConnectionPool {
     }
 
     async fn acquire_entry(&self, addr: &str, want_ready: bool) -> Option<PooledStream> {
-        let arc = Arc::clone(&*self.entries.get(addr)?);
-        let mut list = arc.lock();
-
+        #[cfg(test)]
+        {
+            self.pause_at("checkout_after_clone");
+            self.pause_at("checkout_after_drop");
+        }
+        let mut removed = Vec::new();
+        let mut state = self.state.lock();
+        let list = state.entries.get_mut(addr)?;
         let now = Instant::now();
-        let mut found_idx: Option<usize> = None;
-        for (i, entry) in list.iter().rev().enumerate() {
-            let idx = list.len() - 1 - i;
-            if !Self::entry_matches(entry, want_ready) {
-                continue;
-            }
-            if self.entry_expired(entry, now) {
-                continue;
-            }
-            if Self::is_entry_alive(entry) {
-                found_idx = Some(idx);
-                break;
-            }
-        }
-
-        match found_idx {
-            Some(idx) => {
-                let entry = list.swap_remove(idx);
-                self.total_entries.fetch_sub(1, Ordering::Relaxed);
-                trace!(
-                    "Pool hit ({}): {} ({} idle remaining)",
-                    if want_ready { "ready" } else { "bare" },
-                    addr,
-                    list.len()
-                );
-                if list.is_empty() {
-                    drop(list);
-                    if self.entries.remove(addr).is_some() && want_ready {
-                        self.release_ready_target(&Self::ready_node(addr));
-                    }
-                }
-                Some(entry.stream)
-            }
-            None => {
-                let before = list.len();
-                list.retain(|e| !self.entry_expired(e, now) && Self::is_entry_alive(e));
-                let removed = before - list.len();
-                if removed > 0 {
-                    self.total_entries
-                        .fetch_sub(removed as u64, Ordering::Relaxed);
-                }
-                if list.is_empty() {
-                    drop(list);
-                    if self.entries.remove(addr).is_some() && want_ready {
-                        self.release_ready_target(&Self::ready_node(addr));
-                    }
-                }
-                None
-            }
-        }
+        let found = list.iter().rposition(|entry| {
+            Self::entry_matches(entry, want_ready)
+                && !self.entry_expired(entry, now)
+                && Self::is_entry_alive(entry)
+        });
+        let acquired = if let Some(index) = found {
+            let entry = list.swap_remove(index);
+            trace!(
+                "Pool hit ({}): {} ({} idle remaining)",
+                if want_ready { "ready" } else { "bare" },
+                addr,
+                list.len()
+            );
+            state.total -= 1;
+            Some(entry.stream)
+        } else {
+            removed.extend(list.extract_if(.., |entry| {
+                self.entry_expired(entry, now) || !Self::is_entry_alive(entry)
+            }));
+            state.total -= removed.len() as u64;
+            None
+        };
+        state.remove_empty_key(addr);
+        drop(state);
+        drop(removed);
+        acquired
     }
 
     pub(crate) async fn deposit_tcp(&self, addr: &str, stream: TcpStream) {
@@ -322,24 +373,24 @@ impl ConnectionPool {
     /// expired entries are removed here so a long-lived warm owner can
     /// replace them instead of eventually filling the per-host vector.
     pub(crate) fn has_live_bare_entry(&self, addr: &str) -> bool {
+        let mut removed = Vec::new();
+        let mut state = self.state.lock();
         let now = Instant::now();
-        let Some(entries) = self.entries.get(addr) else {
+        let Some(entries) = state.entries.get_mut(addr) else {
             return false;
         };
-        let mut entries = entries.lock();
-        let before = entries.len();
-        entries.retain(|entry| {
-            !matches!(entry.stream, PooledStream::Bare(_))
-                || (!self.entry_expired(entry, now) && Self::is_entry_alive(entry))
-        });
-        let removed = before - entries.len();
-        if removed > 0 {
-            self.total_entries
-                .fetch_sub(removed as u64, Ordering::Relaxed);
-        }
-        entries
+        removed.extend(entries.extract_if(.., |entry| {
+            matches!(entry.stream, PooledStream::Bare(_))
+                && (self.entry_expired(entry, now) || !Self::is_entry_alive(entry))
+        }));
+        let live = entries
             .iter()
-            .any(|entry| matches!(entry.stream, PooledStream::Bare(_)))
+            .any(|entry| matches!(entry.stream, PooledStream::Bare(_)));
+        state.total -= removed.len() as u64;
+        state.remove_empty_key(addr);
+        drop(state);
+        drop(removed);
+        live
     }
 
     /// Deposit a fully-dialed stream under `key` (see [`ready_key`]).
@@ -351,114 +402,69 @@ impl ConnectionPool {
     }
 
     async fn deposit_entry(&self, addr: &str, stream: PooledStream) {
-        let ready_node = matches!(stream, PooledStream::Ready(_)).then(|| Self::ready_node(addr));
-        if !self.reserve_total() {
+        #[cfg(test)]
+        self.pause_at("deposit_before_lock");
+        let mut state = self.state.lock();
+        if state.total >= self.capacity_limit {
             debug!(
                 "Pool global cap reached ({}); dropping deposit for {}",
                 self.capacity_limit, addr
             );
             return;
         }
-
-        let mut target_reserved = false;
-        let arc = match self.entries.entry(addr.to_string()) {
-            Entry::Occupied(entry) => Arc::clone(entry.get()),
-            Entry::Vacant(entry) => {
-                if let Some(node) = ready_node.as_deref() {
-                    target_reserved = self.reserve_ready_target(node);
-                    if !target_reserved {
-                        self.total_entries.fetch_sub(1, Ordering::AcqRel);
-                        debug!(
-                            "Ready target cardinality cap reached for {} (max={}); dropping deposit",
-                            node, MAX_READY_TARGETS_PER_NODE
-                        );
-                        return;
-                    }
-                }
-                let arc = Arc::new(Mutex::new(Vec::new()));
-                entry.insert(Arc::clone(&arc));
-                arc
-            }
-        };
-        let mut list = arc.lock();
-        if list.len() >= MAX_PER_HOST {
-            self.total_entries.fetch_sub(1, Ordering::AcqRel);
-            if target_reserved {
-                self.release_ready_target(ready_node.as_deref().expect("ready node"));
-            }
+        let list = state.entries.get_mut(addr);
+        if list.as_ref().is_some_and(|list| list.len() >= MAX_PER_HOST) {
             debug!("Pool cap reached for {} (max={})", addr, MAX_PER_HOST);
             return;
         }
+        if list.is_none() && matches!(stream, PooledStream::Ready(_)) {
+            let node = Self::ready_node(addr);
+            let count = state.ready_targets.get(node).copied().unwrap_or(0);
+            if count >= MAX_READY_TARGETS_PER_NODE as u32 {
+                debug!(
+                    "Ready target cardinality cap reached for {} (max={}); dropping deposit",
+                    node, MAX_READY_TARGETS_PER_NODE
+                );
+                return;
+            }
+            state.ready_targets.insert(node.to_owned(), count + 1);
+        }
         let now = Instant::now();
-        let kind = match &stream {
-            PooledStream::Bare(_) => "bare",
-            PooledStream::Ready(_) => "ready",
-        };
-        list.push(TimedStream {
+        let entry = TimedStream {
             stream,
             created: now,
             last_used: now,
-        });
-        debug!(
-            "Pool deposit ({}): {} ({} total pooled)",
-            kind,
-            addr,
-            self.total_entries.load(Ordering::Relaxed)
-        );
-    }
-
-    fn reserve_total(&self) -> bool {
-        self.total_entries
-            .try_update(Ordering::AcqRel, Ordering::Acquire, |current| {
-                (current < self.capacity_limit).then_some(current + 1)
-            })
-            .is_ok()
-    }
-
-    fn ready_node(key: &str) -> String {
-        key.strip_prefix("ready|")
-            .and_then(|rest| rest.split_once('|').map(|(node, _)| node.to_owned()))
-            .unwrap_or_default()
-    }
-
-    fn reserve_ready_target(&self, node: &str) -> bool {
-        let counter = Arc::clone(
-            &*self
-                .ready_targets
-                .entry(node.to_owned())
-                .or_insert_with(|| Arc::new(AtomicU64::new(0))),
-        );
-        counter
-            .try_update(Ordering::AcqRel, Ordering::Acquire, |current| {
-                current
-                    .checked_add(1)
-                    .filter(|next| *next <= MAX_READY_TARGETS_PER_NODE as u64)
-            })
-            .is_ok()
-    }
-
-    fn release_ready_target(&self, node: &str) {
-        if let Some(counter) = self.ready_targets.get(node) {
-            let _ = counter.try_update(Ordering::AcqRel, Ordering::Acquire, |current| {
-                current.checked_sub(1)
-            });
+        };
+        if let Some(list) = state.entries.get_mut(addr) {
+            list.push(entry);
+        } else {
+            state.entries.insert(addr.to_owned(), vec![entry]);
         }
+        state.total += 1;
+        debug!("Pool deposit: {} ({} total pooled)", addr, state.total);
+    }
+
+    fn ready_node(key: &str) -> &str {
+        key.strip_prefix("ready|")
+            .and_then(|rest| rest.split_once('|').map(|(node, _)| node))
+            .unwrap_or_default()
     }
 
     /// Drop only the bare preconnect for a node. Ready streams may belong to
     /// active traffic policy and are not selector warm ownership.
     pub(crate) fn purge_bare(&self, node_addr: &str) {
-        let Some((_, entries)) = self.entries.remove(node_addr) else {
-            return;
-        };
-        let removed = entries.lock().len() as u64;
-        if removed > 0 {
-            self.total_entries.fetch_sub(removed, Ordering::Relaxed);
+        let mut state = self.state.lock();
+        let removed = state.entries.remove(node_addr);
+        if let Some(entries) = &removed {
+            state.total -= entries.len() as u64;
             debug!(
                 "Purged {} selector-warm bare connections for {}",
-                removed, node_addr
+                entries.len(),
+                node_addr
             );
         }
+        drop(state);
+        drop(removed);
     }
 
     /// Drop every pooled connection tied to a proxy node: the bare
@@ -468,54 +474,55 @@ impl ConnectionPool {
     /// serving it for up to 60s).
     pub(crate) fn purge_node(&self, node_addr: &str) {
         let ready_prefix = format!("ready|{}|", node_addr);
-        let mut removed = 0u64;
-        self.entries.retain(|key, arc| {
-            if key == node_addr || key.starts_with(&ready_prefix) {
-                removed += arc.lock().len() as u64;
+        let mut removed = Vec::new();
+        let mut state = self.state.lock();
+        state.remove_matching(
+            |key| key == node_addr || key.starts_with(&ready_prefix),
+            &mut removed,
+        );
+        drop(state);
+        debug!(
+            "Purged {} pooled connections for dead node {}",
+            removed.len(),
+            node_addr
+        );
+        drop(removed);
+    }
+
+    pub(crate) async fn prune_expired(&self) -> usize {
+        #[cfg(test)]
+        self.pause_at("janitor_before_store");
+        let mut removed = Vec::new();
+        let mut state = self.state.lock();
+        let now = Instant::now();
+        let PoolState {
+            entries,
+            total,
+            ready_targets,
+            ..
+        } = &mut *state;
+        entries.retain(|key, list| {
+            let before = removed.len();
+            removed.extend(list.extract_if(.., |entry| {
+                self.entry_expired(entry, now) || !Self::is_entry_alive(entry)
+            }));
+            *total -= (removed.len() - before) as u64;
+            if list.is_empty() {
+                PoolState::decrement_ready_target(ready_targets, key);
                 false
             } else {
                 true
             }
         });
-        if removed > 0 {
-            self.total_entries.fetch_sub(removed, Ordering::Relaxed);
-            self.ready_targets.remove(node_addr);
-            debug!(
-                "Purged {} pooled connections for dead node {}",
-                removed, node_addr
-            );
-        }
-    }
-
-    pub(crate) async fn prune_expired(&self) -> usize {
-        let now = Instant::now();
-        let mut total_removed = 0usize;
-        let total_remaining = AtomicU64::new(0);
-
-        self.entries.retain(|addr, arc| {
-            let mut list = arc.lock();
-            list.retain(|e| {
-                if self.entry_expired(e, now) || !Self::is_entry_alive(e) {
-                    total_removed += 1;
-                    false
-                } else {
-                    true
-                }
-            });
-            if list.is_empty() && addr.starts_with("ready|") {
-                self.release_ready_target(&Self::ready_node(addr));
-            }
-            total_remaining.fetch_add(list.len() as u64, Ordering::Relaxed);
-            !list.is_empty()
-        });
-
-        let remaining = total_remaining.load(Ordering::Relaxed);
-        self.total_entries.store(remaining, Ordering::Relaxed);
+        let remaining = state.total;
+        drop(state);
+        let count = removed.len();
+        drop(removed);
         debug!(
             "Pruned {} expired pooled connections ({} remaining)",
-            total_removed, remaining
+            count, remaining
         );
-        total_removed
+        count
     }
 
     pub(crate) fn spawn_janitor(self: &Arc<Self>) -> tokio::task::JoinHandle<()> {
@@ -596,6 +603,33 @@ impl ConnectionPool {
             Err(_) => true,
         }
     }
+    #[cfg(test)]
+    pub(crate) fn check_invariants(&self) {
+        let state = self.state.lock();
+        assert!(state.total <= self.capacity_limit);
+        let mut sum = 0;
+        let mut targets = HashMap::new();
+        for (key, list) in &state.entries {
+            assert!(!list.is_empty(), "empty pool key {key}");
+            assert!(list.len() <= MAX_PER_HOST);
+            sum += list.len() as u64;
+            let ready = key.starts_with("ready|");
+            assert!(list.iter().all(|entry| Self::entry_matches(entry, ready)));
+            if ready {
+                *targets
+                    .entry(Self::ready_node(key).to_owned())
+                    .or_insert(0u32) += 1;
+            }
+        }
+        assert_eq!(state.total, sum, "pool total disagrees with entry vectors");
+        assert_eq!(state.ready_targets, targets);
+        assert!(
+            targets
+                .values()
+                .all(|count| (1..=MAX_READY_TARGETS_PER_NODE as u32).contains(count))
+        );
+        assert!(state.hot.len() <= 4096);
+    }
 }
 
 impl Default for ConnectionPool {
@@ -611,7 +645,7 @@ mod tests {
     use honk_config::types::NodeProtocol;
     use honk_outbound::proxy::TcpOutbound;
     use honk_outbound::proxy::socks5::Socks5Handler;
-    use std::sync::atomic::AtomicUsize;
+    use std::thread;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
 
@@ -640,6 +674,224 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn race_last_checkout_vs_deposit() {
+        let pool = Arc::new(ConnectionPool::new());
+        let server = spawn_hold_open_listener().await;
+        let key = server.to_string();
+
+        let first = TcpStream::connect(server).await.unwrap();
+        let first_id = first.local_addr().unwrap();
+        pool.deposit_tcp(&key, first).await;
+        pool.check_invariants();
+
+        let second = TcpStream::connect(server).await.unwrap();
+        let second_id = second.local_addr().unwrap();
+        let hook = pool.install_pause_hook("checkout_after_drop");
+
+        let checkout_pool = Arc::clone(&pool);
+        let checkout_key = key.clone();
+        let checkout = thread::spawn(move || {
+            futures::executor::block_on(checkout_pool.acquire_tcp(&checkout_key))
+        });
+        hook.reached.wait();
+
+        let deposit_pool = Arc::clone(&pool);
+        let deposit_key = key.clone();
+        let deposit = thread::spawn(move || {
+            futures::executor::block_on(deposit_pool.deposit_tcp(&deposit_key, second))
+        });
+        deposit.join().expect("deposit thread panicked");
+        hook.resume.wait();
+
+        let checked_out = checkout
+            .join()
+            .expect("checkout thread panicked")
+            .expect("initial stream must be checked out");
+        pool.check_invariants();
+        assert_eq!(
+            pool.ready_metrics().entries,
+            1,
+            "one deposited stream remains after the two operations"
+        );
+        let drained = pool
+            .acquire_tcp(&key)
+            .await
+            .expect("the deposited stream must remain reachable");
+        pool.check_invariants();
+        assert!(
+            pool.acquire_tcp(&key).await.is_none(),
+            "the drain must leave no third stream"
+        );
+
+        let mut returned = [
+            checked_out.local_addr().unwrap(),
+            drained.local_addr().unwrap(),
+        ];
+        returned.sort_unstable();
+        let mut expected = [first_id, second_id];
+        expected.sort_unstable();
+        assert_eq!(
+            returned, expected,
+            "checkout and drain must return each stream exactly once"
+        );
+        pool.check_invariants();
+    }
+
+    #[tokio::test]
+    async fn race_deposit_vs_purge() {
+        let pool = Arc::new(ConnectionPool::new());
+        let server = spawn_hold_open_listener().await;
+        let key = server.to_string();
+
+        let first = TcpStream::connect(server).await.unwrap();
+        pool.deposit_tcp(&key, first).await;
+        pool.check_invariants();
+        let second = TcpStream::connect(server).await.unwrap();
+        let second_id = second.local_addr().unwrap();
+        let hook = pool.install_pause_hook("deposit_before_lock");
+
+        let deposit_pool = Arc::clone(&pool);
+        let deposit_key = key.clone();
+        let deposit = thread::spawn(move || {
+            futures::executor::block_on(deposit_pool.deposit_tcp(&deposit_key, second))
+        });
+        hook.reached.wait();
+
+        let purge_pool = Arc::clone(&pool);
+        let purge_key = key.clone();
+        let purge = thread::spawn(move || purge_pool.purge_node(&purge_key));
+        purge.join().expect("purge thread panicked");
+        hook.resume.wait();
+        deposit.join().expect("deposit thread panicked");
+
+        pool.check_invariants();
+        let entries = pool.ready_metrics().entries;
+        match pool.acquire_tcp(&key).await {
+            Some(stream) => {
+                pool.check_invariants();
+                assert_eq!(
+                    entries, 1,
+                    "a reachable deposited stream must be reflected in total"
+                );
+                assert_eq!(stream.local_addr().unwrap(), second_id);
+                assert!(
+                    pool.acquire_tcp(&key).await.is_none(),
+                    "the stream must be consumed exactly once"
+                );
+            }
+            None => {
+                pool.check_invariants();
+                assert_eq!(entries, 0, "a purge that wins must leave no counted stream");
+                let replacement = TcpStream::connect(server).await.unwrap();
+                pool.deposit_tcp(&key, replacement).await;
+                pool.check_invariants();
+                assert!(
+                    pool.acquire_tcp(&key).await.is_some(),
+                    "a subsequent deposit must succeed after a winning purge"
+                );
+                pool.check_invariants();
+                assert!(
+                    pool.acquire_tcp(&key).await.is_none(),
+                    "the replacement must be consumed exactly once"
+                );
+            }
+        }
+        pool.check_invariants();
+    }
+
+    #[tokio::test]
+    async fn race_checkout_vs_purge() {
+        let pool = Arc::new(ConnectionPool::new());
+        let server = spawn_hold_open_listener().await;
+        let key = server.to_string();
+        let stream = TcpStream::connect(server).await.unwrap();
+        let stream_id = stream.local_addr().unwrap();
+        pool.deposit_tcp(&key, stream).await;
+        pool.check_invariants();
+
+        let hook = pool.install_pause_hook("checkout_after_clone");
+        let checkout_pool = Arc::clone(&pool);
+        let checkout_key = key.clone();
+        let checkout = thread::spawn(move || {
+            futures::executor::block_on(checkout_pool.acquire_tcp(&checkout_key))
+        });
+        hook.reached.wait();
+
+        let purge_pool = Arc::clone(&pool);
+        let purge_key = key.clone();
+        let purge = thread::spawn(move || {
+            let before = purge_pool.ready_metrics().entries;
+            purge_pool.purge_node(&purge_key);
+            before > purge_pool.ready_metrics().entries
+        });
+        let purged = purge.join().expect("purge thread panicked");
+        hook.resume.wait();
+
+        let checked_out = checkout.join().expect("checkout thread panicked");
+        assert_ne!(
+            checked_out.is_some(),
+            purged,
+            "exactly one of checkout and purge must own the stream"
+        );
+        pool.check_invariants();
+        assert_eq!(
+            pool.ready_metrics().entries,
+            0,
+            "checkout and purge must account for the stream exactly once"
+        );
+        if let Some(stream) = checked_out {
+            assert_eq!(
+                stream.local_addr().unwrap(),
+                stream_id,
+                "a successful checkout must return the original stream"
+            );
+        }
+        assert!(
+            pool.acquire_tcp(&key).await.is_none(),
+            "the stream must not remain reachable after checkout or purge"
+        );
+        pool.check_invariants();
+    }
+
+    #[tokio::test]
+    async fn race_janitor_vs_deposit() {
+        let pool = Arc::new(ConnectionPool::new());
+        let server = spawn_hold_open_listener().await;
+        let key = server.to_string();
+        pool.check_invariants();
+        let hook = pool.install_pause_hook("janitor_before_store");
+
+        let janitor_pool = Arc::clone(&pool);
+        let janitor =
+            thread::spawn(move || futures::executor::block_on(janitor_pool.prune_expired()));
+        hook.reached.wait();
+
+        let stream = TcpStream::connect(server).await.unwrap();
+        let deposit_pool = Arc::clone(&pool);
+        let deposit_key = key.clone();
+        let deposit = thread::spawn(move || {
+            futures::executor::block_on(deposit_pool.deposit_tcp(&deposit_key, stream))
+        });
+        deposit.join().expect("deposit thread panicked");
+        hook.resume.wait();
+        janitor.join().expect("janitor thread panicked");
+
+        assert_eq!(
+            pool.ready_metrics().entries,
+            1,
+            "janitor must publish the competitor's deposited stream"
+        );
+        pool.check_invariants();
+        pool.purge_node(&key);
+        assert_eq!(
+            pool.ready_metrics().entries,
+            0,
+            "purging the only stream must restore an empty total"
+        );
+        pool.check_invariants();
+    }
+
+    #[tokio::test]
     async fn test_pool_acquire_deposit() {
         let pool = ConnectionPool::new();
         let addr = spawn_hold_open_listener().await.to_string();
@@ -662,43 +914,53 @@ mod tests {
         let first = TcpStream::connect(&addr).await.unwrap();
         pool.deposit_tcp(&addr, first).await;
         assert!(pool.has_live_bare_entry(&addr));
-        assert_eq!(pool.total_entries.load(Ordering::Relaxed), 1);
+        assert_eq!(pool.ready_metrics().entries, 1);
+        pool.check_invariants();
 
         tokio::time::sleep(Duration::from_millis(30)).await;
         assert!(!pool.has_live_bare_entry(&addr));
-        assert_eq!(pool.total_entries.load(Ordering::Relaxed), 0);
+        assert_eq!(pool.ready_metrics().entries, 0);
+        pool.check_invariants();
 
         let replacement = TcpStream::connect(&addr).await.unwrap();
         pool.deposit_tcp(&addr, replacement).await;
         assert!(pool.has_live_bare_entry(&addr));
-        assert_eq!(pool.total_entries.load(Ordering::Relaxed), 1);
+        assert_eq!(pool.ready_metrics().entries, 1);
+        pool.check_invariants();
     }
 
-    /// Phase 5: deposits past the global FD budget are refused.
     #[tokio::test]
     async fn test_pool_global_cap_refused() {
-        let pool = ConnectionPool::new();
+        let pool = ConnectionPool::with_capacity_limit(1);
         let addr = spawn_hold_open_listener().await.to_string();
-        pool.total_entries
-            .store(MAX_TOTAL_ENTRIES as u64, Ordering::Relaxed);
         pool.deposit_tcp(&addr, TcpStream::connect(&addr).await.unwrap())
             .await;
-        assert!(pool.acquire_tcp(&addr).await.is_none());
-        assert_eq!(
-            pool.total_entries.load(Ordering::Relaxed),
-            MAX_TOTAL_ENTRIES as u64,
-            "a refused deposit must not bump the counter"
-        );
+        pool.check_invariants();
+        pool.deposit_tcp("other:443", TcpStream::connect(&addr).await.unwrap())
+            .await;
+        pool.check_invariants();
+        assert!(pool.acquire_tcp("other:443").await.is_none());
+        pool.check_invariants();
+        assert!(pool.acquire_tcp(&addr).await.is_some());
+        pool.check_invariants();
     }
 
-    #[test]
-    fn explicit_pool_capacity_is_enforced() {
+    #[tokio::test]
+    async fn explicit_pool_capacity_is_enforced() {
         let pool = ConnectionPool::with_capacity_limit(3);
-        assert!(pool.reserve_total());
-        assert!(pool.reserve_total());
-        assert!(pool.reserve_total());
-        assert!(!pool.reserve_total());
-        assert_eq!(pool.total_entries.load(Ordering::Acquire), 3);
+        let addr = spawn_hold_open_listener().await.to_string();
+        for _ in 0..4 {
+            pool.deposit_tcp(&addr, TcpStream::connect(&addr).await.unwrap())
+                .await;
+            pool.check_invariants();
+        }
+        assert_eq!(pool.ready_metrics().entries, 3);
+        for _ in 0..3 {
+            assert!(pool.acquire_tcp(&addr).await.is_some());
+            pool.check_invariants();
+        }
+        assert!(pool.acquire_tcp(&addr).await.is_none());
+        pool.check_invariants();
     }
 
     /// Phase 5: hot-target gating — the first flow is cold, the second
@@ -1052,61 +1314,51 @@ mod tests {
                     .await;
             });
         }
-        while tasks.join_next().await.is_some() {}
+        while let Some(result) = tasks.join_next().await {
+            result.unwrap();
+            pool.check_invariants();
+        }
         assert_eq!(
-            pool.ready_targets
-                .get("node:443")
-                .map(|count| count.load(Ordering::Acquire)),
-            Some(MAX_READY_TARGETS_PER_NODE as u64),
-            "parallel distinct deposits must never exceed the ready-target cap"
-        );
-        assert_eq!(
-            pool.total_entries.load(Ordering::Acquire),
+            pool.ready_metrics().entries,
             MAX_READY_TARGETS_PER_NODE as u64
         );
+        pool.purge_node("node:443");
+        pool.check_invariants();
+        assert_eq!(pool.ready_metrics().entries, 0);
+        let key = "ready|node:443|198.51.100.1:443";
+        let tcp = TcpStream::connect(server).await.unwrap();
+        pool.deposit_ready(key, make_ready_stream(tcp, target))
+            .await;
+        pool.check_invariants();
+        assert!(pool.acquire_ready(key).await.is_some());
+        pool.check_invariants();
     }
 
-    #[test]
-    fn stale_ready_target_release_does_not_poison_counter() {
-        let pool = ConnectionPool::new();
-        let node = "node:443";
-
-        assert!(pool.reserve_ready_target(node));
-        pool.release_ready_target(node);
-        // A concurrent miss may finish after the checkout that removed the key.
-        pool.release_ready_target(node);
-
-        assert!(pool.reserve_ready_target(node));
-        assert_eq!(
-            pool.ready_targets
-                .get(node)
-                .map(|count| count.load(Ordering::Acquire)),
-            Some(1)
-        );
-    }
-
-    #[tokio::test]
-    async fn test_total_cap_cas_never_overshoots_under_parallel_reservations() {
-        let pool = Arc::new(ConnectionPool::new());
-        pool.total_entries
-            .store(MAX_TOTAL_ENTRIES as u64 - 4, Ordering::Release);
-        let accepted = Arc::new(AtomicUsize::new(0));
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_total_cap_never_overshoots_under_parallel_deposits() {
+        let pool = Arc::new(ConnectionPool::with_capacity_limit(4));
+        let server = spawn_hold_open_listener().await;
         let mut tasks = tokio::task::JoinSet::new();
-        for _ in 0..32 {
+        for i in 0..32 {
             let pool = Arc::clone(&pool);
-            let accepted = Arc::clone(&accepted);
             tasks.spawn(async move {
-                if pool.reserve_total() {
-                    accepted.fetch_add(1, Ordering::AcqRel);
-                }
+                let stream = TcpStream::connect(server).await.unwrap();
+                pool.deposit_tcp(&format!("node-{i}:443"), stream).await;
+                pool.check_invariants();
             });
         }
-        while tasks.join_next().await.is_some() {}
-        assert_eq!(accepted.load(Ordering::Acquire), 4);
-        assert_eq!(
-            pool.total_entries.load(Ordering::Acquire),
-            MAX_TOTAL_ENTRIES as u64
-        );
+        while let Some(result) = tasks.join_next().await {
+            result.unwrap();
+            pool.check_invariants();
+        }
+        assert_eq!(pool.ready_metrics().entries, 4);
+        let mut acquired = 0;
+        for i in 0..32 {
+            acquired += usize::from(pool.acquire_tcp(&format!("node-{i}:443")).await.is_some());
+            pool.check_invariants();
+        }
+        assert_eq!(acquired, 4);
+        assert_eq!(pool.ready_metrics().entries, 0);
     }
 
     #[test]
@@ -1128,11 +1380,16 @@ mod tests {
     #[test]
     fn test_hot_map_refuses_new_keys_at_bound_without_scan() {
         let pool = ConnectionPool::new();
-        pool.hot_entries.store(4096, Ordering::Release);
-        assert!(!pool.note_target("ready|node:443|new:443"));
-        assert!(
-            pool.hot.is_empty(),
-            "a full hot map must not insert or scan"
-        );
+        for i in 0..4096 {
+            assert!(!pool.note_target(&format!("ready|node:443|target-{i}:443")));
+            pool.check_invariants();
+        }
+        let new_key = "ready|node:443|new:443";
+        assert!(!pool.note_target(new_key));
+        pool.check_invariants();
+        assert!(!pool.note_target(new_key));
+        pool.check_invariants();
+        assert!(pool.note_target("ready|node:443|target-0:443"));
+        pool.check_invariants();
     }
 }

--- a/crates/honk-core/src/pool.rs
+++ b/crates/honk-core/src/pool.rs
@@ -12,28 +12,33 @@
 //!   server-side state than a bare TCP connection and servers reap idle
 //!   tunnels sooner.
 //!
-//! Ready keys are namespaced (`ready|<node_addr>|<target>`) so they can
-//! never collide with bare `"host:port"` keys (`|` cannot appear in a
-//! host:port pair). The key binds BOTH the proxy node and the target
-//! because the completed handshake already committed the stream to that
-//! exact pair — lookup by the same pair is the only correct reuse.
+//! Ready keys are namespaced (`ready|<generation>|<node-id>|<target>`) so they
+//! can never collide with bare `"host:port"` keys (`|` cannot appear in a
+//! host:port pair). The key binds the proxy generation and node identity as
+//! well as the target because the completed handshake committed the stream
+//! to that exact credential/configuration.
 //!
 //! Budgets beyond the per-key cap: an explicit global FD capacity (bounded by
-//! [`MAX_TOTAL_ENTRIES`]), a per-node ready-target cardinality cap
-//! ([`MAX_READY_TARGETS_PER_NODE`]), and hot-target gating
+//! [`MAX_TOTAL_ENTRIES`]), a per-identity-per-generation ready-target
+//! cardinality cap ([`MAX_READY_TARGETS_PER_NODE`]), and hot-target gating
 //! ([`ConnectionPool::note_target`]) so only repeat destinations earn a
 //! speculative ready deposit. Deposits are also capability-checked at the
-//! call site (multiplexed handlers never deposit ready entries — their
-//! session pool already owns reuse). Hit/miss/entry counters feed the
-//! clash API `/stats`.
+//! call site (multiplexed handlers never deposit ready entries — their session
+//! pool already owns reuse). Hit/miss/entry counters feed the clash API
+//! `/stats`.
 //!
 //! One mutex keeps the stream total equal to the sum of non-empty entry
 //! vectors and ready-target counts equal to the present ready keys. Entry,
 //! target, warm-claim and hotness changes are synchronous transactions; the
 //! lock is never held across an await. Removed streams are dropped after
 //! unlocking, so socket teardown cannot extend the critical section.
-//! Hotness is bounded to 4,096 keys; warm claims remain one per in-flight
-//! dial, without a separate cardinality cap.
+//! Retiring a generation removes its ready namespace, target budget, warm
+//! claims and hotness under that same lock; the successor starts empty and
+//! late writes for the retired generation are refused. The retired-generation
+//! set grows by one entry per retired generation and is never reclaimed.
+//! Hotness is bounded to 4,096 keys; saturation within one live generation is
+//! unchanged, and warm claims remain one per in-flight dial without a separate
+//! cardinality cap.
 
 use parking_lot::Mutex;
 use std::collections::{HashMap, HashSet};
@@ -46,6 +51,7 @@ use std::sync::{Barrier, Mutex as StdMutex};
 use std::time::{Duration, Instant};
 use tokio::net::TcpStream;
 use tracing::{debug, trace};
+use uuid::Uuid;
 
 use honk_outbound::proxy::ProxyStream;
 
@@ -53,13 +59,13 @@ const MAX_PER_HOST: usize = 8;
 /// Global cap across all keys (bare + ready) — an FD budget, not just a
 /// per-key one: deposits past it are refused.
 pub(crate) const MAX_TOTAL_ENTRIES: usize = 2048;
-/// Distinct ready targets per node — bounds target-cardinality-driven
-/// ready pools (a scanner hitting thousands of hosts must not turn the
-/// pool into thousands of dialed tunnels).
+/// Distinct ready targets per node identity and runtime generation — bounds
+/// target-cardinality-driven ready pools (a scanner hitting thousands of
+/// targets must not turn the pool into thousands of dialed tunnels).
 const MAX_READY_TARGETS_PER_NODE: usize = 64;
 /// Ready deposits are made only for "hot" targets: at least this many
-/// flows to the same (node, target) within [`HOT_WINDOW`]. A one-off
-/// flow never triggers a speculative ready dial.
+/// flows to the same (generation, node, target) within [`HOT_WINDOW`]. A one-off flow
+/// never triggers a speculative ready dial.
 const HOT_THRESHOLD: u32 = 2;
 const HOT_WINDOW: Duration = Duration::from_secs(60);
 const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
@@ -122,6 +128,7 @@ struct PoolState {
     ready_targets: HashMap<String, u32>,
     warm_dials: HashSet<String>,
     hot: HashMap<String, (u32, Instant)>,
+    retired: HashSet<u64>,
 }
 
 impl PoolState {
@@ -239,12 +246,16 @@ impl ConnectionPool {
         }
     }
 
-    /// Record one flow to `key` (a `ready|…` key) and report whether the
-    /// target is hot enough to justify a speculative ready deposit
-    /// ([`HOT_THRESHOLD`] flows within [`HOT_WINDOW`]).
-    pub(crate) fn note_target(&self, key: &str) -> bool {
+    /// Record one flow to `key` (a `ready|…` key) for `generation` and report
+    /// whether the target is hot enough to justify a speculative ready deposit
+    /// ([`HOT_THRESHOLD`] flows within [`HOT_WINDOW`]). Retired generations
+    /// cannot acquire new hotness.
+    pub(crate) fn note_target(&self, generation: u64, key: &str) -> bool {
         const MAX_HOT_TARGETS: u64 = 4096;
         let mut state = self.state.lock();
+        if state.retired.contains(&generation) {
+            return false;
+        }
         if let Some(value) = state.hot.get_mut(key) {
             if value.1.elapsed() > HOT_WINDOW {
                 *value = (0, Instant::now());
@@ -261,9 +272,9 @@ impl ConnectionPool {
 
     /// Claim one background warming dial for this ready key. The returned
     /// guard clears the claim on drop, including cancellation and failures.
-    pub(crate) fn try_begin_warm(&self, key: &str) -> Option<WarmDialGuard<'_>> {
+    pub(crate) fn try_begin_warm(&self, generation: u64, key: &str) -> Option<WarmDialGuard<'_>> {
         let mut state = self.state.lock();
-        if state.warm_dials.contains(key) {
+        if state.retired.contains(&generation) || state.warm_dials.contains(key) {
             return None;
         }
         state.warm_dials.insert(key.to_owned());
@@ -288,18 +299,19 @@ impl ConnectionPool {
         self.ready_idle_timeout = timeout;
     }
 
-    /// Pool key for a Ready entry. The completed handshake bound the
-    /// stream to (proxy node, target), so the key contains both; with
-    /// domain routing the CONNECT request carries the domain, making
-    /// `domain:port` — not the resolved IP — the destination identity.
+    /// Pool key for a Ready entry. The completed handshake binds the stream
+    /// to (generation, node identity, target); with domain routing the CONNECT
+    /// request carries the domain, making `domain:port` — not the resolved IP
+    /// — the destination identity.
     pub(crate) fn ready_key(
-        node_addr: &str,
+        generation: u64,
+        node_id: Uuid,
         target: SocketAddr,
         target_domain: Option<&str>,
     ) -> String {
         match target_domain {
-            Some(domain) => format!("ready|{}|{}:{}", node_addr, domain, target.port()),
-            None => format!("ready|{}|{}", node_addr, target),
+            Some(domain) => format!("ready|{generation}|{node_id}|{domain}:{}", target.port()),
+            None => format!("ready|{generation}|{node_id}|{target}"),
         }
     }
 
@@ -365,7 +377,8 @@ impl ConnectionPool {
     }
 
     pub(crate) async fn deposit_tcp(&self, addr: &str, stream: TcpStream) {
-        self.deposit_entry(addr, PooledStream::Bare(stream)).await;
+        self.deposit_entry(addr, PooledStream::Bare(stream), None)
+            .await;
     }
 
     /// Whether a live, unexpired bare-TCP entry exists for `addr`
@@ -397,24 +410,37 @@ impl ConnectionPool {
     /// The stream must come straight out of `TcpOutbound::dial()` with no
     /// application reads performed, so its userspace TLS buffer (if any)
     /// is empty and the fd-level liveness probe stays accurate.
-    pub(crate) async fn deposit_ready(&self, key: &str, stream: ProxyStream) {
-        self.deposit_entry(key, PooledStream::Ready(stream)).await;
+    pub(crate) async fn deposit_ready(&self, generation: u64, key: &str, stream: ProxyStream) {
+        self.deposit_entry(key, PooledStream::Ready(stream), Some(generation))
+            .await;
     }
 
-    async fn deposit_entry(&self, addr: &str, stream: PooledStream) {
+    async fn deposit_entry(&self, addr: &str, stream: PooledStream, generation: Option<u64>) {
         #[cfg(test)]
         self.pause_at("deposit_before_lock");
         let mut state = self.state.lock();
+        if let Some(generation) = generation
+            && state.retired.contains(&generation)
+        {
+            debug!(
+                "Pool generation {} retired; dropping ready deposit for {}",
+                generation, addr
+            );
+            drop(state);
+            return;
+        }
         if state.total >= self.capacity_limit {
             debug!(
                 "Pool global cap reached ({}); dropping deposit for {}",
                 self.capacity_limit, addr
             );
+            drop(state);
             return;
         }
-        let list = state.entries.get_mut(addr);
-        if list.as_ref().is_some_and(|list| list.len() >= MAX_PER_HOST) {
+        let list = state.entries.get(addr);
+        if list.is_some_and(|list| list.len() >= MAX_PER_HOST) {
             debug!("Pool cap reached for {} (max={})", addr, MAX_PER_HOST);
+            drop(state);
             return;
         }
         if list.is_none() && matches!(stream, PooledStream::Ready(_)) {
@@ -425,6 +451,7 @@ impl ConnectionPool {
                     "Ready target cardinality cap reached for {} (max={}); dropping deposit",
                     node, MAX_READY_TARGETS_PER_NODE
                 );
+                drop(state);
                 return;
             }
             state.ready_targets.insert(node.to_owned(), count + 1);
@@ -444,10 +471,20 @@ impl ConnectionPool {
         debug!("Pool deposit: {} ({} total pooled)", addr, state.total);
     }
 
+    #[cfg(test)]
+    fn ready_generation(key: &str) -> Option<u64> {
+        key.strip_prefix("ready|")?.split_once('|')?.0.parse().ok()
+    }
+
     fn ready_node(key: &str) -> &str {
-        key.strip_prefix("ready|")
-            .and_then(|rest| rest.split_once('|').map(|(node, _)| node))
-            .unwrap_or_default()
+        let after = key.strip_prefix("ready|").unwrap_or_default();
+        let Some((generation, after_node)) = after.split_once('|') else {
+            return "";
+        };
+        let Some((node_id, _target)) = after_node.split_once('|') else {
+            return "";
+        };
+        &after[..generation.len() + 1 + node_id.len()]
     }
 
     /// Drop only the bare preconnect for a node. Ready streams may belong to
@@ -467,13 +504,11 @@ impl ConnectionPool {
         drop(removed);
     }
 
-    /// Drop every pooled connection tied to a proxy node: the bare
-    /// `"host:port"` key plus all `ready|<node_addr>|…` entries. Called
-    /// when the node flips alive→dead — a pooled-but-doomed stream must
-    /// never be handed out (idle/max-age expiry would otherwise keep
-    /// serving it for up to 60s).
-    pub(crate) fn purge_node(&self, node_addr: &str) {
-        let ready_prefix = format!("ready|{}|", node_addr);
+    /// Drop every pooled connection tied to a proxy node identity in one
+    /// generation: the bare `"host:port"` key plus that identity's ready
+    /// entries. Called when the node flips alive→dead.
+    pub(crate) fn purge_node(&self, node_addr: &str, generation: u64, node_id: Uuid) {
+        let ready_prefix = format!("ready|{generation}|{node_id}|");
         let mut removed = Vec::new();
         let mut state = self.state.lock();
         state.remove_matching(
@@ -485,6 +520,26 @@ impl ConnectionPool {
             "Purged {} pooled connections for dead node {}",
             removed.len(),
             node_addr
+        );
+        drop(removed);
+    }
+
+    /// Retire all ready-pool state for a generation. Ready streams are
+    /// collected and destroyed after releasing the state lock.
+    pub(crate) fn retire_generation(&self, generation: u64) {
+        let ready_prefix = format!("ready|{generation}|");
+        let mut removed = Vec::new();
+        let mut state = self.state.lock();
+        state.retired.insert(generation);
+        state.remove_matching(|key| key.starts_with(&ready_prefix), &mut removed);
+        state
+            .warm_dials
+            .retain(|key| !key.starts_with(&ready_prefix));
+        state.hot.retain(|key, _| !key.starts_with(&ready_prefix));
+        drop(state);
+        debug!(
+            "Retired generation {generation}, dropping {} ready connections",
+            removed.len()
         );
         drop(removed);
     }
@@ -616,6 +671,12 @@ impl ConnectionPool {
             let ready = key.starts_with("ready|");
             assert!(list.iter().all(|entry| Self::entry_matches(entry, ready)));
             if ready {
+                let generation =
+                    Self::ready_generation(key).expect("ready entry key has a generation");
+                assert!(
+                    !state.retired.contains(&generation),
+                    "retired generation has ready entry: {key}"
+                );
                 *targets
                     .entry(Self::ready_node(key).to_owned())
                     .or_insert(0u32) += 1;
@@ -629,6 +690,14 @@ impl ConnectionPool {
                 .all(|count| (1..=MAX_READY_TARGETS_PER_NODE as u32).contains(count))
         );
         assert!(state.hot.len() <= 4096);
+        for key in state.warm_dials.iter().chain(state.hot.keys()) {
+            if let Some(generation) = Self::ready_generation(key) {
+                assert!(
+                    !state.retired.contains(&generation),
+                    "retired generation has auxiliary state: {key}"
+                );
+            }
+        }
     }
 }
 
@@ -642,7 +711,6 @@ impl Default for ConnectionPool {
 mod tests {
     use super::*;
     use honk_config::node::Node;
-    use honk_config::types::NodeProtocol;
     use honk_outbound::proxy::TcpOutbound;
     use honk_outbound::proxy::socks5::Socks5Handler;
     use std::thread;
@@ -759,7 +827,7 @@ mod tests {
 
         let purge_pool = Arc::clone(&pool);
         let purge_key = key.clone();
-        let purge = thread::spawn(move || purge_pool.purge_node(&purge_key));
+        let purge = thread::spawn(move || purge_pool.purge_node(&purge_key, 1, Uuid::nil()));
         purge.join().expect("purge thread panicked");
         hook.resume.wait();
         deposit.join().expect("deposit thread panicked");
@@ -821,7 +889,7 @@ mod tests {
         let purge_key = key.clone();
         let purge = thread::spawn(move || {
             let before = purge_pool.ready_metrics().entries;
-            purge_pool.purge_node(&purge_key);
+            purge_pool.purge_node(&purge_key, 1, Uuid::nil());
             before > purge_pool.ready_metrics().entries
         });
         let purged = purge.join().expect("purge thread panicked");
@@ -882,7 +950,7 @@ mod tests {
             "janitor must publish the competitor's deposited stream"
         );
         pool.check_invariants();
-        pool.purge_node(&key);
+        pool.purge_node(&key, 1, Uuid::nil());
         assert_eq!(
             pool.ready_metrics().entries,
             0,
@@ -968,11 +1036,19 @@ mod tests {
     #[tokio::test]
     async fn test_note_target_hot_gating() {
         let pool = ConnectionPool::new();
-        let key = "ready|node:443|1.2.3.4:443";
-        assert!(!pool.note_target(key), "first flow is cold");
-        assert!(pool.note_target(key), "second flow within window is hot");
-        assert!(pool.note_target(key), "stays hot");
-        assert!(!pool.note_target("ready|node:443|5.6.7.8:443"));
+        let generation = 1;
+        let node_id = Uuid::from_u128(1);
+        let key =
+            ConnectionPool::ready_key(generation, node_id, "1.2.3.4:443".parse().unwrap(), None);
+        assert!(!pool.note_target(generation, &key), "first flow is cold");
+        assert!(
+            pool.note_target(generation, &key),
+            "second flow within window is hot"
+        );
+        assert!(pool.note_target(generation, &key), "stays hot");
+        let other =
+            ConnectionPool::ready_key(generation, node_id, "5.6.7.8:443".parse().unwrap(), None);
+        assert!(!pool.note_target(generation, &other));
     }
 
     /// Phase 5: ready deposits stop at the per-node target cardinality.
@@ -981,18 +1057,23 @@ mod tests {
         let pool = ConnectionPool::new();
         let addr = spawn_hold_open_listener().await;
         let target = addr;
+        let generation = 1;
+        let node_id = Uuid::from_u128(1);
         for i in 0..MAX_READY_TARGETS_PER_NODE {
-            let key = format!("ready|node:443|10.0.0.{}:443", i + 1);
+            let key_target =
+                SocketAddr::new(std::net::Ipv4Addr::new(10, 0, 0, i as u8 + 1).into(), 443);
+            let key = ConnectionPool::ready_key(generation, node_id, key_target, None);
             let tcp = TcpStream::connect(addr).await.unwrap();
-            pool.deposit_ready(&key, make_ready_stream(tcp, target))
+            pool.deposit_ready(generation, &key, make_ready_stream(tcp, target))
                 .await;
         }
-        // One more distinct target for the same node: refused.
-        let key = "ready|node:443|10.9.9.9:443";
+        // One more distinct target for the same identity: refused.
+        let key_target = SocketAddr::new(std::net::Ipv4Addr::new(10, 9, 9, 9).into(), 443);
+        let key = ConnectionPool::ready_key(generation, node_id, key_target, None);
         let tcp = TcpStream::connect(addr).await.unwrap();
-        pool.deposit_ready(key, make_ready_stream(tcp, target))
+        pool.deposit_ready(generation, &key, make_ready_stream(tcp, target))
             .await;
-        assert!(pool.acquire_ready(key).await.is_none());
+        assert!(pool.acquire_ready(&key).await.is_none());
         // The ready metrics reflect one hit attempt (the refused acquire).
         let m = pool.ready_metrics();
         assert_eq!(m.misses, 1);
@@ -1021,12 +1102,14 @@ mod tests {
         let pool = ConnectionPool::new();
         let server_addr = spawn_hold_open_listener().await;
         let target: SocketAddr = "93.184.216.34:443".parse().unwrap();
-        let key = ConnectionPool::ready_key("proxy.example:1080", target, None);
+        let generation = 1;
+        let node_id = Uuid::from_u128(1);
+        let key = ConnectionPool::ready_key(generation, node_id, target, None);
 
         assert!(pool.acquire_ready(&key).await.is_none());
 
         let tcp = TcpStream::connect(server_addr).await.unwrap();
-        pool.deposit_ready(&key, make_ready_stream(tcp, target))
+        pool.deposit_ready(generation, &key, make_ready_stream(tcp, target))
             .await;
 
         let ready = pool.acquire_ready(&key).await.expect("ready entry");
@@ -1035,15 +1118,17 @@ mod tests {
         assert!(pool.acquire_ready(&key).await.is_none());
         drop(ready);
     }
-
     #[tokio::test]
     async fn test_pool_ready_key_namespacing() {
-        // Ready keys live in a namespace disjoint from bare "host:port"
-        // keys, and bind both node and target (domain-aware).
+        // Ready keys are disjoint from bare keys and bind generation,
+        // identity, target, and optional domain.
         let target: SocketAddr = "93.184.216.34:443".parse().unwrap();
-        let k1 = ConnectionPool::ready_key("proxy.example:1080", target, None);
-        let k2 = ConnectionPool::ready_key("proxy.example:1080", target, Some("example.com"));
-        let k3 = ConnectionPool::ready_key("other.example:1080", target, None);
+        let generation = 1;
+        let node_id = Uuid::from_u128(1);
+        let other_node_id = Uuid::from_u128(2);
+        let k1 = ConnectionPool::ready_key(generation, node_id, target, None);
+        let k2 = ConnectionPool::ready_key(generation, node_id, target, Some("example.com"));
+        let k3 = ConnectionPool::ready_key(generation, other_node_id, target, None);
         assert_ne!(k1, k2);
         assert_ne!(k1, k3);
         assert_ne!(k1, "proxy.example:1080");
@@ -1058,9 +1143,11 @@ mod tests {
         let target: SocketAddr = "93.184.216.34:443".parse().unwrap();
 
         // Ready entry expires after the short TTL.
-        let key = ConnectionPool::ready_key("proxy.example:1080", target, None);
+        let generation = 1;
+        let node_id = Uuid::from_u128(1);
+        let key = ConnectionPool::ready_key(generation, node_id, target, None);
         let tcp = TcpStream::connect(server_addr).await.unwrap();
-        pool.deposit_ready(&key, make_ready_stream(tcp, target))
+        pool.deposit_ready(generation, &key, make_ready_stream(tcp, target))
             .await;
         tokio::time::sleep(Duration::from_millis(100)).await;
         assert!(pool.acquire_ready(&key).await.is_none());
@@ -1099,8 +1186,8 @@ mod tests {
         assert!(saw_fin, "MSG_PEEK never observed the peer FIN");
 
         // A dead ready entry must not be handed out.
-        let key = ConnectionPool::ready_key("proxy.example:1080", target, None);
-        pool.deposit_ready(&key, stream).await;
+        let key = ConnectionPool::ready_key(1, Uuid::from_u128(1), target, None);
+        pool.deposit_ready(1, &key, stream).await;
         assert!(pool.acquire_ready(&key).await.is_none());
     }
 
@@ -1129,112 +1216,36 @@ mod tests {
         assert!(pool.acquire_tcp("proxy.example:1080").await.is_none());
     }
 
-    /// End-to-end: a SOCKS5 stream pooled after a full dial is reused
-    /// without repeating the greeting/CONNECT handshake.
+    /// End-to-end: an authenticated SOCKS5 stream pooled after a full dial is
+    /// reused without repeating the greeting/CONNECT handshake.
     #[tokio::test]
     async fn test_socks5_ready_reuse_skips_handshake() {
-        // Mock SOCKS5 server: counts TCP connections; per connection it
-        // answers greeting + CONNECT, then requires the next 4 bytes to be
-        // exactly b"PING" (any re-handshake would fail this) before
-        // replying b"PONG".
-        let conn_count = Arc::new(AtomicU64::new(0));
-        let payload_ok = Arc::new(AtomicU64::new(0));
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let server_addr = listener.local_addr().unwrap();
-        {
-            let conn_count = Arc::clone(&conn_count);
-            let payload_ok = Arc::clone(&payload_ok);
-            tokio::spawn(async move {
-                loop {
-                    let (mut s, _) = match listener.accept().await {
-                        Ok(v) => v,
-                        Err(_) => break,
-                    };
-                    conn_count.fetch_add(1, Ordering::Relaxed);
-                    let payload_ok = Arc::clone(&payload_ok);
-                    tokio::spawn(async move {
-                        // Greeting: VER NMETHODS METHODS...
-                        let mut hdr = [0u8; 2];
-                        s.read_exact(&mut hdr).await.unwrap();
-                        assert_eq!(hdr[0], 0x05);
-                        let mut methods = vec![0u8; hdr[1] as usize];
-                        s.read_exact(&mut methods).await.unwrap();
-                        s.write_all(&[0x05, 0x00]).await.unwrap();
-                        // Request: VER CMD RSV ATYP ... ADDR PORT
-                        let mut req = [0u8; 4];
-                        s.read_exact(&mut req).await.unwrap();
-                        assert_eq!(req[0], 0x05);
-                        assert_eq!(req[1], 0x01); // CONNECT
-                        let skip = match req[3] {
-                            0x01 => 4 + 2,
-                            0x04 => 16 + 2,
-                            0x03 => {
-                                let mut l = [0u8; 1];
-                                s.read_exact(&mut l).await.unwrap();
-                                l[0] as usize + 2
-                            }
-                            a => panic!("bad ATYP {a}"),
-                        };
-                        let mut rest = vec![0u8; skip];
-                        s.read_exact(&mut rest).await.unwrap();
-                        // Success reply: VER REP RSV ATYP=IPv4 0.0.0.0:0
-                        s.write_all(&[0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0])
-                            .await
-                            .unwrap();
-                        // Data phase: the next bytes must be the payload
-                        // itself, not a repeated greeting.
-                        let mut data = [0u8; 4];
-                        match s.read_exact(&mut data).await {
-                            Ok(_) if &data == b"PING" => {
-                                payload_ok.fetch_add(1, Ordering::Relaxed);
-                                s.write_all(b"PONG").await.unwrap();
-                            }
-                            _ => return, // wrong bytes: close, client assert fails
-                        }
-                        // Hold the tunnel open until the client hangs up.
-                        let mut sink = [0u8; 64];
-                        let _ = s.read(&mut sink).await;
-                    });
-                }
-            });
-        }
-
-        let node = Node {
-            name: "test".into(),
-            outbound: honk_config::node::OutboundConfig::from_protocol(NodeProtocol::Socks5),
-            address: server_addr.ip().to_string(),
-            host: String::new(),
-            port: server_addr.port(),
-            ..Default::default()
-        };
+        let fixture = ReadyIdentitySocks5Fixture::bind().await;
+        let node = ready_identity_socks5_node(fixture.addr(), "a", "a", "reuse");
         let handler = Socks5Handler::new();
-        assert!((honk_outbound::descriptor::descriptor(
-            NodeProtocol::Socks5
-        )
-        .pool_ready_streams)(&node));
         let target: SocketAddr = "93.184.216.34:80".parse().unwrap();
 
-        // Full dial (TCP + greeting + CONNECT), then pool the result.
         let stream = handler
             .dial(&node, target, None, Duration::from_secs(3))
             .await
             .unwrap();
         let pool = ConnectionPool::new();
-        let node_addr = format!("{}:{}", node.host(), node.port);
-        let key = ConnectionPool::ready_key(&node_addr, target, None);
-        pool.deposit_ready(&key, stream).await;
+        let generation = 1;
+        let key = ConnectionPool::ready_key(generation, node.id, target, None);
+        pool.deposit_ready(generation, &key, stream).await;
 
-        // Checkout: payload goes straight through, no handshake bytes.
+        // Raw application bytes on checkout must receive the authenticated
+        // fixture response, not a second SOCKS5 handshake.
         let mut reused = pool.acquire_ready(&key).await.expect("ready stream");
         reused.stream.write_all(b"PING").await.unwrap();
-        let mut buf = [0u8; 4];
-        reused.stream.read_exact(&mut buf).await.unwrap();
-        assert_eq!(&buf, b"PONG");
-
-        // Exactly one TCP connection total, and its data phase saw the raw
-        // payload — proving no greeting/CONNECT was sent on reuse.
-        assert_eq!(conn_count.load(Ordering::Relaxed), 1);
-        assert_eq!(payload_ok.load(Ordering::Relaxed), 1);
+        let mut reply = [0u8; 3];
+        tokio::time::timeout(Duration::from_secs(3), reused.stream.read_exact(&mut reply))
+            .await
+            .expect("SOCKS5 consumer reply timed out")
+            .unwrap();
+        assert_eq!(&reply, b"a:a");
+        assert_eq!(fixture.observed_auths().await.len(), 1);
+        pool.check_invariants();
     }
 
     /// A dead node's bare AND ready entries must all be purged; other
@@ -1245,30 +1256,27 @@ mod tests {
         let server = spawn_hold_open_listener().await;
         let dead_addr = "dead.example:1080";
         let other_addr = "other.example:1080";
+        let dead_id = Uuid::from_u128(1);
+        let other_id = Uuid::from_u128(2);
+        let generation = 1;
         let target: SocketAddr = "93.184.216.34:443".parse().unwrap();
 
-        for addr in [dead_addr, other_addr] {
+        for (addr, node_id) in [(dead_addr, dead_id), (other_addr, other_id)] {
             let tcp = TcpStream::connect(server).await.unwrap();
             pool.deposit_tcp(addr, tcp).await;
-            let key = ConnectionPool::ready_key(addr, target, None);
+            let key = ConnectionPool::ready_key(generation, node_id, target, None);
             let tcp = TcpStream::connect(server).await.unwrap();
-            pool.deposit_ready(&key, make_ready_stream(tcp, target))
+            pool.deposit_ready(generation, &key, make_ready_stream(tcp, target))
                 .await;
         }
-        pool.purge_node(dead_addr);
+        pool.purge_node(dead_addr, generation, dead_id);
         assert!(pool.acquire_tcp(dead_addr).await.is_none());
-        assert!(
-            pool.acquire_ready(&ConnectionPool::ready_key(dead_addr, target, None))
-                .await
-                .is_none()
-        );
+        let dead_key = ConnectionPool::ready_key(generation, dead_id, target, None);
+        assert!(pool.acquire_ready(&dead_key).await.is_none());
         // Other node untouched.
         assert!(pool.acquire_tcp(other_addr).await.is_some());
-        assert!(
-            pool.acquire_ready(&ConnectionPool::ready_key(other_addr, target, None))
-                .await
-                .is_some()
-        );
+        let other_key = ConnectionPool::ready_key(generation, other_id, target, None);
+        assert!(pool.acquire_ready(&other_key).await.is_some());
     }
     #[tokio::test]
     async fn test_dial_permits_cap_concurrent_callers() {
@@ -1304,13 +1312,16 @@ mod tests {
         let pool = Arc::new(ConnectionPool::new());
         let server = spawn_hold_open_listener().await;
         let target: SocketAddr = "93.184.216.34:443".parse().unwrap();
+        let generation = 1;
+        let node_id = Uuid::from_u128(1);
         let mut tasks = tokio::task::JoinSet::new();
         for i in 0..MAX_READY_TARGETS_PER_NODE + 16 {
             let pool = Arc::clone(&pool);
             tasks.spawn(async move {
-                let key = format!("ready|node:443|198.51.100.{i}:443");
+                let key_target: SocketAddr = format!("198.51.100.{i}:443").parse().unwrap();
+                let key = ConnectionPool::ready_key(generation, node_id, key_target, None);
                 let tcp = TcpStream::connect(server).await.unwrap();
-                pool.deposit_ready(&key, make_ready_stream(tcp, target))
+                pool.deposit_ready(generation, &key, make_ready_stream(tcp, target))
                     .await;
             });
         }
@@ -1322,18 +1333,18 @@ mod tests {
             pool.ready_metrics().entries,
             MAX_READY_TARGETS_PER_NODE as u64
         );
-        pool.purge_node("node:443");
+        pool.purge_node("node:443", generation, node_id);
         pool.check_invariants();
         assert_eq!(pool.ready_metrics().entries, 0);
-        let key = "ready|node:443|198.51.100.1:443";
+        let key_target: SocketAddr = "198.51.100.1:443".parse().unwrap();
+        let key = ConnectionPool::ready_key(generation, node_id, key_target, None);
         let tcp = TcpStream::connect(server).await.unwrap();
-        pool.deposit_ready(key, make_ready_stream(tcp, target))
+        pool.deposit_ready(generation, &key, make_ready_stream(tcp, target))
             .await;
         pool.check_invariants();
-        assert!(pool.acquire_ready(key).await.is_some());
+        assert!(pool.acquire_ready(&key).await.is_some());
         pool.check_invariants();
     }
-
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn test_total_cap_never_overshoots_under_parallel_deposits() {
         let pool = Arc::new(ConnectionPool::with_capacity_limit(4));
@@ -1364,15 +1375,20 @@ mod tests {
     #[test]
     fn test_warm_key_singleflight_and_drop_releases_claim() {
         let pool = ConnectionPool::new();
-        let key = "ready|node:443|198.51.100.1:443";
-        let guard = pool.try_begin_warm(key).expect("first warmer owns key");
+        let generation = 1;
+        let node_id = Uuid::from_u128(1);
+        let target: SocketAddr = "198.51.100.1:443".parse().unwrap();
+        let key = ConnectionPool::ready_key(generation, node_id, target, None);
+        let guard = pool
+            .try_begin_warm(generation, &key)
+            .expect("first warmer owns key");
         assert!(
-            pool.try_begin_warm(key).is_none(),
+            pool.try_begin_warm(generation, &key).is_none(),
             "follower must not duplicate warm dial"
         );
         drop(guard);
         assert!(
-            pool.try_begin_warm(key).is_some(),
+            pool.try_begin_warm(generation, &key).is_some(),
             "cancelled/failed owner must release key"
         );
     }
@@ -1380,16 +1396,479 @@ mod tests {
     #[test]
     fn test_hot_map_refuses_new_keys_at_bound_without_scan() {
         let pool = ConnectionPool::new();
+        let generation = 1;
+        let node_id = Uuid::from_u128(1);
         for i in 0..4096 {
-            assert!(!pool.note_target(&format!("ready|node:443|target-{i}:443")));
+            let target = SocketAddr::new(
+                std::net::Ipv4Addr::new(192, 0, (i / 256) as u8, (i % 256) as u8).into(),
+                443,
+            );
+            let key = ConnectionPool::ready_key(generation, node_id, target, None);
+            assert!(!pool.note_target(generation, &key));
             pool.check_invariants();
         }
-        let new_key = "ready|node:443|new:443";
-        assert!(!pool.note_target(new_key));
+        let new_target: SocketAddr = "203.0.113.1:443".parse().unwrap();
+        let new_key = ConnectionPool::ready_key(generation, node_id, new_target, None);
+        assert!(!pool.note_target(generation, &new_key));
         pool.check_invariants();
-        assert!(!pool.note_target(new_key));
+        assert!(!pool.note_target(generation, &new_key));
         pool.check_invariants();
-        assert!(pool.note_target("ready|node:443|target-0:443"));
+        let first_target: SocketAddr = "192.0.0.0:443".parse().unwrap();
+        let first_key = ConnectionPool::ready_key(generation, node_id, first_target, None);
+        assert!(pool.note_target(generation, &first_key));
         pool.check_invariants();
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct ReadyIdentitySocks5Auth {
+        username: String,
+        password: String,
+    }
+
+    struct ReadyIdentitySocks5Fixture {
+        addr: SocketAddr,
+        observed: Arc<tokio::sync::Mutex<Vec<ReadyIdentitySocks5Auth>>>,
+        accept_task: tokio::task::JoinHandle<()>,
+    }
+
+    impl ReadyIdentitySocks5Fixture {
+        async fn bind() -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let addr = listener.local_addr().unwrap();
+            let observed = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+            let task_observed = Arc::clone(&observed);
+            let accept_task = tokio::spawn(async move {
+                let mut connections = tokio::task::JoinSet::new();
+                loop {
+                    tokio::select! {
+                        accepted = listener.accept() => {
+                            let Ok((stream, _)) = accepted else { break };
+                            let observed = Arc::clone(&task_observed);
+                            connections.spawn(async move {
+                                let _ = serve_ready_identity_socks5(stream, observed).await;
+                            });
+                        }
+                        result = connections.join_next(), if !connections.is_empty() => {
+                            let _ = result;
+                        }
+                    }
+                }
+            });
+            Self {
+                addr,
+                observed,
+                accept_task,
+            }
+        }
+
+        fn addr(&self) -> SocketAddr {
+            self.addr
+        }
+
+        async fn observed_auths(&self) -> Vec<ReadyIdentitySocks5Auth> {
+            self.observed.lock().await.clone()
+        }
+    }
+
+    impl Drop for ReadyIdentitySocks5Fixture {
+        fn drop(&mut self) {
+            // The accept task owns a JoinSet, so aborting it also aborts all
+            // connection handlers instead of leaving detached fixture tasks.
+            self.accept_task.abort();
+        }
+    }
+
+    async fn serve_ready_identity_socks5(
+        mut stream: TcpStream,
+        observed: Arc<tokio::sync::Mutex<Vec<ReadyIdentitySocks5Auth>>>,
+    ) -> std::io::Result<()> {
+        let mut greeting = [0u8; 2];
+        stream.read_exact(&mut greeting).await?;
+        if greeting[0] != 0x05 {
+            return Ok(());
+        }
+        let mut methods = vec![0u8; greeting[1] as usize];
+        stream.read_exact(&mut methods).await?;
+        if !methods.contains(&0x02) {
+            return Ok(());
+        }
+        stream.write_all(&[0x05, 0x02]).await?;
+
+        let mut auth_header = [0u8; 2];
+        stream.read_exact(&mut auth_header).await?;
+        if auth_header[0] != 0x01 {
+            return Ok(());
+        }
+        let mut username = vec![0u8; auth_header[1] as usize];
+        stream.read_exact(&mut username).await?;
+        let mut password_len = [0u8; 1];
+        stream.read_exact(&mut password_len).await?;
+        let mut password = vec![0u8; password_len[0] as usize];
+        stream.read_exact(&mut password).await?;
+        let username = String::from_utf8_lossy(&username).into_owned();
+        let password = String::from_utf8_lossy(&password).into_owned();
+        observed.lock().await.push(ReadyIdentitySocks5Auth {
+            username: username.clone(),
+            password: password.clone(),
+        });
+        stream.write_all(&[0x01, 0x00]).await?;
+
+        let mut request = [0u8; 4];
+        stream.read_exact(&mut request).await?;
+        let mut destination = match request[3] {
+            0x01 => vec![0u8; 6],
+            0x04 => vec![0u8; 18],
+            0x03 => {
+                let mut length = [0u8; 1];
+                stream.read_exact(&mut length).await?;
+                vec![0u8; length[0] as usize + 2]
+            }
+            _ => return Ok(()),
+        };
+        stream.read_exact(&mut destination).await?;
+        stream
+            .write_all(&[0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0])
+            .await?;
+
+        // The consumer writes a marker after either taking a pooled stream or
+        // falling back to a fresh dial. Reply with the credentials authenticated
+        // on this actual RFC1929 connection, making cross-identity reuse visible
+        // to the consumer rather than only through a key assertion.
+        let response = format!("{username}:{password}");
+        loop {
+            let mut marker = [0u8; 4];
+            if stream.read_exact(&mut marker).await.is_err() {
+                return Ok(());
+            }
+            if &marker != b"PING" {
+                return Ok(());
+            }
+            stream.write_all(response.as_bytes()).await?;
+        }
+    }
+
+    fn ready_identity_socks5_node(
+        addr: SocketAddr,
+        username: &str,
+        password: &str,
+        name: &str,
+    ) -> Node {
+        let mut node =
+            Node::from_share_link(&format!("socks5://{username}:{password}@{addr}#{name}"))
+                .unwrap();
+        node.id = node.derive_id();
+        node
+    }
+
+    fn ready_identity_trojan_node(addr: SocketAddr, sni: &str, name: &str) -> Node {
+        let mut node =
+            Node::from_share_link(&format!("trojan://secret@{addr}?sni={sni}#{name}")).unwrap();
+        node.id = node.derive_id();
+        node
+    }
+
+    #[tokio::test]
+    async fn ready_identity_socks5_credentials_do_not_share() {
+        let fixture = ReadyIdentitySocks5Fixture::bind().await;
+        let node_a = ready_identity_socks5_node(fixture.addr(), "a", "a", "ready-a");
+        let node_b = ready_identity_socks5_node(fixture.addr(), "b", "b", "ready-b");
+        assert_ne!(node_a.id, node_b.id);
+
+        let target: SocketAddr = "192.0.2.10:443".parse().unwrap();
+        let handler = Socks5Handler::new();
+        let pool = ConnectionPool::new();
+        let generation = 1;
+        let key_a = ConnectionPool::ready_key(generation, node_a.id, target, None);
+        let key_b = ConnectionPool::ready_key(generation, node_b.id, target, None);
+
+        let stream_a = tokio::time::timeout(
+            Duration::from_secs(3),
+            handler.dial(&node_a, target, None, Duration::from_secs(3)),
+        )
+        .await
+        .expect("SOCKS5 A dial timed out")
+        .unwrap();
+        pool.deposit_ready(generation, &key_a, stream_a).await;
+        pool.check_invariants();
+
+        // Distinct identity keys force B's physical dial when no B stream is pooled.
+        let mut stream_b = match pool.acquire_ready(&key_b).await {
+            Some(stream) => stream,
+            None => tokio::time::timeout(
+                Duration::from_secs(3),
+                handler.dial(&node_b, target, None, Duration::from_secs(3)),
+            )
+            .await
+            .expect("SOCKS5 B fallback dial timed out")
+            .unwrap(),
+        };
+        pool.check_invariants();
+
+        stream_b.stream.write_all(b"PING").await.unwrap();
+        let mut reply = [0u8; 3];
+        tokio::time::timeout(
+            Duration::from_secs(3),
+            stream_b.stream.read_exact(&mut reply),
+        )
+        .await
+        .expect("SOCKS5 consumer reply timed out")
+        .unwrap();
+        let observed = fixture.observed_auths().await;
+        assert_eq!(
+            &reply, b"b:b",
+            "B's consumer must use a stream authenticated as B"
+        );
+        assert!(
+            observed
+                .iter()
+                .any(|auth| auth.username == "b" && auth.password == "b"),
+            "the RFC1929 server did not observe B credentials: {observed:?}"
+        );
+        drop(stream_b);
+        pool.check_invariants();
+    }
+
+    #[tokio::test]
+    async fn ready_identity_trojan_sni_do_not_share() {
+        let server = spawn_hold_open_listener().await;
+        let node_a = ready_identity_trojan_node(server, "a.example", "trojan-a");
+        let node_b = ready_identity_trojan_node(server, "b.example", "trojan-b");
+        assert_ne!(node_a.id, node_b.id);
+        assert_eq!(node_a.host(), node_b.host());
+        assert_eq!(node_a.port, node_b.port);
+
+        let target: SocketAddr = "192.0.2.20:443".parse().unwrap();
+        let pool = ConnectionPool::new();
+        let key_a = ConnectionPool::ready_key(1, node_a.id, target, None);
+        let key_b = ConnectionPool::ready_key(1, node_b.id, target, None);
+        let tcp = TcpStream::connect(server).await.unwrap();
+        pool.deposit_ready(1, &key_a, make_ready_stream(tcp, target))
+            .await;
+
+        assert!(
+            pool.acquire_ready(&key_b).await.is_none(),
+            "a TCP Trojan stream for SNI A must not be consumed by SNI B"
+        );
+        pool.check_invariants();
+    }
+
+    #[tokio::test]
+    async fn ready_identity_generation_do_not_share() {
+        let server = spawn_hold_open_listener().await;
+        let node = ready_identity_socks5_node(server, "same", "same", "generation");
+        let target: SocketAddr = "192.0.2.30:443".parse().unwrap();
+        let pool = ConnectionPool::new();
+        let key_generation_one = ConnectionPool::ready_key(1, node.id, target, None);
+        let key_generation_two = ConnectionPool::ready_key(2, node.id, target, None);
+
+        let tcp = TcpStream::connect(server).await.unwrap();
+        pool.deposit_ready(1, &key_generation_one, make_ready_stream(tcp, target))
+            .await;
+        pool.check_invariants();
+
+        assert!(
+            pool.acquire_ready(&key_generation_two).await.is_none(),
+            "a generation-1 stream must not be consumed by generation 2"
+        );
+        pool.check_invariants();
+    }
+
+    #[tokio::test]
+    async fn ready_identity_purge_a_preserves_b_same_address() {
+        let server = spawn_hold_open_listener().await;
+        let node_a = ready_identity_socks5_node(server, "a", "a", "purge-a");
+        let node_b = ready_identity_socks5_node(server, "b", "b", "purge-b");
+        assert_ne!(node_a.id, node_b.id);
+
+        let target_a: SocketAddr = "192.0.2.40:443".parse().unwrap();
+        let target_b: SocketAddr = "192.0.2.41:443".parse().unwrap();
+        let pool = ConnectionPool::new();
+        let generation = 1;
+        let key_a = ConnectionPool::ready_key(generation, node_a.id, target_a, None);
+        let key_b = ConnectionPool::ready_key(generation, node_b.id, target_b, None);
+
+        let tcp_a = TcpStream::connect(server).await.unwrap();
+        pool.deposit_ready(generation, &key_a, make_ready_stream(tcp_a, target_a))
+            .await;
+        pool.check_invariants();
+        let tcp_b = TcpStream::connect(server).await.unwrap();
+        pool.deposit_ready(generation, &key_b, make_ready_stream(tcp_b, target_b))
+            .await;
+        pool.check_invariants();
+
+        let node_addr = format!("{}:{}", node_a.host(), node_a.port);
+        pool.purge_node(&node_addr, generation, node_a.id);
+        pool.check_invariants();
+
+        assert!(pool.acquire_ready(&key_a).await.is_none());
+        pool.check_invariants();
+        let survivor = pool
+            .acquire_ready(&key_b)
+            .await
+            .expect("purging A must preserve B's same-address stream");
+        assert_eq!(survivor.target_addr, target_b);
+        pool.check_invariants();
+    }
+
+    #[tokio::test]
+    async fn ready_identity_each_id_gets_64_target_budget() {
+        let server = spawn_hold_open_listener().await;
+        let node_a = ready_identity_socks5_node(server, "a", "a", "budget-a");
+        let node_b = ready_identity_socks5_node(server, "b", "b", "budget-b");
+        assert_ne!(node_a.id, node_b.id);
+        let pool = ConnectionPool::new();
+
+        for index in 1..=64u8 {
+            let target = SocketAddr::new(std::net::Ipv4Addr::new(192, 0, 2, index).into(), 443);
+            let key = ConnectionPool::ready_key(1, node_a.id, target, None);
+            let tcp = TcpStream::connect(server).await.unwrap();
+            pool.deposit_ready(1, &key, make_ready_stream(tcp, target))
+                .await;
+            pool.check_invariants();
+        }
+        for index in 1..=64u8 {
+            let target = SocketAddr::new(std::net::Ipv4Addr::new(198, 51, 100, index).into(), 443);
+            let key = ConnectionPool::ready_key(1, node_b.id, target, None);
+            let tcp = TcpStream::connect(server).await.unwrap();
+            pool.deposit_ready(1, &key, make_ready_stream(tcp, target))
+                .await;
+            pool.check_invariants();
+        }
+
+        assert_eq!(pool.ready_metrics().entries, 128);
+        for index in 1..=64u8 {
+            let target = SocketAddr::new(std::net::Ipv4Addr::new(192, 0, 2, index).into(), 443);
+            let key = ConnectionPool::ready_key(1, node_a.id, target, None);
+            assert!(
+                pool.acquire_ready(&key).await.is_some(),
+                "identity A lost target {target}"
+            );
+            pool.check_invariants();
+        }
+        for index in 1..=64u8 {
+            let target = SocketAddr::new(std::net::Ipv4Addr::new(198, 51, 100, index).into(), 443);
+            let key = ConnectionPool::ready_key(1, node_b.id, target, None);
+            assert!(
+                pool.acquire_ready(&key).await.is_some(),
+                "identity B lost target {target}"
+            );
+            pool.check_invariants();
+        }
+    }
+
+    #[tokio::test]
+    async fn ready_retirement_clears_generation_and_preserves_successor() {
+        let pool = ConnectionPool::new();
+        let server = spawn_hold_open_listener().await;
+        let target = "192.0.2.1:443".parse().unwrap();
+        let node_id = Uuid::from_u128(1);
+        let old = ConnectionPool::ready_key(1, node_id, target, None);
+        let next = ConnectionPool::ready_key(2, node_id, target, None);
+        for (generation, key) in [(1, &old), (2, &next)] {
+            let tcp = TcpStream::connect(server).await.unwrap();
+            pool.deposit_ready(generation, key, make_ready_stream(tcp, target))
+                .await;
+            pool.check_invariants();
+            assert!(!pool.note_target(generation, key));
+            pool.check_invariants();
+            assert!(pool.note_target(generation, key));
+            pool.check_invariants();
+        }
+        let old_guard = pool.try_begin_warm(1, &old).unwrap();
+        pool.check_invariants();
+        let next_guard = pool.try_begin_warm(2, &next).unwrap();
+        pool.check_invariants();
+        pool.retire_generation(1);
+        pool.check_invariants();
+        assert!(pool.acquire_ready(&old).await.is_none());
+        pool.check_invariants();
+        {
+            let state = pool.state.lock();
+            assert!(state.retired.contains(&1));
+            assert!(!state.retired.contains(&2));
+            assert!(!state.hot.contains_key(&old));
+            assert!(!state.warm_dials.contains(&old));
+            assert!(
+                !state
+                    .ready_targets
+                    .contains_key(ConnectionPool::ready_node(&old))
+            );
+            assert!(state.hot.contains_key(&next));
+            assert!(state.warm_dials.contains(&next));
+        }
+        assert!(pool.acquire_ready(&next).await.is_some());
+        pool.check_invariants();
+        drop(old_guard);
+        pool.check_invariants();
+        assert!(pool.try_begin_warm(2, &next).is_none());
+        pool.check_invariants();
+        drop(next_guard);
+        pool.check_invariants();
+        assert!(pool.try_begin_warm(2, &next).is_some());
+        pool.check_invariants();
+    }
+
+    #[tokio::test]
+    async fn ready_retirement_refuses_late_deposit() {
+        let pool = ConnectionPool::new();
+        let server = spawn_hold_open_listener().await;
+        let target = "192.0.2.1:443".parse().unwrap();
+        let generation = 1;
+        let key = ConnectionPool::ready_key(generation, Uuid::from_u128(1), target, None);
+        pool.retire_generation(generation);
+        pool.check_invariants();
+        let tcp = TcpStream::connect(server).await.unwrap();
+        pool.deposit_ready(generation, &key, make_ready_stream(tcp, target))
+            .await;
+        pool.check_invariants();
+        assert!(pool.acquire_ready(&key).await.is_none());
+        pool.check_invariants();
+    }
+
+    #[test]
+    fn ready_retirement_refuses_late_hotness() {
+        let pool = ConnectionPool::new();
+        let generation = 1;
+        let target: SocketAddr = "192.0.2.1:443".parse().unwrap();
+        let key = ConnectionPool::ready_key(generation, Uuid::from_u128(1), target, None);
+        pool.retire_generation(generation);
+        pool.check_invariants();
+        assert!(!pool.note_target(generation, &key));
+        pool.check_invariants();
+        assert!(!pool.note_target(generation, &key));
+        pool.check_invariants();
+        assert!(!pool.state.lock().hot.contains_key(&key));
+    }
+
+    #[test]
+    fn ready_retirement_refuses_late_warm_claim() {
+        let pool = ConnectionPool::new();
+        let generation = 1;
+        let target: SocketAddr = "192.0.2.1:443".parse().unwrap();
+        let key = ConnectionPool::ready_key(generation, Uuid::from_u128(1), target, None);
+        pool.retire_generation(generation);
+        pool.check_invariants();
+        assert!(pool.try_begin_warm(generation, &key).is_none());
+        pool.check_invariants();
+    }
+    #[test]
+    fn ready_retirement_reclaims_hotness_across_seventy_generations() {
+        let pool = ConnectionPool::new();
+        let node_id = Uuid::from_u128(1);
+        for generation in 1..=70 {
+            for port in 1..=64 {
+                let target = SocketAddr::from(([192, 0, 2, 1], port));
+                let key = ConnectionPool::ready_key(generation, node_id, target, None);
+                assert!(!pool.note_target(generation, &key));
+                pool.check_invariants();
+                assert!(
+                    pool.note_target(generation, &key),
+                    "generation {generation} must become hot"
+                );
+                pool.check_invariants();
+            }
+            pool.retire_generation(generation);
+            pool.check_invariants();
+        }
     }
 }

--- a/crates/honk-outbound/src/runtime.rs
+++ b/crates/honk-outbound/src/runtime.rs
@@ -22,13 +22,15 @@ pub(crate) use admission::{
 use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 const TLS_ACTIVE_RATIO_NUMERATOR: usize = 1;
 const TLS_ACTIVE_RATIO_DENOMINATOR: usize = 10;
 const TLS_ACTIVE_MIN: usize = 8;
 pub const TLS_IDLE_RETENTION: Duration = Duration::from_secs(10 * 60);
 pub const TLS_REAP_INTERVAL: Duration = Duration::from_secs(60);
+
+static NEXT_RUNTIME_GENERATION: AtomicU64 = AtomicU64::new(1);
 
 use honk_config::node::Node;
 
@@ -801,6 +803,7 @@ pub enum RuntimeRegistryError {
 /// through to a newer generation.
 #[derive(Debug)]
 pub struct OutboundRuntimeRegistry {
+    generation: u64,
     nodes: HashMap<uuid::Uuid, Arc<NodeRuntime>>,
     terminal: AtomicBool,
     /// Runtimes a successor generation took over at the reload commit point.
@@ -956,6 +959,7 @@ impl OutboundRuntimeRegistry {
         }
         Ok((
             Self {
+                generation: NEXT_RUNTIME_GENERATION.fetch_add(1, Ordering::Relaxed),
                 nodes: map,
                 terminal: AtomicBool::new(false),
                 moved_out: parking_lot::Mutex::new(HashSet::new()),
@@ -973,6 +977,10 @@ impl OutboundRuntimeRegistry {
     /// Wrap into the shared cell used by the control plane.
     pub fn into_shared(self) -> SharedRuntimeRegistry {
         Arc::new(parking_lot::RwLock::new(Arc::new(self)))
+    }
+
+    pub fn generation(&self) -> u64 {
+        self.generation
     }
 
     pub fn get(&self, id: &uuid::Uuid) -> Option<Arc<NodeRuntime>> {

--- a/doc/en/design/outbound.md
+++ b/doc/en/design/outbound.md
@@ -98,6 +98,15 @@ pooling stores only a connected proxy-server socket and lets `dial_with_tcp`
 perform the per-target protocol handshake. Multiplexed and QUIC protocols
 exclude both because their generation runtime is the sole reusable-state owner.
 
+Ready streams are keyed by runtime generation, node identity, and target; only
+flows using the generation that dialed them may acquire them. After a reload
+publishes its successor, retiring the old generation removes its ready streams,
+target counts, warm claims, and hotness under the pool lock and refuses late
+ready deposits, hotness updates, and warm claims for it. The successor starts
+with an empty ready namespace. A rejected reload keeps the active pool state.
+Bare-TCP keys remain proxy-server addresses; health purges remove that address's
+bare entries and only the current generation's matching identity's ready entries.
+
 Registry assembly checks that descriptor capabilities, populated slots, and runtime kinds agree.
 Node-dependent entries may carry a packet slot even when the default node lacks
 UDP. `block` is the explicit exception: its descriptor says no UDP capability,

--- a/doc/zh/design/outbound.md
+++ b/doc/zh/design/outbound.md
@@ -83,6 +83,14 @@ Ready-stream pooling 保存已经完成且绑定目标的握手。Bare-TCP pooli
 多路复用与 QUIC 协议排除两者，因为其 generation runtime 是可复用状态的
 唯一所有者。
 
+Ready stream 按 runtime generation、节点身份和目标分别保存，只能由使用
+拨号时所属 generation 的流取出。reload 发布新 generation 后，连接池在
+同一把锁内移除旧 generation 的 ready stream、目标计数、预热任务记录和
+目标访问计数，并拒绝旧 generation 后续的 ready 写入、访问计数更新和预热请求。
+新 generation 的 ready 命名空间从空开始。reload 被拒绝时，保留当前连接池状态。
+Bare-TCP 仍以代理服务器地址为键；节点失效时，清除该地址的 bare 连接，
+但只清除当前 generation 中对应节点身份的 ready 连接。
+
 Registry 组装会检查 descriptor capability 与填充的槽是否一致。
 依赖节点的 entry 即使默认节点没有 UDP，也可以携带 packet 槽。`block`
 是显式例外：其 descriptor 声明没有 UDP capability，但分派允许其 packet


### PR DESCRIPTION
## Problem

`ConnectionPool` keeps its streams, its total, the per-node ready-target counts, the warm-dial claims and the hotness map in five separately synchronised structures, so the invariants the code assumes do not hold under concurrency: a checkout racing a health purge can take the purged stream and subtract twice, a deposit can land in a vector the checkout has just unlinked and vanish with its reservation, the janitor's snapshot store loses a concurrent deposit, and once the total is wrong the pool refuses every deposit until restart (#194). Separately, ready streams are keyed by the proxy's `host:port`, so two nodes on one address with different credentials share each other's authenticated streams, and a reload leaves the old node's ready streams reachable until they expire (#145).

## How I fixed it

The first commit puts all pool state under one `parking_lot::Mutex<PoolState>`: every operation takes it once, never across an `.await`, never touches a second key inside it, and evicted streams are destroyed after it is released. The total is then exact by construction, a `check_invariants` helper states the invariants and the tests call it after every step, and the four races above are reproduced by pause-hook tests that fail on the old structure. The second commit keys ready streams by runtime generation and node identity (`ready|<generation>|<id>|<target>`; `OutboundRuntimeRegistry` gets a generation number) so a re-credentialed or replaced node can never find its predecessor's streams, and retires a generation as one pool operation right after the reload's `begin_retirement`: its ready streams, target budget, warm claims and hotness are removed and late deposits, hotness updates and warm claims for it are refused. Health purges narrow from the whole address to the identity that died. Limits, bare-TCP keys, selector warm ownership and `derive_id` are unchanged.

## Verified

`cargo fmt --check`, `cargo clippy --all --all-targets -- -D warnings`, `cargo test -p honk-core`, the workspace gate and `just outbound-ci` pass on both commits. Each failing-first test was run against the previous structure and failed by assertion: the four race tests, the credential and dial-shape isolation tests against a loopback RFC 1929 SOCKS5 server, the two-generation and per-identity budget tests, the retirement and late-write tests, the 70-generation hotness test, and the three reload cases in `reload_tests` (re-credentialed, replaced, unchanged-plus-routing-change; a rejected reload keeps its stream). Eleven single-hunk ablations each make their test fail. A non-gating loopback measurement with 2,048 pooled streams put a janitor pass at about 250 µs and a full generation retirement at about 2 ms under the lock. Not run: `just test-netns`, the eBPF job.

---

- [x] `just fmt`, `just lint` and `just test-ci` pass.
- [x] I updated `doc/en/` and `doc/zh/` if I changed documented behaviour.
- [x] If I used AI: it followed `CONTRIBUTING.md` and `AGENTS.md`, and Verified shows what I ran, not guesses.
