### PR TITLE
fix(config): read the legacy ss:// base64 link as fields, not as url syntax

### DIFF
--- a/crates/honk-config/src/share_link.rs
+++ b/crates/honk-config/src/share_link.rs
@@ -22,7 +22,7 @@ use std::borrow::Cow;
 use base64::Engine as _;
 
 use crate::error::ConfigError;
-use crate::node::{Node, OutboundConfig};
+use crate::node::{Node, OutboundConfig, ShadowsocksConfig};
 
 mod options;
 
@@ -31,6 +31,7 @@ impl Node {
     /// A chain describes several hops; only the first is parsed.
     pub fn from_share_link(link: &str) -> Result<Node, ConfigError> {
         let first = link.split("->").next().unwrap_or("").trim();
+        let mut ss_config = None;
         let (decoded, shadowrocket) = match first.split_once("://") {
             Some((scheme, payload)) if scheme.eq_ignore_ascii_case("vmess") => {
                 let Some(decoded) = decode_full_base64_vmess_link(payload)? else {
@@ -44,7 +45,12 @@ impl Node {
                 (decoded, shadowrocket)
             }
             Some((scheme, payload)) if scheme.eq_ignore_ascii_case("ss") => {
-                (decode_full_base64_ss_link(payload), false)
+                if let Some((link, config)) = decode_full_base64_ss_link(payload)? {
+                    ss_config = Some(config);
+                    (Some(link), false)
+                } else {
+                    (None, false)
+                }
             }
             _ => (None, false),
         };
@@ -53,6 +59,9 @@ impl Node {
         let url = url::Url::parse(first.as_ref())
             .map_err(|_| ConfigError::Parse("invalid share link syntax".into()))?;
         let mut node = node_from_url(&url)?;
+        if let Some(config) = ss_config {
+            node.outbound = OutboundConfig::Shadowsocks(config);
+        }
         let query = options::parse_query(&url, node.protocol(), shadowrocket)?;
         node.name = url
             .fragment()
@@ -332,20 +341,67 @@ fn looks_like_cipher(s: &str) -> bool {
         && (s.contains('-') || matches!(s, "salsa20" | "chacha20" | "rc4"))
 }
 
-/// Decode the SIP002 full-base64 form `ss://base64(method:password@host:port)`,
-/// keeping any `?query` / `#fragment` suffix, and return the rebuilt link.
-/// Returns `None` for the (more common) forms that already carry an `@`.
-fn decode_full_base64_ss_link(rest: &str) -> Option<String> {
-    let end = rest.find(['?', '#', '/']).unwrap_or(rest.len());
-    let authority = &rest[..end];
-    if authority.is_empty() || authority.contains('@') {
-        return None;
+/// Decode legacy credentials literally, leaving the endpoint and suffix on the URL path.
+/// Returns `None` for URL forms without a UTF-8 payload; rejects decoded text
+/// without credentials or credentials that cannot supply a method and password.
+fn decode_full_base64_ss_link(
+    rest: &str,
+) -> Result<Option<(String, ShadowsocksConfig)>, ConfigError> {
+    let authority_end = rest.find(['?', '#']).unwrap_or(rest.len());
+    if rest[..authority_end].contains('@') {
+        return Ok(None);
     }
-    let text = String::from_utf8(base64_decode_flexible(authority)?).ok()?;
-    if !text.contains('@') {
-        return None;
+    let end = rest
+        .bytes()
+        .position(|b| !b.is_ascii_alphanumeric() && !matches!(b, b'+' | b'/' | b'=' | b'_' | b'-'))
+        .unwrap_or(rest.len());
+    if end == 0 {
+        return Ok(None);
     }
-    Some(format!("ss://{}{}", text, &rest[end..]))
+    // An optional delimiter can also decode as payload; prefer preserving the suffix.
+    let without_delimiter = rest[..end]
+        .strip_suffix('/')
+        .filter(|_| matches!(rest.as_bytes().get(end), None | Some(b'?' | b'#')))
+        .map(str::len);
+    // Preserve the old path boundary only after trying both base64 alphabets.
+    let path_start = rest[..end]
+        .find('/')
+        .filter(|&start| Some(start) != without_delimiter);
+    let mut decoded_text = false;
+    for end in [without_delimiter, Some(end), path_start]
+        .into_iter()
+        .flatten()
+    {
+        let Some(text) =
+            base64_decode_flexible(&rest[..end]).and_then(|bytes| String::from_utf8(bytes).ok())
+        else {
+            continue;
+        };
+        decoded_text = true;
+        let Some((userinfo, endpoint)) = text.rsplit_once('@') else {
+            continue;
+        };
+        let Some((method, password)) = decode_ss_userinfo(userinfo) else {
+            return Err(ConfigError::Parse(
+                "invalid legacy ss:// link: no method separator".into(),
+            ));
+        };
+        return Ok(Some((
+            format!("ss://{endpoint}{}", &rest[end..]),
+            ShadowsocksConfig {
+                encryption: Some(method),
+                password: Some(password),
+                ..Default::default()
+            },
+        )));
+    }
+    if decoded_text {
+        Err(ConfigError::Parse(
+            "invalid legacy ss:// link: no credentials".into(),
+        ))
+    } else {
+        Ok(None)
+    }
 }
 
 fn decode_full_base64_vless_link(rest: &str) -> Result<Option<String>, ConfigError> {

--- a/crates/honk-config/tests/share_link.rs
+++ b/crates/honk-config/tests/share_link.rs
@@ -594,6 +594,205 @@ fn test_ss_full_base64_authority_with_fragment() {
 }
 
 #[test]
+fn test_ss_legacy_literal_percent_password() {
+    let link = format!("ss://{}", b64("aes-256-gcm:a%20b@1.2.3.4:8388"));
+    let node = Node::from_share_link(&link).unwrap();
+    assert_eq!(
+        node.shadowsocks().unwrap().password.as_deref(),
+        Some("a%20b")
+    );
+}
+
+#[test]
+fn test_ss_legacy_standard_base64_slash() {
+    let payload = base64::engine::general_purpose::STANDARD.encode("aes-256-gcm:ab?@1.2.3.4:8388");
+    let node = Node::from_share_link(&format!("ss://{payload}")).unwrap();
+    assert_eq!(node.host, "1.2.3.4");
+    assert_eq!(node.port, 8388);
+    assert_eq!(
+        node.shadowsocks().unwrap().encryption.as_deref(),
+        Some("aes-256-gcm")
+    );
+    assert_eq!(node.shadowsocks().unwrap().password.as_deref(), Some("ab?"));
+}
+
+#[test]
+fn test_ss_legacy_literal_slash_password() {
+    let link = format!("ss://{}", b64("aes-256-gcm:a/b@1.2.3.4:8388"));
+    let node = Node::from_share_link(&link).unwrap();
+    assert_eq!(node.shadowsocks().unwrap().password.as_deref(), Some("a/b"));
+}
+
+#[test]
+fn test_ss_legacy_literal_hash_password() {
+    let link = format!("ss://{}", b64("aes-256-gcm:p#x@1.2.3.4:8388"));
+    let node = Node::from_share_link(&link).unwrap();
+    assert_eq!(node.shadowsocks().unwrap().password.as_deref(), Some("p#x"));
+}
+
+#[test]
+fn test_ss_legacy_rejects_missing_credentials() {
+    let link = format!("ss://{}", b64("1.2.3.4:8388"));
+    let error = Node::from_share_link(&link).unwrap_err();
+    assert!(
+        matches!(error, honk_config::ConfigError::Parse(message) if message.contains("no credentials"))
+    );
+}
+
+#[test]
+fn test_ss_legacy_rejects_missing_method_separator() {
+    let link = format!("ss://{}", b64("password@1.2.3.4:8388"));
+    let error = Node::from_share_link(&link).unwrap_err();
+    assert!(
+        matches!(error, honk_config::ConfigError::Parse(message) if message.contains("no method separator"))
+    );
+}
+
+#[test]
+fn test_ss_legacy_plain_matches_userinfo_form() {
+    let link = format!("ss://{}", b64("aes-256-gcm:plain@1.2.3.4:8388"));
+    let node = Node::from_share_link(&link).unwrap();
+    let canonical = Node::from_share_link("ss://aes-256-gcm:plain@1.2.3.4:8388").unwrap();
+    assert_eq!(node.id, canonical.id);
+    assert_eq!(
+        node.shadowsocks().unwrap().password.as_deref(),
+        Some("plain")
+    );
+}
+
+#[test]
+fn test_ss_legacy_colon_password() {
+    let link = format!("ss://{}", b64("aes-256-gcm:a:b@1.2.3.4:8388"));
+    let node = Node::from_share_link(&link).unwrap();
+    assert_eq!(node.shadowsocks().unwrap().password.as_deref(), Some("a:b"));
+}
+
+#[test]
+fn test_ss_legacy_last_at_separates_endpoint() {
+    let link = format!("ss://{}", b64("aes-256-gcm:a@b@1.2.3.4:8388"));
+    let node = Node::from_share_link(&link).unwrap();
+    assert_eq!(node.host, "1.2.3.4");
+    assert_eq!(node.shadowsocks().unwrap().password.as_deref(), Some("a@b"));
+}
+
+#[test]
+fn test_ss_legacy_encoded_method() {
+    let link = format!(
+        "ss://{}",
+        b64("Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNQ:pw@1.2.3.4:8388")
+    );
+    let node = Node::from_share_link(&link).unwrap();
+    assert_eq!(
+        node.shadowsocks().unwrap().encryption.as_deref(),
+        Some("chacha20-ietf-poly1305")
+    );
+}
+
+#[test]
+fn test_ss_legacy_ipv6_matches_userinfo_form() {
+    let link = format!("ss://{}", b64("aes-256-gcm:plain@[2001:db8::1]:8388"));
+    let node = Node::from_share_link(&link).unwrap();
+    let canonical = Node::from_share_link("ss://aes-256-gcm:plain@[2001:db8::1]:8388").unwrap();
+    assert_eq!(node.host, "[2001:db8::1]");
+    assert_eq!(node.id, canonical.id);
+}
+
+#[test]
+fn test_ss_legacy_padded_plugin_suffix() {
+    let payload =
+        base64::engine::general_purpose::STANDARD.encode("aes-256-gcm:plain@1.2.3.4:8388");
+    let node = Node::from_share_link(&format!(
+        "ss://{payload}/?plugin=v2ray-plugin%3Btls&remark=query#name"
+    ))
+    .unwrap();
+    assert_eq!(
+        node.shadowsocks().unwrap().plugin.as_deref(),
+        Some("v2ray-plugin")
+    );
+    assert_eq!(
+        node.shadowsocks().unwrap().plugin_opts.as_deref(),
+        Some("tls")
+    );
+    assert_eq!(node.name, "name");
+}
+
+#[test]
+fn test_ss_legacy_unpadded_plugin_delimiter() {
+    let payload = b64("aes-256-gcm:abcdefghijklmnop@1.2.3.4:8388");
+    let node =
+        Node::from_share_link(&format!("ss://{payload}/?plugin=v2ray-plugin%3Btls#name")).unwrap();
+    assert_eq!(node.port, 8388);
+    assert_eq!(
+        node.shadowsocks().unwrap().plugin.as_deref(),
+        Some("v2ray-plugin")
+    );
+    assert_eq!(
+        node.shadowsocks().unwrap().plugin_opts.as_deref(),
+        Some("tls")
+    );
+    assert_eq!(node.name, "name");
+}
+
+#[test]
+fn test_ss_legacy_remark_suffix() {
+    let link = format!(
+        "ss://{}/?remark=name",
+        b64("aes-256-gcm:plain@1.2.3.4:8388")
+    );
+    let node = Node::from_share_link(&link).unwrap();
+    assert_eq!(node.name, "name");
+}
+
+#[test]
+fn test_ss_url_userinfo_still_percent_decodes() {
+    let link = "ss://aes-256-gcm:a%20b@1.2.3.4:8388";
+    let node = Node::from_share_link(link).unwrap();
+    assert_eq!(node.shadowsocks().unwrap().password.as_deref(), Some("a b"));
+}
+
+#[test]
+fn test_ss_compat_nested_base64_userinfo() {
+    let link = format!(
+        "ss://{}",
+        b64(&format!("{}@1.2.3.4:8388", b64("aes-256-gcm:pw")))
+    );
+    let node = Node::from_share_link(&link).unwrap();
+    let ss = node.shadowsocks().unwrap();
+    assert_eq!(ss.encryption.as_deref(), Some("aes-256-gcm"));
+    assert_eq!(ss.password.as_deref(), Some("pw"));
+}
+
+#[test]
+fn test_ss_compat_empty_base64_run() {
+    let link = "ss://[2001:db8::1]:8388#nm";
+    let node = Node::from_share_link(link).unwrap();
+    assert_eq!(node.host, "[2001:db8::1]");
+    assert_eq!(node.port, 8388);
+    assert_eq!(node.name, "nm");
+}
+
+#[test]
+fn test_ss_compat_legacy_path_suffix() {
+    let link = format!("ss://{}/path#name", b64("aes-256-gcm:plain@1.2.3.4:8388"));
+    let node = Node::from_share_link(&link).unwrap();
+    assert_eq!(node.host, "1.2.3.4");
+    assert_eq!(node.port, 8388);
+    assert_eq!(
+        node.shadowsocks().unwrap().password.as_deref(),
+        Some("plain")
+    );
+    assert_eq!(node.name, "name");
+}
+
+#[test]
+fn test_ss_compat_bare_hostname() {
+    let link = "ss://host:8388";
+    let node = Node::from_share_link(link).unwrap();
+    assert_eq!(node.host, "host");
+    assert_eq!(node.port, 8388);
+}
+
+#[test]
 fn test_name_fallback_never_contains_credentials() {
     // Links without #name get a `scheme-host` fallback; the raw URI (with
     // the password) must never end up in the display name.

--- a/doc/en/reference/nodes.md
+++ b/doc/en/reference/nodes.md
@@ -23,6 +23,8 @@ In quoted tags and links, a backslash escapes the next character when locating t
 
 A malformed recognized link is dropped with `node section: skipping unparseable entry: ...` on stderr. An unknown scheme is a hard configuration error. A standalone `mux:` or `mux=` line is also rejected; VLESS wire behavior belongs in each link's `vless_mode=` query.
 
+In the legacy `ss://base64(method:password@host:port)` form, decoded credentials are literal text, not URL-decoded: `%20` stays `%20`, and `?`, `/`, `#`, `:` and `@` remain password characters. The last `@` separates the endpoint; the userinfo may itself be `base64(method:password)`. A decoded payload without `@`, or credentials that cannot supply a method and password, is rejected. URL userinfo forms still percent-decode their credentials. The endpoint, path, query (including `/?plugin=...`) and fragment keep the usual URL handling.
+
 ## Node identity
 
 `Node::derive_id()` is the only identity derivation path. It computes UUID v5 over:

--- a/doc/zh/reference/nodes.md
+++ b/doc/zh/reference/nodes.md
@@ -23,6 +23,8 @@ node {
 
 格式错误但 scheme 已识别的链接会被丢弃，并向 stderr 输出 `node section: skipping unparseable entry: ...`。未知 scheme 是配置硬错误。独立的 `mux:` 或 `mux=` 行也会被拒绝；VLESS wire 行为必须写在各链接的 `vless_mode=` query 中。
 
+旧版 `ss://base64(method:password@host:port)` 格式按字面值读取解码后的凭据，不做 URL 解码：`%20` 保持为 `%20`，`?`、`/`、`#`、`:` 和 `@` 仍是密码字符。最后一个 `@` 分隔凭据与端点；userinfo 本身也可以是 `base64(method:password)`。解码后的载荷缺少 `@`，或凭据无法解析为方法与密码时，拒绝解析。URL userinfo 格式仍按百分号解码凭据。端点、路径、query（包括 `/?plugin=...`）和 fragment 继续按 URL 处理。
+
 ## 节点身份
 
 `Node::derive_id()` 是唯一的身份派生路径。它对以下材料计算 UUID v5：


### PR DESCRIPTION
## Problem

The legacy `ss://base64(method:password@host:port)` form was handled by base64-decoding the authority and splicing the decoded text back into a URL string for `url::Url::parse`. The decoded text is not URL-encoded, so a `%xx` in the password was percent-decoded a second time, a `?`, `#` or `/` inside the password moved the URL boundaries, and a standard-alphabet payload containing `/` was cut short at that `/`: the decode then found no `@`, the function gave up, and the original `ss://<base64>` parsed as host `<base64>`, port 443, no cipher, no password, and passed `Config::validate` with nothing on stderr (#208).

## How I fixed it

One commit. The endpoint stays on the URL path; only the credentials leave it.

- The base64 run is the longest prefix in `[A-Za-z0-9+/=_-]`. A trailing `/` before `?`, `#` or the end is ambiguous (it may be the legacy optional delimiter, `ss://<b64>/?plugin=…`), so candidates are tried in order: the run without that `/`, the full run, then the prefix up to the first `/` (the previous boundary, which keeps `ss://<b64>/path#name` working). The first candidate that decodes to UTF-8 text containing `@` wins.
- The text splits at the last `@` into credentials and endpoint. `ss://<endpoint><suffix>` is parsed with `url::Url` exactly as before, so the host representation (IPv6 stays bracketed), the plugin query and the name precedence are unchanged. The credentials go through the existing `decode_ss_userinfo`, which keeps cipher-name normalisation and the nested `base64(method:password)` form; the only thing removed is the percent-decoding that URL userinfo gets.
- A payload that decodes to text without credentials is rejected with a message naming the cause instead of becoming a host. A link whose run is empty or decodes to no UTF-8 at all (`ss://[2001:db8::1]:8388#nm`, `ss://host:8388`) is not a legacy form and takes the URL path as on `main`. `doc/*/reference/nodes.md` say the decoded text is taken literally.

## Verified

- `cargo fmt --all -- --check`, `cargo clippy --all --all-targets -- -D warnings`, `cargo test -p honk-config`, `cargo test --workspace --no-fail-fast -- --skip test_routing_with_config_dae` (2076 passed, 0 failed): exit 0.
- Failing-first: literal `%20`, `?`, `/` and `#` in the password, the base64-with-`/` payload, and the two rejections fail on `main` and pass after. Controls that pass on both sides: the plain form, `a:b` passwords, an encoded cipher name, IPv6, the `/?plugin=` and `?remark=` suffixes, the nested base64 userinfo, an empty run, a path suffix, and a bare host.
- Reviewer ablation, tests kept, one site at a time: delimiter-first rule off, split at the first `@`, cipher normalisation bypassed, percent-decoding restored, the `:` pre-check restored ahead of `decode_ss_userinfo`, the empty-run guard off, the path candidate removed. Each fails exactly its test by assertion, no compile errors.
- Differential: the frozen parser corpus (230 files × 4 modes = 920 cells) is byte-identical to `origin/main`; an issue corpus of 17 fixtures (one per behaviour-table row) dumped on `origin/main` and on this commit changes only the five rows the table says change and leaves the twelve controls byte-identical.
- Not run: `just test-routing`, `just test-netns`, the eBPF job.

Closes #208.

- CI: the `eBPF object + real VM kernel tests` job failed at its `Enable KVM` step (`test -r /dev/kvm -a -w /dev/kvm` on a runner without KVM), before building or running anything; the other four jobs pass. Not related to this change.

---

- [x] `just fmt`, `just lint` and `just test-ci` pass.
- [x] I updated `doc/en/` and `doc/zh/` if I changed documented behaviour.
- [x] If I used AI: it followed `CONTRIBUTING.md` and `AGENTS.md`, and Verified shows what I ran, not guesses.

