### PR TITLE
ci: drop the runner image's third-party apt sources before apt-get update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
           components: rustfmt, clippy
       - name: Install boring-sys build deps (cmake + libclang for bindgen)
         run: |
+          # The runner image ships Chrome and Microsoft apt sources; a Hash Sum mismatch
+          # at either fails apt-get update, and the jobs install nothing from them.
+          sudo grep -lE 'dl\.google\.com|packages\.microsoft\.com' /etc/apt/sources.list.d/* | xargs -r sudo rm -f || true
           sudo apt-get update
           sudo apt-get install -y cmake libclang-dev
       - run: cargo fmt --all -- --check
@@ -37,6 +40,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install boring-sys build deps (cmake + libclang for bindgen)
         run: |
+          sudo grep -lE 'dl\.google\.com|packages\.microsoft\.com' /etc/apt/sources.list.d/* | xargs -r sudo rm -f || true
           sudo apt-get update
           sudo apt-get install -y cmake libclang-dev
 
@@ -71,6 +75,7 @@ jobs:
       - name: Install build and VM dependencies
         run: |
           echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections
+          sudo grep -lE 'dl\.google\.com|packages\.microsoft\.com' /etc/apt/sources.list.d/* | xargs -r sudo rm -f || true
           sudo apt-get update
           sudo apt-get install --yes --no-install-recommends \
             busybox-static clang cmake coreutils file iproute2 iptables jq kbd kmod \


### PR DESCRIPTION
## Problem

Two `CI` runs in the last two days (`34385865210` on `main`, `34380239251` on a PR) failed in all three apt-using jobs before building anything, at `apt-get update`:

```
E: Failed to fetch https://dl.google.com/linux/chrome-stable/deb/dists/stable/main/binary-amd64/Packages.gz  Hash Sum mismatch
```

`apt-get update` exits non-zero when any configured source fails, and the runner image ships Chrome and Microsoft apt sources that these jobs never install from (`cmake libclang-dev`, and the eBPF job's package list, all come from the Ubuntu archive). A CDN inconsistency at an unrelated repository therefore fails the job.

## How I fixed it

Before each of the three `sudo apt-get update` lines, one line removes every file under `/etc/apt/sources.list.d/` whose content references `dl.google.com` or `packages.microsoft.com`, matched by content so the image's file names (`google-chrome.sources`, formerly `.list`; `microsoft-prod.list`) do not matter. `ubuntu.sources` does not match and stays. No retries, no `continue-on-error`, no package or runner change; the KVM step is left to #216. The trailing `|| true` is only so the line survives a future `shell: bash` (which adds `pipefail`); under today's `bash -e` a non-matching `grep` already lets the pipeline through.

## Verified

- `actionlint` 1.7.12 on the changed workflow: clean.
- The removal line run locally against a directory with a deb822 `ubuntu.sources`, a `google-chrome.sources` and a `microsoft-prod.list`: only the two third-party files are removed; with no matching file it is a no-op with exit 0, under `bash -e` and under `bash -e -o pipefail`.
- This PR's own CI run `34492848405`: all five jobs pass; across the whole run's logs the only apt host contacted is `azure.archive.ubuntu.com` (`dl.google.com` and `packages.microsoft.com` no longer appear). The eBPF job's `Enable KVM` step is outside this change and can still fail on a runner without `/dev/kvm` until #216 lands; it happened to pass here.

---

- [x] `just fmt`, `just lint` and `just test-ci` pass.
- [x] I updated `doc/en/` and `doc/zh/` if I changed documented behaviour.
- [x] If I used AI: it followed `CONTRIBUTING.md` and `AGENTS.md`, and Verified shows what I ran, not guesses.
