### PR TITLE
fix(tool): let diagnose fail, and keep scanning /proc past an unreadable entry

### DIFF
--- a/crates/honk-tool/README.md
+++ b/crates/honk-tool/README.md
@@ -125,8 +125,11 @@ tx/rx counters.
 ### `diagnose` — one-shot health check
 
 ```bash
-honk-tool diagnose [--api http://127.0.0.1:9090] [--pin-root PATH] [--tproxy-mark 0x8000000]
+honk-tool diagnose [--api http://127.0.0.1:9090] [--secret TOKEN] [--pin-root PATH] [--tproxy-mark 0x8000000]
 ```
+
+For an authenticated Clash API, supply `--secret TOKEN` or set `HONK_API_SECRET`.
+The flag takes precedence; the token is sent as `Authorization: Bearer`.
 
 Read-only checks, each printed as `[ok]` / `[FAIL]`:
 
@@ -136,9 +139,11 @@ Read-only checks, each printed as `[ok]` / `[FAIL]`:
 4. required pinned maps present (`CONN_STATE_MAP`, `REDIRECT_TRACK`,
    `ROUTING_HANDOFF_MAP`, `CONN_STATE_OCCUPANCY`),
 5. conn-state occupancy + overflow counters readable,
-6. clash API reachable (`/version`).
+6. clash API returns a 2xx status (`/version`), printing the response body;
+   a non-2xx status prints `[FAIL]` with the status text.
 
-Exits with `all checks passed` or `N issue(s) found`.
+Standard output ends with `diagnose: all checks passed` (exit status `0`) or
+`diagnose: N issue(s) found` (exit status `1`, with the count in the error message).
 
 ## Design notes
 

--- a/crates/honk-tool/README_CN.md
+++ b/crates/honk-tool/README_CN.md
@@ -97,8 +97,11 @@ honk-tool bpf stats [--pin-root PATH]
 ### `diagnose` — 一键体检
 
 ```bash
-honk-tool diagnose [--api http://127.0.0.1:9090] [--pin-root PATH] [--tproxy-mark 0x8000000]
+honk-tool diagnose [--api http://127.0.0.1:9090] [--secret TOKEN] [--pin-root PATH] [--tproxy-mark 0x8000000]
 ```
+
+Clash API 启用认证时，可传入 `--secret TOKEN` 或设置 `HONK_API_SECRET`。
+命令行参数优先；令牌通过 `Authorization: Bearer` 发送。
 
 只读检查，逐项打印 `[ok]` / `[FAIL]`:
 
@@ -108,9 +111,11 @@ honk-tool diagnose [--api http://127.0.0.1:9090] [--pin-root PATH] [--tproxy-mar
 4. 必需的 pin map 存在（`CONN_STATE_MAP`、`REDIRECT_TRACK`、
    `ROUTING_HANDOFF_MAP`、`CONN_STATE_OCCUPANCY`);
 5. conntrack 水位/溢出计数可读；
-6. clash API 可达（`/version`)。
+6. clash API 返回 2xx 状态码（`/version`），打印响应正文；
+   非 2xx 状态码则打印 `[FAIL]` 和状态文本。
 
-末尾输出 `all checks passed` 或 `N issue(s) found`。
+标准输出末尾为 `diagnose: all checks passed`（退出状态 `0`）或
+`diagnose: N issue(s) found`（退出状态 `1`，错误信息包含问题数量）。
 
 ## 设计说明
 

--- a/crates/honk-tool/src/diagnose.rs
+++ b/crates/honk-tool/src/diagnose.rs
@@ -3,7 +3,7 @@
 //! Read-only: inspects the process, namespace/veth plumbing, pinned maps,
 //! policy routing, and the clash API.  Requires root for the map reads.
 
-use std::path::PathBuf;
+use std::{ffi::OsString, io, path::PathBuf};
 
 use clap::Args;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
