### PR TITLE
test(config): stop the compat-entry logging test racing the tracing interest cache

### DIFF
--- a/crates/honk-config/src/parser/tests.rs
+++ b/crates/honk-config/src/parser/tests.rs
@@ -77,38 +77,6 @@ global {
     }
 
     #[test]
-    fn test_millisecond_duration_compat_entry_logs_warning() {
-        #[derive(Clone)]
-        struct Writer(std::sync::Arc<parking_lot::Mutex<Vec<u8>>>);
-
-        impl std::io::Write for Writer {
-            fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
-                self.0.lock().extend_from_slice(bytes);
-                Ok(bytes.len())
-            }
-
-            fn flush(&mut self) -> std::io::Result<()> {
-                Ok(())
-            }
-        }
-
-        let output = Writer(Default::default());
-        let writer = output.clone();
-        let subscriber = tracing_subscriber::fmt()
-            .with_ansi(false)
-            .without_time()
-            .with_max_level(tracing::Level::WARN)
-            .with_writer(move || writer.clone())
-            .finish();
-        tracing::subscriber::with_default(subscriber, || {
-            parse_dae_config("global {\n    check_tolerance: abc\n}").unwrap();
-        });
-        let bytes = output.0.lock();
-        let log = String::from_utf8_lossy(&bytes);
-        assert!(log.contains("global.check_tolerance"), "{log}");
-    }
-
-    #[test]
     fn test_timer_diagnostic_survives_later_parse_error() {
         let mut diagnostics = Vec::new();
         let result = parse_dae_config_with_diagnostics(

--- a/crates/honk-config/tests/compat_entry_logging.rs
+++ b/crates/honk-config/tests/compat_entry_logging.rs
@@ -1,0 +1,36 @@
+//! Keep this test alone in its binary: scoped-subscriber callsite interest is resolved through
+//! the registering thread's default (`Rebuilder::JustOne`). Another test reaching
+//! `report_diagnostics` first under `NoSubscriber` caches the callsite as never-interested.
+use honk_config::parser::parse_dae_config;
+
+#[test]
+fn test_millisecond_duration_compat_entry_logs_warning() {
+    #[derive(Clone)]
+    struct Writer(std::sync::Arc<parking_lot::Mutex<Vec<u8>>>);
+
+    impl std::io::Write for Writer {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    let output = Writer(Default::default());
+    let writer = output.clone();
+    let subscriber = tracing_subscriber::fmt()
+        .with_ansi(false)
+        .without_time()
+        .with_max_level(tracing::Level::WARN)
+        .with_writer(move || writer.clone())
+        .finish();
+    tracing::subscriber::with_default(subscriber, || {
+        parse_dae_config("global {\n    check_tolerance: abc\n}").unwrap();
+    });
+    let bytes = output.0.lock();
+    let log = String::from_utf8_lossy(&bytes);
+    assert!(log.contains("global.check_tolerance"), "{log}");
+}


### PR DESCRIPTION
## Problem

`test_millisecond_duration_compat_entry_logs_warning` installs a thread-local tracing subscriber with `with_default` and asserts on captured output, inside a test binary that runs tests on many threads. It fails 2 of 16 runs of the `honk-config` lib suite on unmodified `main`, never alone (#198).

The mechanism, checked against the pinned `tracing-core` sources by the second reviewer: with exactly one registered dispatcher, `Dispatchers::rebuilder()` returns `Rebuilder::JustOne` (`callsite.rs:544-548`), which resolves callsite interest through the *registering* thread's current default (`callsite.rs:562-566`). If another test's thread is the first to reach the `report_diagnostics` callsite while its default is still `NoSubscriber`, the callsite is cached as `Interest::never()` (`subscriber.rs:674-678`) and this test's warning is never delivered. The max-level hint is not involved, and dispatchers are not rebuilt on drop; the issue's original wording said otherwise and is corrected there.

## How I fixed it

No production change. The logging assertion moves to its own one-test integration binary, `crates/honk-config/tests/compat_entry_logging.rs`, with the scoped subscriber and the buffer unchanged; that process runs no other test, so nothing can race the callsite registration. The value itself (fallback, diagnostic count, setting, value) was already pinned by the existing `parser/tests.rs` case, which stays. A global `set_global_default` was considered and rejected: dispatcher construction rebuilds interest before publication, so it still races a concurrent first registration.

## Verified

- `cargo fmt --all -- --check`, `cargo clippy --all --all-targets -- -D warnings`, `cargo test -p honk-config`, `cargo test --workspace --no-fail-fast -- --skip test_routing_with_config_dae` (2057 passed, 0 failed): exit 0. The workspace gate runs integration tests, so the moved test stays in `just test-ci`.
- Loops: candidate lib suite at `RUST_TEST_THREADS=64`, 50 runs, 0 failures; candidate integration test, 50 runs, 0 failures; parent (`origin/main`) lib suite at 64 threads, 50 runs, 1 failure. A second, independent run: 200 runs of the new binary and 60 of the lib suite at 64 threads, 0 failures; parent flake 2 of 80. The default schedule did not reproduce the parent flake in 50 runs, which is recorded rather than claimed.
- One more test has the same shape and is left for a follow-up, not fixed here: `crates/honk-core/src/dns/transport/retry.rs:78` installs a scoped subscriber on a `debug!` callsite that four other tests in the same binary also reach.

Closes #198.

- CI: the `eBPF object + real VM kernel tests` job failed at its `Enable KVM` step (`test -r /dev/kvm -a -w /dev/kvm` on a runner without KVM), before building or running anything; the other four jobs pass. Not related to this change.

---

- [x] `just fmt`, `just lint` and `just test-ci` pass.
- [x] I updated `doc/en/` and `doc/zh/` if I changed documented behaviour.
- [x] If I used AI: it followed `CONTRIBUTING.md` and `AGENTS.md`, and Verified shows what I ran, not guesses.

