### PR TITLE
perf(routing): reduce lazy fact emission overhead

### DIFF
--- a/crates/honk-core/src/control/routing_matcher/codegen.rs
+++ b/crates/honk-core/src/control/routing_matcher/codegen.rs
@@ -72,7 +72,13 @@ struct FactCache {
     ready: i16,
 }
 
-fn fact_caches(plan: &RoutingPushPlan) -> [Option<FactCache>; 3] {
+struct FactCaches {
+    slots: [Option<FactCache>; 3],
+    must_ready: u8,
+    may_ready: u8,
+}
+
+fn fact_caches(plan: &RoutingPushPlan) -> FactCaches {
     let mut uses = [0u8; 3];
     for condition in plan.rules.iter().flat_map(|rule| &rule.conditions) {
         if let Some(kind) = FactKind::of(&condition.predicate) {
@@ -83,13 +89,17 @@ fn fact_caches(plan: &RoutingPushPlan) -> [Option<FactCache>; 3] {
     // Separate DW slots preserve ready constants on 6.12; packed W flags
     // lose precision and exhaust the verifier budget on mixed 256-bit policies.
     // Pairs occupy [-32, -1] and [-80, -65], outside both key buffers.
-    std::array::from_fn(|index| {
-        let pointer = [-16, -32, -80][index];
-        (uses[index] == 2).then_some(FactCache {
-            pointer,
-            ready: pointer + 8,
-        })
-    })
+    FactCaches {
+        slots: std::array::from_fn(|index| {
+            let pointer = [-16, -32, -80][index];
+            (uses[index] == 2).then_some(FactCache {
+                pointer,
+                ready: pointer + 8,
+            })
+        }),
+        must_ready: 0,
+        may_ready: 0,
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -294,8 +304,8 @@ pub fn emit_routing_program(
     )?;
     asm.st_imm(R7, RULE_ID, u32::MAX as i32)?;
 
-    let caches = fact_caches(plan);
-    for cache in caches.iter().flatten() {
+    let mut caches = fact_caches(plan);
+    for cache in caches.slots.iter().flatten() {
         asm.st_dw_imm(R10, cache.pointer, 0)?;
         asm.st_dw_imm(R10, cache.ready, 0)?;
     }
@@ -316,9 +326,21 @@ pub fn emit_routing_program(
     for rule in &plan.rules {
         asm.source(rule.id + 1, rule.source.as_str());
         let fail = asm.label();
+        let mut failure_ready: Option<(u8, u8)> = None;
         for condition in &rule.conditions {
             let pass = asm.label();
             emit_condition(&mut asm, condition, pass, fail, &fds, &caches)?;
+            if let Some(kind) = FactKind::of(&condition.predicate) {
+                let bit = 1u8 << kind as u8;
+                caches.must_ready |= bit;
+                caches.may_ready |= bit;
+            }
+            // Every failed condition can enter the next rule, including a
+            // short circuit before this rule's first fact lookup.
+            failure_ready = Some(match failure_ready {
+                None => (caches.must_ready, caches.may_ready),
+                Some((must, may)) => (must & caches.must_ready, may | caches.may_ready),
+            });
             asm.bind(pass);
         }
         asm.st_imm(R7, OUTBOUND, rule.outbound as i32)?;
@@ -328,6 +350,7 @@ pub fn emit_routing_program(
         asm.mov_imm(R0, 0)?;
         asm.exit()?;
         asm.bind(fail);
+        (caches.must_ready, caches.may_ready) = failure_ready.unwrap_or_default();
     }
 
     asm.source(0, "fallback");
@@ -439,7 +462,7 @@ fn emit_condition(
     pass: Label,
     fail: Label,
     fds: &RoutingMapFds,
-    caches: &[Option<FactCache>; 3],
+    caches: &FactCaches,
 ) -> anyhow::Result<()> {
     if condition.not {
         emit_predicate(asm, &condition.predicate, fail, pass, fds, caches)
@@ -454,7 +477,7 @@ fn emit_predicate(
     on_true: Label,
     on_false: Label,
     fds: &RoutingMapFds,
-    caches: &[Option<FactCache>; 3],
+    caches: &FactCaches,
 ) -> anyhow::Result<()> {
     match predicate {
         KernelPredicate::Domain(id) => {
@@ -613,23 +636,31 @@ fn emit_fact_bit(
     asm: &mut Assembler,
     kind: FactKind,
     id: u32,
-    caches: &[Option<FactCache>; 3],
+    caches: &FactCaches,
     on_true: Label,
     on_false: Label,
     fds: &RoutingMapFds,
 ) -> anyhow::Result<()> {
-    if let Some(cache) = caches[kind as usize] {
-        let reuse = asm.label();
-        let ready = asm.label();
-        asm.ldx_dw(R0, R10, cache.ready)?;
-        asm.jump(BPF_JNE, R0, 0, reuse)?;
-        emit_fact_lookup(asm, kind, fds)?;
-        asm.stx_dw(R10, R0, cache.pointer)?;
-        asm.st_dw_imm(R10, cache.ready, 1)?;
-        asm.ja(ready)?;
-        asm.bind(reuse);
-        asm.ldx_dw(R0, R10, cache.pointer)?;
-        asm.bind(ready);
+    if let Some(cache) = caches.slots[kind as usize] {
+        let bit = 1u8 << kind as u8;
+        if caches.must_ready & bit != 0 {
+            asm.ldx_dw(R0, R10, cache.pointer)?;
+        } else {
+            let branch = (caches.may_ready & bit != 0).then(|| (asm.label(), asm.label()));
+            if let Some((reuse, _)) = branch {
+                asm.ldx_dw(R0, R10, cache.ready)?;
+                asm.jump(BPF_JNE, R0, 0, reuse)?;
+            }
+            emit_fact_lookup(asm, kind, fds)?;
+            asm.stx_dw(R10, R0, cache.pointer)?;
+            asm.st_dw_imm(R10, cache.ready, 1)?;
+            if let Some((reuse, ready)) = branch {
+                asm.ja(ready)?;
+                asm.bind(reuse);
+                asm.ldx_dw(R0, R10, cache.pointer)?;
+                asm.bind(ready);
+            }
+        }
     } else {
         emit_fact_lookup(asm, kind, fds)?;
     }
@@ -642,13 +673,14 @@ fn emit_fact_lookup(
     fds: &RoutingMapFds,
 ) -> anyhow::Result<()> {
     let absent = asm.label();
+    let lookup = asm.label();
     let done = asm.label();
     match kind {
         FactKind::Mac => {
             asm.ldx_w(R0, R6, INPUT_MAC_PRESENT)?;
             asm.jump(BPF_JEQ, R0, 0, absent)?;
-            emit_lpm_lookup(asm, fds.mac, 128, INPUT_MAC)?;
-            asm.ja(done)?;
+            write_key_from_input(asm, INPUT_MAC, 128)?;
+            load_map_fd(asm, fds.mac)?;
         }
         FactKind::Destination | FactKind::Source => {
             let (v4_fd, v6_fd, input_offset) = match kind {
@@ -662,30 +694,23 @@ fn emit_fact_lookup(
             asm.jump(BPF_JEQ, R0, 2, v6)?;
             asm.ja(absent)?;
             asm.bind(v4);
-            emit_lpm_lookup(asm, v4_fd, 32, input_offset + 12)?;
-            asm.ja(done)?;
+            write_key_from_input(asm, input_offset + 12, 32)?;
+            load_map_fd(asm, v4_fd)?;
+            asm.ja(lookup)?;
             asm.bind(v6);
-            emit_lpm_lookup(asm, v6_fd, 128, input_offset)?;
-            asm.ja(done)?;
+            write_key_from_input(asm, input_offset, 128)?;
+            load_map_fd(asm, v6_fd)?;
         }
     }
+    asm.bind(lookup);
+    asm.mov_reg(R2, R10)?;
+    asm.add_imm(R2, STACK_KEY as i32)?;
+    asm.call(MAP_LOOKUP_ELEM)?;
+    asm.ja(done)?;
     asm.bind(absent);
     asm.mov_imm(R0, 0)?;
     asm.bind(done);
     Ok(())
-}
-
-fn emit_lpm_lookup(
-    asm: &mut Assembler,
-    fd: i32,
-    prefix_len: u32,
-    input_offset: i16,
-) -> anyhow::Result<()> {
-    write_key_from_input(asm, input_offset, prefix_len)?;
-    load_map_fd(asm, fd)?;
-    asm.mov_reg(R2, R10)?;
-    asm.add_imm(R2, STACK_KEY as i32)?;
-    asm.call(MAP_LOOKUP_ELEM)
 }
 
 fn write_key_from_input(
@@ -694,15 +719,14 @@ fn write_key_from_input(
     prefix_len: u32,
 ) -> anyhow::Result<()> {
     asm.st_imm(R10, STACK_KEY, prefix_len as i32)?;
-    for index in 0..4 {
-        asm.st_imm(R10, STACK_KEY + 4 + index * 4, 0)?;
-    }
-    asm.mov_reg(R2, R6)?;
     let words = if prefix_len == 32 { 1 } else { 4 };
     for index in 0..words {
-        let offset = index as i16 * 4;
-        asm.ldx_w(R3, R2, input_offset + offset)?;
+        let offset = index * 4;
+        asm.ldx_w(R3, R6, input_offset + offset)?;
         asm.stx_w(R10, R3, STACK_KEY + 4 + offset)?;
+    }
+    for index in words..4 {
+        asm.st_imm(R10, STACK_KEY + 4 + index * 4, 0)?;
     }
     Ok(())
 }

--- a/crates/honk-core/src/ebpf/real/routing/tests.rs
+++ b/crates/honk-core/src/ebpf/real/routing/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+mod readiness;
 use crate::control::routing_matcher::RoutingPushPlan;
 use crate::routing::{ConnectionInfo, Router, golden};
 use honk_config::types::DialMode;

--- a/crates/honk-core/src/ebpf/real/routing/tests/readiness.rs
+++ b/crates/honk-core/src/ebpf/real/routing/tests/readiness.rs
@@ -1,0 +1,311 @@
+use super::{assert_route, decision, input, object};
+use crate::control::routing_matcher::{
+    KernelCondition, KernelPredicate, KernelRule, RoutingFactMaps, RoutingPushPlan,
+};
+use crate::ebpf::EbpfBackend;
+use crate::ebpf::maps::LpmKey;
+use crate::ebpf::real::RealEbpfBackend;
+use crate::routing::golden;
+use honk_ebpf_common::DomainRouting;
+use std::net::IpAddr;
+
+fn condition(not: bool, predicate: KernelPredicate) -> KernelCondition {
+    KernelCondition { not, predicate }
+}
+
+fn kernel_rule(
+    id: u32,
+    conditions: Vec<KernelCondition>,
+    outbound: u8,
+    mark: u32,
+    must: bool,
+) -> KernelRule {
+    KernelRule {
+        id,
+        source: format!("readiness-{id}"),
+        conditions,
+        outbound,
+        must,
+        mark,
+    }
+}
+
+fn bitmap(mask: u32) -> DomainRouting {
+    let mut value = DomainRouting::default();
+    value.bitmap[0] = mask;
+    value
+}
+
+fn key(bytes: [u8; 16], prefix_len: u32) -> LpmKey {
+    LpmKey {
+        prefix_len,
+        data: std::array::from_fn(|index| {
+            u32::from_ne_bytes(bytes[index * 4..index * 4 + 4].try_into().unwrap())
+        }),
+    }
+}
+
+fn ip_key(value: &str) -> LpmKey {
+    let ip: IpAddr = value.parse().unwrap();
+    let mut bytes = [0; 16];
+    let prefix_len = match ip {
+        IpAddr::V4(ip) => {
+            bytes[..4].copy_from_slice(&ip.octets());
+            32
+        }
+        IpAddr::V6(ip) => {
+            bytes.copy_from_slice(&ip.octets());
+            128
+        }
+    };
+    key(bytes, prefix_len)
+}
+
+fn mac_key(mac: [u8; 6]) -> LpmKey {
+    let mut bytes = [0; 16];
+    bytes[10..].copy_from_slice(&mac);
+    key(bytes, 128)
+}
+
+fn readiness_plan(facts: RoutingFactMaps) -> RoutingPushPlan {
+    RoutingPushPlan {
+        rules: vec![
+            // Each failure edge is deliberately reachable: the scalar gate can
+            // fail before any fact, while each fact and the family gate can fail
+            // after a different prefix of the fact categories was computed.
+            kernel_rule(
+                0,
+                vec![
+                    condition(false, KernelPredicate::Protocol(1)),
+                    condition(false, KernelPredicate::DestinationIp(0)),
+                    condition(false, KernelPredicate::SourceIp(0)),
+                    condition(false, KernelPredicate::Mac(0)),
+                    condition(false, KernelPredicate::IpVersion(1)),
+                ],
+                0,
+                0xa00,
+                false,
+            ),
+            kernel_rule(
+                1,
+                vec![
+                    condition(false, KernelPredicate::DestinationIp(1)),
+                    condition(false, KernelPredicate::SourceIp(1)),
+                    condition(false, KernelPredicate::Mac(1)),
+                ],
+                2,
+                0xa01,
+                true,
+            ),
+            kernel_rule(
+                2,
+                vec![condition(true, KernelPredicate::DestinationIp(1))],
+                1,
+                0xa02,
+                false,
+            ),
+            kernel_rule(
+                3,
+                vec![condition(true, KernelPredicate::SourceIp(1))],
+                1,
+                0xa03,
+                false,
+            ),
+            kernel_rule(
+                4,
+                vec![condition(true, KernelPredicate::Mac(1))],
+                1,
+                0xa04,
+                false,
+            ),
+        ],
+        facts,
+        fallback: 0,
+        features: 0,
+        fingerprint: [0; 32],
+        has_domain_rules: false,
+        domain_predicate_count: 0,
+    }
+}
+
+#[test]
+#[ignore = "requires root, Linux 6.12+, and HONK_ROUTING_TEST_OBJECT"]
+fn fact_readiness_failure_joins_preserve_full_decisions() {
+    let all = bitmap(0b11);
+    let second_only = bitmap(0b10);
+    let facts = RoutingFactMaps {
+        destination_v4: vec![
+            (ip_key("192.0.2.10"), all),
+            (ip_key("192.0.2.11"), second_only),
+        ],
+        destination_v6: vec![(ip_key("2001:db8::10"), all)],
+        source_v4: vec![
+            (ip_key("198.51.100.10"), all),
+            (ip_key("198.51.100.11"), second_only),
+        ],
+        source_v6: vec![(ip_key("2001:db8::20"), all)],
+        mac: vec![
+            (mac_key([2, 0, 0, 0, 0, 10]), all),
+            (mac_key([2, 0, 0, 0, 0, 11]), second_only),
+            (mac_key([0; 6]), DomainRouting::default()),
+        ],
+    };
+    let plan = readiness_plan(facts);
+    let mut backend = RealEbpfBackend::load_routing_test_fixture(&object()).unwrap();
+    backend.publish_routing_plan(&plan, &[]).unwrap();
+
+    let mut full = golden::connection();
+    full.dst_ip = "192.0.2.10".parse().unwrap();
+    full.src_ip = "198.51.100.10".parse().unwrap();
+    full.mac = Some("02:00:00:00:00:0a".into());
+
+    let mut scalar_miss = full.clone();
+    scalar_miss.protocol = "udp";
+    let mut destination_miss = full.clone();
+    destination_miss.dst_ip = "192.0.2.11".parse().unwrap();
+    let mut source_miss = full.clone();
+    source_miss.src_ip = "198.51.100.11".parse().unwrap();
+    let mut mac_miss = full.clone();
+    mac_miss.mac = Some("02:00:00:00:00:0b".into());
+    let mut ipv6 = golden::connection();
+    ipv6.dst_ip = "2001:db8::10".parse().unwrap();
+    ipv6.src_ip = "2001:db8::20".parse().unwrap();
+    ipv6.mac = full.mac.clone();
+    let mut absent_mac = full.clone();
+    absent_mac.mac = None;
+    let mut zero_mac = full.clone();
+    zero_mac.mac = Some("00:00:00:00:00:00".into());
+
+    let positive = decision(2, 0xa01, true, 1, 1);
+    assert_route(
+        &mut backend,
+        "IPv4 all-positive first rule",
+        &input(&full),
+        decision(0, 0xa00, false, 1, 0),
+    );
+
+    for (label, connection, expected) in [
+        ("scalar failure before first lookup", &scalar_miss, positive),
+        (
+            "destination failure after destination lookup",
+            &destination_miss,
+            positive,
+        ),
+        (
+            "source failure after destination/source lookups",
+            &source_miss,
+            positive,
+        ),
+        ("MAC failure after all fact categories", &mac_miss, positive),
+        (
+            "scalar failure after a prior cached path",
+            &scalar_miss,
+            positive,
+        ),
+        ("IPv6 family selects IPv6 fact maps", &ipv6, positive),
+    ] {
+        assert_route(&mut backend, label, &input(connection), expected);
+    }
+
+    let mut invalid = input(&full);
+    invalid.ip_version = 3;
+    assert_route(
+        &mut backend,
+        "invalid family is an absent destination fact",
+        &invalid,
+        decision(1, 0xa02, false, 1, 2),
+    );
+    assert_route(
+        &mut backend,
+        "absent MAC is a cached NULL negative fact",
+        &input(&absent_mac),
+        decision(1, 0xa04, false, 1, 4),
+    );
+    assert_route(
+        &mut backend,
+        "present all-zero MAC is also a negative fact",
+        &input(&zero_mac),
+        decision(1, 0xa04, false, 1, 4),
+    );
+}
+
+#[test]
+#[ignore = "requires root, Linux 6.12+, and HONK_ROUTING_TEST_OBJECT"]
+fn fact_readiness_independent_bitmap_states() {
+    // Missing, present-zero, first bit, second bit, and both bits must remain
+    // independent across categories at every failure join.
+    let masks = [0, 0, 1, 2, 3];
+    let mut facts = RoutingFactMaps::default();
+    for (index, mask) in masks.iter().copied().enumerate().skip(1) {
+        let value = bitmap(mask);
+        facts
+            .destination_v4
+            .push((ip_key(&format!("192.0.2.{index}")), value));
+        facts
+            .source_v4
+            .push((ip_key(&format!("198.51.100.{index}")), value));
+        facts
+            .destination_v6
+            .push((ip_key(&format!("2001:db8::{index}")), value));
+        facts
+            .source_v6
+            .push((ip_key(&format!("2001:db9::{index}")), value));
+        facts
+            .mac
+            .push((mac_key([2, 0, 0, 0, 0, index as u8]), value));
+    }
+    let mut backend = RealEbpfBackend::load_routing_test_fixture(&object()).unwrap();
+    backend
+        .publish_routing_plan(&readiness_plan(facts), &[])
+        .unwrap();
+    let mut comparisons = 0;
+    for ipv6 in [false, true] {
+        for tcp in [false, true] {
+            for (destination, destination_bits) in masks.iter().enumerate() {
+                for (source, source_bits) in masks.iter().enumerate() {
+                    for (mac, mac_bits) in masks.iter().enumerate() {
+                        let mut connection = golden::connection();
+                        connection.protocol = if tcp { "tcp" } else { "udp" };
+                        connection.dst_ip = if ipv6 {
+                            format!("2001:db8::{destination}")
+                        } else {
+                            format!("192.0.2.{destination}")
+                        }
+                        .parse()
+                        .unwrap();
+                        connection.src_ip = if ipv6 {
+                            format!("2001:db9::{source}")
+                        } else {
+                            format!("198.51.100.{source}")
+                        }
+                        .parse()
+                        .unwrap();
+                        connection.mac = Some(format!("02:00:00:00:00:{mac:02x}"));
+                        let common = destination_bits & source_bits & mac_bits;
+                        let expected = if tcp && !ipv6 && common & 1 != 0 {
+                            decision(0, 0xa00, false, 1, 0)
+                        } else if common & 2 != 0 {
+                            decision(2, 0xa01, true, 1, 1)
+                        } else if destination_bits & 2 == 0 {
+                            decision(1, 0xa02, false, 1, 2)
+                        } else if source_bits & 2 == 0 {
+                            decision(1, 0xa03, false, 1, 3)
+                        } else {
+                            decision(1, 0xa04, false, 1, 4)
+                        };
+                        assert_route(
+                            &mut backend,
+                            &format!(
+                                "v6={ipv6}/tcp={tcp}/dst={destination}/src={source}/mac={mac}"
+                            ),
+                            &input(&connection),
+                            expected,
+                        );
+                        comparisons += 1;
+                    }
+                }
+            }
+        }
+    }
+    eprintln!("readiness: {comparisons} independent bitmap-state decisions");
+}

--- a/doc/en/design/routing.md
+++ b/doc/en/design/routing.md
@@ -159,6 +159,15 @@ look up unreached categories, but repeated categories pay stack initialization.
 No fact pointer survives the invocation or crosses a generation. The entry
 domain lookup remains unchanged because it also determines `domain_final`.
 
+Emission tracks three-bit definite/possible readiness masks. Every failed
+condition is a predecessor of the next rule: definite readiness intersects at
+that join, while possible readiness unions. A known first use omits the ready
+check, a definitely ready use only reloads its pointer, and an uncertain use
+keeps the runtime guard. NULL and missing-input results count as computed;
+negation does not change that state. Cache initialization remains unchanged.
+IPv4/IPv6 key construction and map selection join at one lookup call; only
+IPv4 key padding is zeroed, without clearing bytes immediately overwritten.
+
 Fact preparation keeps hash-first duplicate coalescing, sorts only unique keys,
 and applies ancestor inheritance in the original vector before compacting its
 retained capacity. Assembler-owned ordinal labels identify internal branches;

--- a/doc/zh/design/routing.md
+++ b/doc/zh/design/routing.md
@@ -98,6 +98,12 @@ IP 分 family，避免 IPv6 前缀误匹配 mapped IPv4。更具体的 LPM 条�
 不预查未到达的类别，但重复类别仍有入口栈初始化成本。fact pointer 不跨调用或
 generation 保留。domain 入口 lookup 不变，因为它还负责确定 `domain_final`。
 
+发射时用两个三位掩码跟踪“必然已计算”和“可能已计算”。每个失败条件都是下一规则的
+前驱：合流时前者取交集，后者取并集。确定首次使用时省去 ready 检查，必然已计算时只
+重载 pointer，不确定时保留运行时守卫。NULL 和输入缺失也算完成计算，否定不改变此
+状态；入口缓存初始化保持不变。IPv4/IPv6 分别构造 key、选择 map，再合流到一次
+lookup；仅清零 IPv4 key 的 padding，不清零马上会被覆盖的字节。
+
 事实准备先用 hash 合并重复键，只排序唯一键，再在原向量中继承祖先位并压缩保留容量。
 内部跳转由 assembler 自己分配的 ordinal label 标识，只有规则 source record 保留
 诊断文本。输入/输出偏移从共享 ABI 声明推导，不再独立维护一份偏移表。


### PR DESCRIPTION
## Problem

Follow-up to #192: lazy fact caching still emits redundant readiness checks and duplicated family-specific lookup code. #192 is now merged; this branch is rebased on `c6a76ca` and contains only the follow-up optimization.

## How I fixed it

Propagate definite/possible fact readiness across every condition-failure join, retaining runtime guards only for uncertain paths. Share the IPv4/IPv6 lookup site and remove overwritten key stores while preserving lazy NULL handling, full-width stack initialization, the decision ABI and publication ordering. Add independent failure-join/bitmap regressions and update both routing design documents.

## Verified

At head `6b700f9`, both 10.10.10.49 (Arch 7.2.3) and 10.10.10.117 (Debian 6.12.94) passed 257 tests each, covering all 15 matcher fields in both polarities, all four dial modes, 468 kernel goldens and 500 independent bitmap cases per host. [Pinned logs, coverage and hashes](https://github.com/Glassyiris/honk/tree/c137461c358f961d9fea079270371c652428dc4d/bench/results/routing-fact-ready-flow-2026-09-10/hosts-49-117). Tests used isolated BPF_TEST_RUN and geo files copied read-only from VyOS; existing services were untouched. [Corrected benchmarks](https://github.com/Glassyiris/honk/blob/c137461c358f961d9fea079270371c652428dc4d/bench/results/routing-fact-ready-flow-2026-09-10/summary.json) show lower JIT/verifier cost but retain latency regressions; no live-traffic or whole-gateway throughput claim. Rebase validation at `179e8da`: all five PR files are byte-identical to `6b700f9`; fmt, workspace tests (2040 passed with the existing legacy routing exclusion), nine real-routing tests, and workspace/eBPF clippy passed again. The two-host results above remain the original `6b700f9` run.