@@ -101,13 +101,27 @@ pub async fn run(args: DiagnoseArgs) -> anyhow::Result<()> {
 }
 
 fn find_engine() -> Option<(u32, String)> {
-    for entry in std::fs::read_dir("/proc").ok()? {
-        let entry = entry.ok()?;
-        let pid: u32 = match entry.file_name().to_str()?.parse() {
+    let entries = std::fs::read_dir("/proc").ok()?;
+    find_engine_in(entries.map(|entry| entry.map(|entry| (entry.file_name(), entry.path()))))
+}
+
+fn find_engine_in(
+    entries: impl Iterator<Item = io::Result<(OsString, PathBuf)>>,
+) -> Option<(u32, String)> {
+    for entry in entries {
+        let Ok((name, path)) = entry else {
+            continue;
+        };
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        let pid: u32 = match name.parse() {
             Ok(p) => p,
             Err(_) => continue,
         };
-        let comm = std::fs::read_to_string(entry.path().join("comm")).ok()?;
+        let Ok(comm) = std::fs::read_to_string(path.join("comm")) else {
+            continue;
+        };
         let comm = comm.trim().to_string();
         if comm == "honk-core" || comm == "honk" || comm == "dae" {
             return Some((pid, comm));
@@ -177,4 +191,32 @@ async fn reqwest_get(url: &str, secret: Option<&str>) -> anyhow::Result<String> 
     let mut body = String::new();
     reader.read_to_string(&mut body).await?;
     Ok(body)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+
+    use super::find_engine_in;
+
+    #[test]
+    fn find_engine_skips_unreadable_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing_comm = dir.path().join("100");
+        let engine = dir.path().join("200");
+        std::fs::create_dir(&missing_comm).unwrap();
+        std::fs::create_dir(&engine).unwrap();
+        std::fs::write(engine.join("comm"), "honk-core\n").unwrap();
+        let entries = [
+            Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied)),
+            Ok((OsString::from_vec(vec![0xff]), dir.path().to_path_buf())),
+            Ok(("100".into(), missing_comm)),
+            Ok(("200".into(), engine)),
+        ];
+
+        let found = find_engine_in(entries.into_iter());
+
+        assert_eq!(found, Some((200, "honk-core".to_owned())));
+    }
 }

--- a/crates/honk-tool/src/diagnose.rs
+++ b/crates/honk-tool/src/diagnose.rs
@@ -6,6 +6,7 @@
 use std::path::PathBuf;
 
 use clap::Args;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 
 #[derive(Args)]
 pub struct DiagnoseArgs {
@@ -15,6 +16,9 @@ pub struct DiagnoseArgs {
     /// Clash API base URL to probe (empty = skip API checks).
     #[arg(long, default_value = "http://127.0.0.1:9090")]
     pub api: String,
+    /// Clash API Bearer token (overrides HONK_API_SECRET).
+    #[arg(long, env = "HONK_API_SECRET", hide_env_values = true)]
+    pub secret: Option<String>,
     /// Expected TPROXY mark (hex, no 0x).
     #[arg(long, default_value_t = 0x0800_0000)]
     pub tproxy_mark: u32,
@@ -75,7 +79,7 @@ pub async fn run(args: DiagnoseArgs) -> anyhow::Result<()> {
 
     if !args.api.is_empty() {
         let url = format!("{}/version", args.api.trim_end_matches('/'));
-        match reqwest_get(&url).await {
+        match reqwest_get(&url, args.secret.as_deref()).await {
             Ok(body) => println!("[ok] clash API {}: {}", args.api, body.trim()),
             Err(e) => {
                 println!("[FAIL] clash API {}: {}", args.api, e);
@@ -92,6 +96,7 @@ pub async fn run(args: DiagnoseArgs) -> anyhow::Result<()> {
             format!("diagnose: {issues} issue(s) found")
         }
     );
+    anyhow::ensure!(issues == 0, "diagnose: {issues} issue(s) found");
     Ok(())
 }
 
@@ -126,7 +131,7 @@ fn run_cmd(cmd: &str, args: &[&str]) -> anyhow::Result<String> {
 }
 
 /// Minimal GET helper (avoids pulling reqwest into the tool for one call).
-async fn reqwest_get(url: &str) -> anyhow::Result<String> {
+async fn reqwest_get(url: &str, secret: Option<&str>) -> anyhow::Result<String> {
     let rest = url
         .strip_prefix("http://")
         .ok_or_else(|| anyhow::anyhow!("only http:// API URLs are supported"))?;
@@ -135,13 +140,41 @@ async fn reqwest_get(url: &str) -> anyhow::Result<String> {
         None => (rest, "/"),
     };
     let stream = tokio::net::TcpStream::connect(host).await?;
-    let (mut reader, mut writer) = tokio::io::split(stream);
-    tokio::io::AsyncWriteExt::write_all(
-        &mut writer,
-        format!("GET {path} HTTP/1.1\r\nHost: {host}\r\nConnection: close\r\n\r\n").as_bytes(),
-    )
-    .await?;
-    let mut buf = String::new();
-    tokio::io::AsyncReadExt::read_to_string(&mut reader, &mut buf).await?;
-    Ok(buf)
+    let (reader, mut writer) = tokio::io::split(stream);
+    let mut request = format!("GET {path} HTTP/1.1\r\nHost: {host}\r\nConnection: close\r\n");
+    if let Some(secret) = secret {
+        request.push_str("Authorization: Bearer ");
+        request.push_str(secret);
+        request.push_str("\r\n");
+    }
+    request.push_str("\r\n");
+    writer.write_all(request.as_bytes()).await?;
+
+    let mut reader = BufReader::new(reader);
+    let mut line = String::new();
+    reader.read_line(&mut line).await?;
+    let mut status = line.split_whitespace();
+    anyhow::ensure!(
+        matches!(status.next(), Some("HTTP/1.0" | "HTTP/1.1")),
+        "invalid HTTP status line"
+    );
+    let code = status
+        .next()
+        .filter(|code| code.len() == 3)
+        .and_then(|code| code.parse::<u16>().ok())
+        .ok_or_else(|| anyhow::anyhow!("invalid HTTP status code"))?;
+    anyhow::ensure!((200..300).contains(&code), "{}", line.trim_end());
+    loop {
+        line.clear();
+        anyhow::ensure!(
+            reader.read_line(&mut line).await? != 0,
+            "incomplete HTTP response headers"
+        );
+        if line == "\r\n" || line == "\n" {
+            break;
+        }
+    }
+    let mut body = String::new();
+    reader.read_to_string(&mut body).await?;
+    Ok(body)
 }

--- a/crates/honk-tool/tests/diagnose_cli.rs
+++ b/crates/honk-tool/tests/diagnose_cli.rs
@@ -1,0 +1,137 @@
+use std::os::unix::fs::PermissionsExt;
+use std::process::Output;
+
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::Command;
+
+fn diagnose(api: &str) -> (tempfile::TempDir, Command) {
+    let dir = tempfile::tempdir().unwrap();
+    let ip = dir.path().join("ip");
+    std::fs::write(
+        &ip,
+        "#!/bin/sh\nprintf '100: fwmark 0x8000000 lookup 100\\n'\n",
+    )
+    .unwrap();
+    std::fs::set_permissions(&ip, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let mut command = Command::new(env!("CARGO_BIN_EXE_honk-tool"));
+    command
+        .args(["diagnose", "--api", api, "--pin-root"])
+        .arg(dir.path().join("missing-pins"))
+        .env("PATH", dir.path())
+        .env_remove("HONK_API_SECRET");
+    (dir, command)
+}
+
+async fn api_check(required_secret: Option<&str>, flag: Option<&str>, env: Option<&str>) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let api = format!("http://{}", listener.local_addr().unwrap());
+    let authorization = required_secret.map(|secret| format!("Authorization: Bearer {secret}"));
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let mut reader = BufReader::new(stream);
+        let mut authorized = authorization.is_none();
+        loop {
+            let mut line = String::new();
+            assert_ne!(reader.read_line(&mut line).await.unwrap(), 0);
+            if line == "\r\n" {
+                break;
+            }
+            if authorization.as_deref() == Some(line.trim_end()) {
+                authorized = true;
+            }
+        }
+        let (status, body) = if authorized {
+            ("200 OK", r#"{"version":"diagnose-fixture"}"#)
+        } else {
+            ("401 Unauthorized", "unauthorized")
+        };
+        reader
+            .get_mut()
+            .write_all(
+                format!(
+                    "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                )
+                .as_bytes(),
+            )
+            .await
+            .unwrap();
+    });
+    let (_dir, mut command) = diagnose(&api);
+    if let Some(secret) = flag {
+        command.args(["--secret", secret]);
+    }
+    if let Some(secret) = env {
+        command.env("HONK_API_SECRET", secret);
+    }
+    let out = command.output().await.unwrap();
+    server.abort();
+    String::from_utf8(out.stdout)
+        .unwrap()
+        .replace(&api, "<api>")
+}
+
+#[tokio::test]
+async fn api_authentication_and_secret_precedence() {
+    let mut lines = Vec::new();
+    for (flag, env) in [
+        (None, None),
+        (Some("expected"), None),
+        (None, Some("expected")),
+        (Some("expected"), Some("wrong")),
+    ] {
+        let stdout = api_check(Some("expected"), flag, env).await;
+        lines.push(
+            stdout
+                .lines()
+                .find(|line| line.contains("clash API"))
+                .unwrap_or("API check not reached")
+                .to_owned(),
+        );
+    }
+    assert_eq!(
+        lines,
+        [
+            "[FAIL] clash API <api>: HTTP/1.1 401 Unauthorized",
+            "[ok] clash API <api>: {\"version\":\"diagnose-fixture\"}",
+            "[ok] clash API <api>: {\"version\":\"diagnose-fixture\"}",
+            "[ok] clash API <api>: {\"version\":\"diagnose-fixture\"}",
+        ]
+    );
+}
+
+#[tokio::test]
+async fn unauthenticated_api_success() {
+    let stdout = api_check(None, None, None).await;
+    assert!(stdout.contains("[ok] clash API <api>:"), "{stdout}");
+    assert!(
+        stdout.contains(r#"{"version":"diagnose-fixture"}"#),
+        "{stdout}"
+    );
+}
+
+#[tokio::test]
+async fn failed_checks_print_summary_and_exit_one() {
+    let (_dir, mut command) = diagnose("");
+    let Output {
+        status,
+        stdout,
+        stderr,
+    } = command.output().await.unwrap();
+    let stdout = String::from_utf8(stdout).unwrap();
+    let summary = stdout.lines().last().unwrap();
+    let count: usize = summary
+        .strip_prefix("diagnose: ")
+        .unwrap()
+        .strip_suffix(" issue(s) found")
+        .unwrap()
+        .parse()
+        .unwrap();
+    assert!(count > 0, "{stdout}");
+    assert_eq!(status.code(), Some(1), "{stdout}");
+    assert!(
+        String::from_utf8(stderr)
+            .unwrap()
+            .contains(&format!("{count} issue(s) found"))
+    );
+}

--- a/doc/en/reference/cli.md
+++ b/doc/en/reference/cli.md
@@ -170,16 +170,17 @@ The implementation opens pins with raw `bpf(2)` operations; it does not use aya,
 ### `diagnose`
 
 ```text
-honk-tool diagnose [--api URL] [--pin-root PATH] [--tproxy-mark VALUE]
+honk-tool diagnose [--api URL] [--secret TOKEN] [--pin-root PATH] [--tproxy-mark VALUE]
 ```
 
 | Option | Default | Meaning |
 | --- | --- | --- |
 | `--api URL` | `http://127.0.0.1:9090` | Plain-HTTP Clash API base URL. An empty value skips the API check; the built-in client does not support HTTPS. |
+| `--secret TOKEN` | `HONK_API_SECRET`, if set | Bearer token for the Clash API. The flag overrides the environment variable. |
 | `--pin-root PATH` | `/sys/fs/bpf` | Root used for pinned-map presence and statistics reads. |
 | `--tproxy-mark VALUE` | `134217728` (`0x08000000`) | Expected fwmark in the `daens` policy rule. |
 
-The check is read-only. It looks for an engine process (`honk-core`, `honk`, or `dae`), `/var/run/netns/daens`, `/sys/class/net/dae0`, the fwmark rule inside `daens`, required pinned maps, readable occupancy/overflow statistics, and `<api>/version` reachability. It ends with exactly `diagnose: all checks passed` or `diagnose: N issue(s) found`. Detected failed checks are summarized but do not by themselves change the process exit status.
+The check is read-only. It looks for an engine process (`honk-core`, `honk`, or `dae`), `/var/run/netns/daens`, `/sys/class/net/dae0`, the fwmark rule inside `daens`, required pinned maps, readable occupancy/overflow statistics, and a successful HTTP response from `<api>/version`. The API check prints `[ok]` with the body for a 2xx status, or `[FAIL]` with the status text for a non-2xx status. Standard output ends with `diagnose: all checks passed` or `diagnose: N issue(s) found`. Failed checks cause exit status `1` and an error message with the issue count; all checks passing gives exit status `0`.
 
 ### `geosite` and `geoip`
 

--- a/doc/zh/reference/cli.md
+++ b/doc/zh/reference/cli.md
@@ -170,16 +170,17 @@ honk-tool bpf stats [--pin-root PATH]
 ### `diagnose`
 
 ```text
-honk-tool diagnose [--api URL] [--pin-root PATH] [--tproxy-mark VALUE]
+honk-tool diagnose [--api URL] [--secret TOKEN] [--pin-root PATH] [--tproxy-mark VALUE]
 ```
 
 | 参数 | 默认值 | 含义 |
 | --- | --- | --- |
 | `--api URL` | `http://127.0.0.1:9090` | 明文 HTTP Clash API 基础 URL。空值跳过 API 检查；内置客户端不支持 HTTPS。 |
+| `--secret TOKEN` | `HONK_API_SECRET`（若已设置） | Clash API 的 Bearer 令牌。命令行参数优先于环境变量。 |
 | `--pin-root PATH` | `/sys/fs/bpf` | 检查 pin map 是否存在及读取统计时使用的根目录。 |
 | `--tproxy-mark VALUE` | `134217728`（`0x08000000`） | `daens` 策略规则中预期的 fwmark。 |
 
-该检查只读。它查找引擎进程（`honk-core`、`honk` 或 `dae`）、`/var/run/netns/daens`、`/sys/class/net/dae0`、`daens` 内的 fwmark 规则、必需的 pin map、可读取的占用/溢出统计，以及 `<api>/version` 可达性。最后一行严格为 `diagnose: all checks passed` 或 `diagnose: N issue(s) found`。发现失败检查会计入汇总，但本身不会改变进程退出状态。
+该检查只读。它查找引擎进程（`honk-core`、`honk` 或 `dae`）、`/var/run/netns/daens`、`/sys/class/net/dae0`、`daens` 内的 fwmark 规则、必需的 pin map、可读取的占用/溢出统计，并检查 `<api>/version` 是否返回成功的 HTTP 响应。API 返回 2xx 状态码时打印 `[ok]` 和响应正文；返回非 2xx 状态码时打印 `[FAIL]` 和状态文本。标准输出末尾为 `diagnose: all checks passed` 或 `diagnose: N issue(s) found`。存在失败检查时，退出状态为 `1`，错误信息包含问题数量；全部通过时，退出状态为 `0`。
 
 ### `geosite` 与 `geoip`
 


### PR DESCRIPTION
## Problem

`honk-tool diagnose` could not fail. Its hand-rolled GET read the socket to a string and returned it whole, so any engine with `experimental.clash_api.secret` set answered `401` and the tool printed `[ok] clash API …: HTTP/1.0 401 Unauthorized`; there was no way to send the secret; and `run` returned `Ok(())` after printing `diagnose: N issue(s) found`, so the exit code was always 0 (#210). Separately, `find_engine` returned `None` from the whole `/proc` scan on the first unreadable entry, so a live engine could be reported missing.

## How I fixed it

Two commits.

1. `fix(tool): let diagnose report an HTTP failure and exit non-zero`. The hand-written GET is replaced by `reqwest`, which `honk-tool` already links through `honk-core`: a client with a 5 s timeout, `Authorization: Bearer` when a secret is given (`--secret`, or `HONK_API_SECRET`; the flag wins, the help text says so), a non-2xx status reported as `[FAIL]` with the status code and reason, a silent peer reported as `[FAIL] … timed out after 5s`, and the body returned as text; `https://` works as a result. When any check failed, `run` returns the `diagnose: N issue(s) found` line as its error instead of printing it, so the summary appears once and the process exits 1. `doc/*/reference/cli.md`, the tool's two READMEs and `AGENTS.md` replace the sentence that said failed checks do not change the exit status, document the secret and its environment variable (and that the flag is visible in the process list), and say `--api` accepts `http://` and `https://`.
2. `fix(tool): keep scanning /proc when one entry is unreadable`. The loop `continue`s on an unreadable entry, a non-UTF-8 name or a missing `comm` instead of returning; the scan is split into `find_engine()` (production, unsorted `read_dir` as before) and `find_engine_in(entries)` so the order of failures can be tested.

## Verified

- Per commit: `cargo fmt --all -- --check`, `cargo clippy --all --all-targets -- -D warnings`, `cargo test --workspace --no-fail-fast -- --skip test_routing_with_config_dae` (2061 / 2062 passed, 0 failed): exit 0.
- Failing-first: a loopback server that returns the version body only with the right Bearer credential and `401` otherwise; the no-secret case printed `[ok]` on `main` and prints `[FAIL] … 401 Unauthorized` after; the `--secret` and `HONK_API_SECRET` cases and their precedence pass after. A subprocess test with a child-local `ip` on `PATH`, API disabled and a missing pin directory reaches the summary and exits 1. `find_engine_in` fed an `Err` entry, a non-UTF-8 name and a directory without `comm` before a valid engine finds the engine.
- Reviewer ablation, tests kept: removing the exit-code check fails the subprocess test; accepting any status fails the authentication test; not sending the Bearer header fails it too; raising the timeout to an hour fails the silent-peer test; turning each of the three `continue`s back into an early return fails the `/proc` test. All assertions, no compile errors.
- Not run: `just test-netns`, the eBPF job.

Closes #210.

---

- [x] `just fmt`, `just lint` and `just test-ci` pass.
- [x] I updated `doc/en/` and `doc/zh/` if I changed documented behaviour.
- [x] If I used AI: it followed `CONTRIBUTING.md` and `AGENTS.md`, and Verified shows what I ran, not guesses.
