### PR TITLE
fix(config): escape the fields that make up a node identity

### DIFF
--- a/crates/honk-config/src/config.rs
+++ b/crates/honk-config/src/config.rs
@@ -694,30 +694,19 @@ impl Config {
                     node.name, transport.transport
                 )));
             }
-            if let Some(vless) = node.vless() {
-                if let Some(flow) = vless.flow.as_deref() {
-                    if vless.tls.reality_public_key.is_none() && !vless.tls.enabled {
-                        return Err(crate::ConfigError::Validation(format!(
-                            "Node '{}' sets flow '{}' without TLS or REALITY",
-                            node.name, flow
-                        )));
-                    }
-                    if flow != "xtls-rprx-vision" {
-                        return Err(crate::ConfigError::Validation(format!(
-                            "Node '{}' has unsupported flow '{}' (expected xtls-rprx-vision)",
-                            node.name, flow
-                        )));
-                    }
-                }
-                if vless
-                    .encryption
-                    .as_deref()
-                    .is_some_and(|value| !value.is_empty() && value != "none")
-                    && vless.flow.as_deref().is_some_and(|flow| !flow.is_empty())
-                {
+            if let Some(vless) = node.vless()
+                && let Some(flow) = vless.flow.as_deref()
+            {
+                if vless.tls.reality_public_key.is_none() && !vless.tls.enabled {
                     return Err(crate::ConfigError::Validation(format!(
-                        "Node '{}' combines VLESS Encryption with flow; this combination is unsupported",
-                        node.name
+                        "Node '{}' sets flow '{}' without TLS or REALITY",
+                        node.name, flow
+                    )));
+                }
+                if flow != "xtls-rprx-vision" {
+                    return Err(crate::ConfigError::Validation(format!(
+                        "Node '{}' has unsupported flow '{}' (expected xtls-rprx-vision)",
+                        node.name, flow
                     )));
                 }
             }

--- a/crates/honk-config/src/node.rs
+++ b/crates/honk-config/src/node.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use serde::{Deserialize, Serialize};
 
 mod protocol;
@@ -310,18 +312,22 @@ impl Node {
         Ok(())
     }
 
+    pub(crate) fn identity_material(&self) -> String {
+        format!(
+            "{}|{}|{}|{}|{}",
+            self.protocol().as_str(),
+            identity_field(self.host()),
+            self.port,
+            self.outbound.credential_fingerprint(),
+            self.outbound.dial_shape_fingerprint()
+        )
+    }
+
     /// Content-derived stable identity: UUID v5 over
     /// `protocol|host|port|credential-fingerprint|dial-shape`.
     /// Explicit ALPN derives a child UUID from the legacy ID and an ordered JSON list.
     pub fn derive_id(&self) -> uuid::Uuid {
-        let material = format!(
-            "{}|{}|{}|{}|{}",
-            self.protocol().as_str(),
-            self.host(),
-            self.port,
-            self.outbound.credential_fingerprint(),
-            self.outbound.dial_shape_fingerprint()
-        );
+        let material = self.identity_material();
         let legacy_id = uuid::Uuid::new_v5(&NODE_ID_NAMESPACE, material.as_bytes());
         if let Some(tls) = self.tls().filter(|tls| !tls.alpn.is_empty()) {
             let alpn = serde_json::to_vec(&("tls-alpn", &tls.alpn))
@@ -331,6 +337,26 @@ impl Node {
             legacy_id
         }
     }
+}
+
+/// Escape raw identity fields without changing ordinary nodes' legacy material.
+/// Both `|` and `\` must be escaped so different field splits stay distinct (#193).
+fn identity_field(value: &str) -> Cow<'_, str> {
+    let escapes = value
+        .bytes()
+        .filter(|byte| matches!(byte, b'|' | b'\\'))
+        .count();
+    if escapes == 0 {
+        return Cow::Borrowed(value);
+    }
+    let mut escaped = String::with_capacity(value.len() + escapes);
+    for character in value.chars() {
+        if matches!(character, '|' | '\\') {
+            escaped.push('\\');
+        }
+        escaped.push(character);
+    }
+    Cow::Owned(escaped)
 }
 
 /// A group of nodes for load balancing / failover.
@@ -565,6 +591,16 @@ mod tests {
                 "4133852f-b86f-5a8f-b8fb-b335023645fe",
             ),
             (
+                "vless-encrypted",
+                "vless://b@example.com:443?encryption=a#encrypted",
+                "9add2074-63e8-5b29-ba6b-26ed937d2464",
+            ),
+            (
+                "vless-populated-dial",
+                "vless://uuid@example.com:443?security=reality&type=ws&sni=cdn.example.com&path=%2Fp&host=ws.example.com&pbk=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&sid=abcd&spx=%2Fprobe#populated",
+                "529c3f31-3295-54f2-86e5-15cfc43f1a39",
+            ),
+            (
                 "hysteria2",
                 "hysteria2://secret@example.com:443#hysteria2",
                 "f622cf2a-ef2e-5777-abdb-d8c826d11f57",
@@ -590,6 +626,66 @@ mod tests {
             let node = Node::from_share_link(link).unwrap();
             assert_eq!(node.id.to_string(), expected, "{name}");
         }
+    }
+
+    #[test]
+    fn test_identity_credential_split() {
+        for [left, right] in ["socks5", "ss", "tuic", "juicity"].map(|p| {
+            ["a%7Cb:c", "a:b%7Cc"].map(|c| Node::from_share_link(&format!("{p}://{c}@h")).unwrap())
+        }) {
+            assert_ne!(left.id, right.id);
+        }
+    }
+
+    #[test]
+    fn test_identity_vless_credential_arity() {
+        let left = Node::from_share_link("vless://b@example.com:443?encryption=a").unwrap();
+        let right = Node::from_share_link("vless://a%7Cb@example.com:443").unwrap();
+        assert_ne!(left.id, right.id);
+    }
+
+    #[test]
+    fn test_identity_dial_shape_split() {
+        let left =
+            Node::from_share_link("vless://uuid@example.com:443?type=ws&sni=a%7Cws&path=%2Fp")
+                .unwrap();
+        let right =
+            Node::from_share_link("vless://uuid@example.com:443?type=ws&sni=a&path=ws%7C%2Fp")
+                .unwrap();
+        assert_ne!(left.id, right.id);
+    }
+
+    #[test]
+    fn test_identity_effective_host_split() {
+        let mut node = Node::from_share_link("socks5://a:b@h:443").unwrap();
+        let plain_id = node.derive_id();
+        node.host = "h|1080".into();
+        assert!(node.identity_material().contains(r"|h\|1080|"));
+        assert_ne!(node.derive_id(), plain_id);
+    }
+
+    #[test]
+    fn test_identity_vless_layout_control() {
+        let encrypted =
+            Node::from_share_link("vless://b@example.com:443?encryption=a&sni=tcp").unwrap();
+        let xudp =
+            Node::from_share_link("vless://a@example.com:443?vless_mode=xudp&sni=b").unwrap();
+        for node in [&encrypted, &xudp] {
+            crate::Config {
+                nodes: vec![node.clone()],
+                ..Default::default()
+            }
+            .validate()
+            .unwrap();
+        }
+        assert_ne!(encrypted.id, xudp.id);
+    }
+
+    #[test]
+    fn test_identity_escape_mutation_check() {
+        let left = [r"|\", ""].map(identity_field).join("|");
+        let right = [r"\", "|"].map(identity_field).join("|");
+        assert_ne!(left, right);
     }
 
     #[test]

--- a/crates/honk-config/src/node/protocol.rs
+++ b/crates/honk-config/src/node/protocol.rs
@@ -1,6 +1,6 @@
 use crate::types::NodeProtocol;
 
-use super::WireMode;
+use super::{WireMode, identity_field};
 
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct TlsOptions {
@@ -107,6 +107,16 @@ pub struct VlessConfig {
 
 impl VlessConfig {
     pub fn validate(&self, name: &str) -> Result<(), crate::ConfigError> {
+        if self
+            .encryption
+            .as_deref()
+            .is_some_and(|value| !value.is_empty() && value != "none")
+            && self.flow.as_deref().is_some_and(|flow| !flow.is_empty())
+        {
+            return Err(crate::ConfigError::Validation(format!(
+                "Node '{name}' combines VLESS Encryption with flow; this combination is unsupported"
+            )));
+        }
         if self.mode != WireMode::Legacy {
             if let Some(flow) = self.flow.as_deref().filter(|flow| !flow.is_empty())
                 && !(self.mode == WireMode::Xudp && flow == "xtls-rprx-vision")
@@ -314,43 +324,38 @@ impl OutboundConfig {
 
     pub(crate) fn credential_fingerprint(&self) -> String {
         match self {
-            Self::Shadowsocks(config) => format!(
-                "{}|{}",
+            Self::Shadowsocks(config) => identity_join(&[
                 config.encryption.as_deref().unwrap_or(""),
-                config.password.as_deref().unwrap_or("")
-            ),
-            Self::Trojan(config) => config.password.as_deref().unwrap_or("").to_string(),
-            Self::Vmess(config) => config.uuid.as_deref().unwrap_or("").to_string(),
+                config.password.as_deref().unwrap_or(""),
+            ]),
+            Self::Trojan(config) => identity_join(&[config.password.as_deref().unwrap_or("")]),
+            Self::Vmess(config) => identity_join(&[config.uuid.as_deref().unwrap_or("")]),
             Self::Vless(config)
                 if config
                     .encryption
                     .as_deref()
                     .is_some_and(|value| !value.is_empty() && value != "none") =>
             {
-                format!(
-                    "{}|{}",
+                identity_join(&[
                     config.encryption.as_deref().unwrap_or_default(),
-                    config.uuid.as_deref().unwrap_or("")
-                )
+                    config.uuid.as_deref().unwrap_or(""),
+                ])
             }
-            Self::Vless(config) => config.uuid.as_deref().unwrap_or("").to_string(),
-            Self::Socks5(config) => format!(
-                "{}|{}",
+            Self::Vless(config) => identity_join(&[config.uuid.as_deref().unwrap_or("")]),
+            Self::Socks5(config) => identity_join(&[
                 config.username.as_deref().unwrap_or(""),
-                config.password.as_deref().unwrap_or("")
-            ),
-            Self::Hysteria2(config) => config.auth.as_deref().unwrap_or("").to_string(),
-            Self::Tuic(config) => format!(
-                "{}|{}",
+                config.password.as_deref().unwrap_or(""),
+            ]),
+            Self::Hysteria2(config) => identity_join(&[config.auth.as_deref().unwrap_or("")]),
+            Self::Tuic(config) => identity_join(&[
                 config.uuid.as_deref().unwrap_or(""),
-                config.password.as_deref().unwrap_or("")
-            ),
-            Self::Juicity(config) => format!(
-                "{}|{}",
+                config.password.as_deref().unwrap_or(""),
+            ]),
+            Self::Juicity(config) => identity_join(&[
                 config.uuid.as_deref().unwrap_or(""),
-                config.password.as_deref().unwrap_or("")
-            ),
-            Self::AnyTls(config) => config.password.as_deref().unwrap_or("").to_string(),
+                config.password.as_deref().unwrap_or(""),
+            ]),
+            Self::AnyTls(config) => identity_join(&[config.password.as_deref().unwrap_or("")]),
             Self::Direct | Self::Block => String::new(),
         }
     }
@@ -385,13 +390,27 @@ impl OutboundConfig {
                 _ => "",
             },
         ]
+        .map(identity_field)
         .join("|");
         if let Self::Vless(config) = self
             && config.mode != WireMode::Legacy
         {
             fingerprint.push('|');
-            fingerprint.push_str(config.mode.as_str());
+            fingerprint.push_str(&identity_field(config.mode.as_str()));
         }
         fingerprint
     }
+}
+
+fn identity_join(fields: &[&str]) -> String {
+    let capacity =
+        fields.iter().map(|field| field.len()).sum::<usize>() + fields.len().saturating_sub(1);
+    let mut identity = String::with_capacity(capacity);
+    for (index, field) in fields.iter().enumerate() {
+        if index != 0 {
+            identity.push('|');
+        }
+        identity.push_str(&identity_field(field));
+    }
+    identity
 }

--- a/crates/honk-config/tests/share_link.rs
+++ b/crates/honk-config/tests/share_link.rs
@@ -1096,10 +1096,11 @@ fn test_vless_encryption_param_and_identity() {
 #[test]
 fn test_validate_rejects_vless_encryption_with_flow() {
     let encryption = "mlkem768x25519plus.native.1rtt.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-    let node = Node::from_share_link(&format!(
-        "vless://uuid@example.com:443?security=tls&flow=xtls-rprx-vision&encryption={encryption}#encrypted-flow"
+    let mut node = Node::from_share_link(&format!(
+        "vless://uuid@example.com:443?security=tls&encryption={encryption}#encrypted-flow"
     ))
     .unwrap();
+    node.vless_mut().unwrap().flow = Some("xtls-rprx-vision".into());
     let mut config = Config::default();
     config.nodes.push(node);
     let error = config.validate().unwrap_err();

--- a/crates/honk-core/src/subscription/tests.rs
+++ b/crates/honk-core/src/subscription/tests.rs
@@ -223,6 +223,30 @@ fn test_parse_subscription_keeps_unique_nodes_with_duplicates() {
 }
 
 #[test]
+fn test_parse_subscription_rejects_encrypted_vless_flow_before_deduplication() {
+    let invalid = "vless://u@h:443?encryption=e&type=ws&sni=ws&flow=xudp#a";
+    let valid = "vless://e@h:443?type=ws&sni=u&path=ws&vless_mode=xudp#b";
+    let sub = Subscription {
+        sub_type: SubscriptionType::Simple,
+        ..Default::default()
+    };
+    let nodes = parse_subscription_content(&sub, &format!("{invalid}\n{valid}")).unwrap();
+    assert_eq!(
+        nodes
+            .iter()
+            .map(|node| node.name.as_str())
+            .collect::<Vec<_>>(),
+        ["b"]
+    );
+    let error = Node::from_share_link(invalid).unwrap_err();
+    assert!(matches!(
+        error,
+        honk_config::ConfigError::Validation(message)
+            if message == "Node 'a' combines VLESS Encryption with flow; this combination is unsupported"
+    ));
+}
+
+#[test]
 fn test_parse_subscription_skips_proxy_plugins() {
     let clash = Subscription {
         sub_type: SubscriptionType::Clash,

--- a/doc/en/reference/nodes.md
+++ b/doc/en/reference/nodes.md
@@ -33,6 +33,10 @@ protocol|host|port|credential-fingerprint|dial-shape
 
 The credential fingerprint follows each handler's field precedence. The legacy dial shape includes `sni`, transport, WebSocket/gRPC shape, Hysteria2 obfuscation, REALITY parameters, `flow`, and every non-`legacy` VLESS mode. Nonempty structured `tls_alpn` derives a child UUID v5 using the legacy ID as its namespace and the JSON tuple `["tls-alpn", <ordered list>]` as its name; this separates ALPN from arbitrary credential text. Empty `tls_alpn` retains legacy IDs. Tuning and display metadata do not participate.
 
+Before joining, each raw credential and dial-shape field and the effective host escapes `\` as `\\` and `|` as `\|`. Joined fingerprints are not escaped again. For nodes accepted by `Config::validate`, different identity fields produce different hash material. This guarantee does not cover nodes rejected by full configuration validation, even if `Node::from_share_link` can derive their IDs.
+
+At this upgrade, a node with `|` or `\` in one of these pipe-joined identity fields receives a new ID once; its ID-keyed health and warm state starts fresh. Nodes without either character in those fields retain their IDs. ALPN uses the separate JSON child-UUID step, so `|` or `\` in ALPN alone does not change an existing ID at this upgrade. Selector choices migrate by member name, pooled ready streams already retire per generation, and `name`/`subtag` filters are unaffected.
+
 Identity is therefore stable across rename, reload, and subscription refresh when the dialable endpoint is unchanged. Configuration/runtime assembly rejects duplicate derived IDs. `Node::default()` has a nil ID; construction paths derive it, and the outbound runtime registry rejects any nil ID that reaches it.
 
 ## Node fields

--- a/doc/zh/reference/nodes.md
+++ b/doc/zh/reference/nodes.md
@@ -33,6 +33,10 @@ protocol|host|port|credential-fingerprint|dial-shape
 
 凭据指纹遵循各 handler 的字段优先级。旧版 dial shape 包含 `sni`、transport、WebSocket/gRPC 形态、Hysteria2 混淆、REALITY 参数、`flow` 以及每种非 `legacy` VLESS mode。非空的结构化 `tls_alpn` 以旧 ID 为 namespace、JSON 元组 `["tls-alpn", <有序列表>]` 为 name 派生子 UUID v5，从而将 ALPN 与任意凭据文本分离。空 `tls_alpn` 保留旧 ID。调优参数与显示元数据不参与。
 
+拼接前，每个原始凭据字段、拨号形态字段和有效的 `host` 值都会将 `\` 转义为 `\\`，将 `|` 转义为 `\|`。拼接后的指纹不再转义。对于通过 `Config::validate` 的节点，不同的身份字段会产生不同的哈希输入。完整配置校验拒绝的节点不在此保证范围内，即使 `Node::from_share_link` 能为其派生 ID。
+
+本次升级时，上述以 `|` 拼接的身份字段中含有 `|` 或 `\` 的节点，其 ID 会变更一次，以 ID 为键的健康状态和预热状态会重新建立。这些字段不含两种字符的节点保留原 ID。ALPN 使用独立的 JSON 子 UUID 派生步骤，因此仅 ALPN 含有 `|` 或 `\` 不会在本次升级时改变已有 ID。Selector 选择按成员名称迁移。连接池中的就绪流原本就会在所属配置版本退出时移除。`name`/`subtag` 筛选器不受影响。
+
 因此，只要可拨号端点不变，身份在改名、reload 和订阅刷新后仍保持稳定。配置/运行时组装会拒绝重复的派生 ID。`Node::default()` 的 ID 为 nil；构造路径会派生 ID，出站运行时注册表会拒绝任何抵达该处的 nil ID。
 
 ## 节点字段


### PR DESCRIPTION
## Problem

`Node::derive_id` hashes `protocol|host|port|<credential fingerprint>|<dial shape fingerprint>`, and both fingerprints are themselves `|`-joined from raw fields (`node/protocol.rs`). Nothing escapes the fields, and `|` is legal in most of them: RFC 1929 makes SOCKS5 usernames and passwords opaque, and the share-link parser percent-decodes them. So two nodes with different credentials can hash the same material (#193):

```
socks5://a%7Cb:c@127.0.0.1:1080   username "a|b", password "c"  → a|b|c
socks5://a:b%7Cc@127.0.0.1:1080   username "a",   password "b|c" → a|b|c
```

In one configuration the second node is rejected as a duplicate for a reason the operator cannot see. Across a reload, rotating from one link to the other keeps the id, so health and warm state keyed on it carry over to a node whose credentials changed. VLESS has the same problem between its one-field and two-field credential layouts, and SNI, paths, service names and REALITY fields have it in the dial shape.

## How I fixed it

One commit. A private `identity_field` helper escapes `\` as `\\` and `|` as `\|`, and every raw field that enters the material goes through it: each credential arm including the single-field ones, every dial-shape field and the VLESS mode suffix, and the effective host in `derive_id`. The joins, field order, arity, namespace UUID and the ALPN child-UUID step are unchanged, and the two fingerprints are not escaped again at the outer join.

A field free of both characters is returned unchanged, so the material, and the id, of every node whose fields contain neither `|` nor `\` is byte-identical to today's. That keeps the legacy-id requirement in `AGENTS.md` for every node that is not broken today. A node with `|` or `\` in one of those fields gets a new id once at this upgrade; ALPN is not one of them. The uniqueness guarantee covers nodes `Config::validate` accepts: VLESS has two twelve-field layouts (encrypted legacy, unencrypted non-legacy) that cannot collide there because validation forces the flow field empty when encryption is set and the mode name is never empty. The one VLESS rule that made that guarantee depend on `Config::validate`, encryption combined with a flow, now lives in `VlessConfig::validate`, so the subscription path, which deliberately skips whole-config validation, enforces it too: such a node is rejected at ingest with the same message instead of loading and colliding with a valid unencrypted node. `AGENTS.md` already described the rule as node-level. No id moves.

`derive_id`'s material construction is now `identity_material()` so the escaping can be asserted where it happens. Both `doc/*/reference/nodes.md` state the rule, the migration boundary and the guarantee. The ten credential arms share one `identity_join` helper, so each arm is a single expression.

## Verified

- `cargo fmt --all -- --check`, `cargo clippy --all --all-targets -- -D warnings`, `cargo test -p honk-config`, `cargo test --workspace --no-fail-fast -- --skip test_routing_with_config_dae`: all exit 0 on the final commit (workspace: 2064 passed, 0 failed).
- Failing-first: SOCKS5, Shadowsocks, TUIC, Juicity credential splits, the VLESS one-versus-two-field layout, and an adjacent-field dial-shape split (`sni = "a|ws"`/`ws_path = "/p"` versus `sni = "a"`/`ws_path = "ws|/p"`) all produce equal ids on `main` and different ids after. Two controls that pass on both sides: the VLESS twelve-field layout pair, and the escape mutation check (`["|\", ""]` versus `["\", "|"]`), which fails only if pipes are escaped and backslashes are not.
- Failing-first through `parse_subscription_content`: an encrypted VLESS node with a flow is rejected with the message and the valid node beside it survives; reverting the moved check fails it.
- Stability: the existing `test_protocol_identity_goldens` UUID literals are untouched; two rows (encrypted VLESS, VLESS with SNI, ws path/host and REALITY fields) were captured from `main` before the change and added.
- Reviewer ablation on the final commit, one escaping site removed at a time: no escaping at all fails 4 tests (the credential splits are one table test); pipe-only escaping fails the mutation check; unescaped host fails the material assertion; unescaped VLESS singleton fails the layout test; unescaped dial fields fail the dial-shape test. All by assertion, no compile errors.
- Differential: the frozen parser corpus from #190 (230 files × 4 modes = 920 cells) dumped on this branch and on `origin/main`: 0 cells differ from the expectations on either side, and the two output trees are byte-identical. Derived ids are version-5 UUIDs the dumper preserves, so this is a machine check that no fixture's id moved.
- Not run: `just test-routing`, `just test-netns`, the eBPF job.

Closes #193.

---

- [x] `just fmt`, `just lint` and `just test-ci` pass.
- [x] I updated `doc/en/` and `doc/zh/` if I changed documented behaviour.
- [x] If I used AI: it followed `CONTRIBUTING.md` and `AGENTS.md`, and Verified shows what I ran, not guesses.


