### PR TITLE
fix(tool): size the per-cpu buffer from the possible cpu count

### DIFF
--- a/crates/honk-tool/src/bpf.rs
+++ b/crates/honk-tool/src/bpf.rs
@@ -141,8 +141,7 @@ fn read_value<T: Copy>(fd: RawFd, key: &[u8]) -> io::Result<Option<T>> {
     }
 }
 
-fn read_percpu_sum(fd: RawFd, ncpu: usize, index: u32) -> io::Result<u64> {
-    let mut buf = vec![0u8; ncpu * 8];
+fn read_percpu_sum(fd: RawFd, buf: &mut [u8], index: u32) -> io::Result<u64> {
     let mut attr = BpfAttr {
         map_fd: fd as u32,
         key: &index as *const u32 as u64,
@@ -157,9 +156,11 @@ fn read_percpu_sum(fd: RawFd, ncpu: usize, index: u32) -> io::Result<u64> {
     Ok(total)
 }
 
-fn read_percpu_outbound(fd: RawFd, ncpu: usize, index: u32) -> io::Result<OutboundStatsCounters> {
-    let value_len = std::mem::size_of::<OutboundStatsCounters>();
-    let mut buf = vec![0u8; ncpu * value_len];
+fn read_percpu_outbound(
+    fd: RawFd,
+    buf: &mut [u8],
+    index: u32,
+) -> io::Result<OutboundStatsCounters> {
     let mut attr = BpfAttr {
         map_fd: fd as u32,
         key: &index as *const u32 as u64,
@@ -167,7 +168,7 @@ fn read_percpu_outbound(fd: RawFd, ncpu: usize, index: u32) -> io::Result<Outbou
         ..Default::default()
     };
     bpf(BPF_MAP_LOOKUP_ELEM, &mut attr)?;
-    Ok(sum_percpu_outbound(&buf))
+    Ok(sum_percpu_outbound(buf))
 }
 
 fn sum_percpu_outbound(buf: &[u8]) -> OutboundStatsCounters {
@@ -182,22 +183,118 @@ fn sum_percpu_outbound(buf: &[u8]) -> OutboundStatsCounters {
     total
 }
 
-fn possible_cpus() -> usize {
-    std::fs::read_dir("/sys/devices/system/cpu")
-        .map(|rd| {
-            rd.filter_map(|e| e.ok())
-                .filter(|e| e.file_name().to_string_lossy().starts_with("cpu"))
-                .filter(|e| {
-                    e.file_name()
-                        .to_string_lossy()
-                        .chars()
-                        .nth(3)
-                        .is_some_and(|c| c.is_ascii_digit())
-                })
-                .count()
-        })
-        .unwrap_or(1)
-        .max(1)
+fn parse_possible_cpus(input: &str) -> anyhow::Result<usize> {
+    let input = input.trim();
+    anyhow::ensure!(!input.is_empty(), "possible CPU list is empty");
+
+    let mut count = 0usize;
+    let mut previous_end = None;
+    for term in input.split(',') {
+        anyhow::ensure!(!term.is_empty(), "possible CPU list contains an empty term");
+
+        let (start, end) = match term.split_once('-') {
+            Some((start, end)) => (parse_cpu_id(start)?, parse_cpu_id(end)?),
+            None => {
+                let id = parse_cpu_id(term)?;
+                (id, id)
+            }
+        };
+        anyhow::ensure!(start <= end, "possible CPU range {term:?} is descending");
+        if let Some(previous_end) = previous_end {
+            anyhow::ensure!(
+                start > previous_end,
+                "possible CPU ranges are overlapping or out of order at {term:?}"
+            );
+        }
+        let range_count = end
+            .checked_sub(start)
+            .and_then(|count| count.checked_add(1))
+            .context("possible CPU range count overflow")?;
+        count = count
+            .checked_add(range_count)
+            .context("possible CPU population count overflow")?;
+        previous_end = Some(end);
+    }
+    Ok(count)
+}
+
+fn parse_cpu_id(value: &str) -> anyhow::Result<usize> {
+    anyhow::ensure!(
+        !value.is_empty() && value.bytes().all(|byte| byte.is_ascii_digit()),
+        "possible CPU ID {value:?} is not a decimal number"
+    );
+    anyhow::ensure!(
+        value == "0" || !value.starts_with('0'),
+        "possible CPU ID {value:?} is not canonical"
+    );
+    value
+        .parse()
+        .with_context(|| format!("possible CPU ID {value:?} overflows"))
+}
+
+fn percpu_buffer_len(count: usize, value_size: usize) -> anyhow::Result<usize> {
+    let stride = value_size
+        .checked_add(7)
+        .context("per-CPU value stride overflow")?
+        & !7;
+    let bytes = count
+        .checked_mul(stride)
+        .context("per-CPU buffer length overflow")?;
+    anyhow::ensure!(
+        bytes <= isize::MAX as usize,
+        "per-CPU buffer length {bytes} exceeds isize::MAX"
+    );
+    Ok(bytes)
+}
+
+fn possible_cpus(cpu_root: &Path) -> anyhow::Result<usize> {
+    let path = cpu_root.join("possible");
+    let input = std::fs::read_to_string(&path)
+        .map_err(|error| anyhow::anyhow!("read possible CPU file {}: {error}", path.display()))?;
+    parse_possible_cpus(&input)
+        .map_err(|error| anyhow::anyhow!("parse possible CPU file {}: {error}", path.display()))
+}
+
+struct PerCpuStats {
+    occupancy_fd: OwnedFd,
+    occupancy: Vec<u8>,
+    outbound_fd: OwnedFd,
+    outbound: Vec<u8>,
+}
+
+fn prepare_percpu_stats<F>(
+    cpu_root: &Path,
+    print_ordinary: impl FnOnce() -> anyhow::Result<()>,
+    mut open_info: F,
+) -> anyhow::Result<PerCpuStats>
+where
+    F: FnMut(&str) -> anyhow::Result<(OwnedFd, [u32; 6])>,
+{
+    let ncpu = possible_cpus(cpu_root)?;
+    let occupancy_len = percpu_buffer_len(ncpu, 8)?;
+    let outbound_len = percpu_buffer_len(ncpu, std::mem::size_of::<OutboundStatsCounters>())?;
+
+    print_ordinary()?;
+
+    let (occupancy_fd, occupancy_info) =
+        open_info("CONN_STATE_OCCUPANCY").context("open/query map CONN_STATE_OCCUPANCY")?;
+    check_map_layout("CONN_STATE_OCCUPANCY", occupancy_info, 6, 4, 8)?;
+    let (outbound_fd, outbound_info) =
+        open_info("OUTBOUND_STATS").context("open/query map OUTBOUND_STATS")?;
+    check_map_layout(
+        "OUTBOUND_STATS",
+        outbound_info,
+        6,
+        4,
+        std::mem::size_of::<OutboundStatsCounters>() as u32,
+    )?;
+
+    Ok(PerCpuStats {
+        occupancy_fd,
+        occupancy: vec![0u8; occupancy_len],
+        outbound_fd,
+        outbound: vec![0u8; outbound_len],
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -278,7 +375,7 @@ fn map_by_id(id: u32) -> io::Result<OwnedFd> {
     }
 }
 
-fn check_map_layout(fd: RawFd, kind: u32, key_size: u32, value_size: u32) -> anyhow::Result<()> {
+fn map_info(fd: RawFd, map_name: &str) -> anyhow::Result<[u32; 6]> {
     #[repr(C)]
     struct InfoAttr {
         fd: u32,
@@ -300,11 +397,22 @@ fn check_map_layout(fd: RawFd, kind: u32, key_size: u32, value_size: u32) -> any
         )
     };
     if result < 0 {
-        return Err(io::Error::last_os_error().into());
+        return Err(io::Error::last_os_error())
+            .with_context(|| format!("query metadata for map {map_name}"));
     }
+    Ok(info)
+}
+
+fn check_map_layout(
+    map_name: &str,
+    info: [u32; 6],
+    kind: u32,
+    key_size: u32,
+    value_size: u32,
+) -> anyhow::Result<()> {
     anyhow::ensure!(
         (info[0], info[2], info[3]) == (kind, key_size, value_size),
-        "unexpected routing map layout: type={} key={} value={}",
+        "unexpected map layout for {map_name}: expected type={kind} key={key_size} value={value_size}, actual type={} key={} value={}",
         info[0],
         info[2],
         info[3]
@@ -312,9 +420,20 @@ fn check_map_layout(fd: RawFd, kind: u32, key_size: u32, value_size: u32) -> any
     Ok(())
 }
 
+fn query_map_layout(
+    fd: RawFd,
+    map_name: &str,
+    kind: u32,
+    key_size: u32,
+    value_size: u32,
+) -> anyhow::Result<()> {
+    let info = map_info(fd, map_name)?;
+    check_map_layout(map_name, info, kind, key_size, value_size)
+}
+
 fn open_domain_map(pin_root: &Path) -> anyhow::Result<OwnedFd> {
     let root = unsafe { OwnedFd::from_raw_fd(open(pin_root, ROUTING_POLICY_ROOT_NAME)?) };
-    check_map_layout(root.as_raw_fd(), 12, 4, 4)?;
+    query_map_layout(root.as_raw_fd(), ROUTING_POLICY_ROOT_NAME, 12, 4, 4)?;
     let key = 0u32.to_ne_bytes();
     // A generation can retire between reading its ID and acquiring an FD.
     for _ in 0..3 {
@@ -325,8 +444,9 @@ fn open_domain_map(pin_root: &Path) -> anyhow::Result<OwnedFd> {
             Err(error) if error.raw_os_error() == Some(libc::ENOENT) => continue,
             Err(error) => return Err(error.into()),
         };
-        check_map_layout(
+        query_map_layout(
             descriptor.as_raw_fd(),
+            "routing policy descriptor",
             2,
             4,
             std::mem::size_of::<RoutingPolicyDescriptor>() as u32,
@@ -338,8 +458,9 @@ fn open_domain_map(pin_root: &Path) -> anyhow::Result<OwnedFd> {
             Err(error) if error.raw_os_error() == Some(libc::ENOENT) => continue,
             Err(error) => return Err(error.into()),
         };
-        check_map_layout(
+        query_map_layout(
             domain.as_raw_fd(),
+            "domain routing",
             1,
             16,
             std::mem::size_of::<DomainRouting>() as u32,
@@ -485,10 +606,9 @@ fn show(args: ShowArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub(crate) fn stats(args: StatsArgs) -> anyhow::Result<()> {
-    let ncpu = possible_cpus();
-
-    let fd = open(&args.pin_root, "BPF_STATS_MAP")?;
+fn print_ordinary_stats(pin_root: &Path) -> anyhow::Result<()> {
+    let stats_fd = unsafe { OwnedFd::from_raw_fd(open(pin_root, "BPF_STATS_MAP")?) };
+    let fd = stats_fd.as_raw_fd();
     let udp_ovf: u64 = read_value(fd, &0u32.to_ne_bytes())?.unwrap_or(0);
     let tcp_ovf: u64 = read_value(fd, &1u32.to_ne_bytes())?.unwrap_or(0);
     println!("conn-state overflow: udp={udp_ovf} tcp={tcp_ovf}");
@@ -499,19 +619,34 @@ pub(crate) fn stats(args: StatsArgs) -> anyhow::Result<()> {
         "auxiliary insert failures: redirect_track={redirect_failures} \
          routing_handoff={handoff_failures} cookie_pid={cookie_failures}"
     );
+    Ok(())
+}
 
-    let fd = open(&args.pin_root, "CONN_STATE_OCCUPANCY")?;
-    let inserts = read_percpu_sum(fd, ncpu, 0)?;
-    let deletes = read_percpu_sum(fd, ncpu, 1)?;
+pub(crate) fn stats(args: StatsArgs) -> anyhow::Result<()> {
+    let mut percpu = prepare_percpu_stats(
+        Path::new("/sys/devices/system/cpu"),
+        || print_ordinary_stats(&args.pin_root),
+        |name| {
+            let fd = unsafe { OwnedFd::from_raw_fd(open(&args.pin_root, name)?) };
+            let info = map_info(fd.as_raw_fd(), name)?;
+            Ok((fd, info))
+        },
+    )?;
+
+    let inserts = read_percpu_sum(percpu.occupancy_fd.as_raw_fd(), &mut percpu.occupancy, 0)?;
+    let deletes = read_percpu_sum(percpu.occupancy_fd.as_raw_fd(), &mut percpu.occupancy, 1)?;
     println!(
         "conn-state occupancy: inserts={inserts} ebpf_deletes={deletes} raw_live={}",
         inserts.saturating_sub(deletes)
     );
 
-    let fd = open(&args.pin_root, "OUTBOUND_STATS")?;
     println!("\noutbound counters (tx_pkts tx_bytes rx_pkts rx_bytes):");
     for outbound in 0..OUTBOUND_STATS_MAP_LEN {
-        let counters = read_percpu_outbound(fd, ncpu, outbound)?;
+        let counters = read_percpu_outbound(
+            percpu.outbound_fd.as_raw_fd(),
+            &mut percpu.outbound,
+            outbound,
+        )?;
         if counters.tx_packets != 0
             || counters.tx_bytes != 0
             || counters.rx_packets != 0
@@ -529,6 +664,188 @@ pub(crate) fn stats(args: StatsArgs) -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct SysfsFixture(tempfile::TempDir);
+
+    impl SysfsFixture {
+        fn new(possible: Option<&str>, present: &[u32]) -> Self {
+            let fixture = Self(tempfile::tempdir().unwrap());
+            if let Some(possible) = possible {
+                std::fs::write(fixture.root().join("possible"), possible).unwrap();
+            }
+            for cpu in present {
+                std::fs::create_dir(fixture.root().join(format!("cpu{cpu}"))).unwrap();
+            }
+            fixture
+        }
+
+        fn root(&self) -> &Path {
+            self.0.path()
+        }
+    }
+
+    fn stats_metadata_fixture(name: &str) -> [u32; 6] {
+        let mut info = [0; 6];
+        info[0] = 6;
+        info[2] = 4;
+        info[3] = match name {
+            "CONN_STATE_OCCUPANCY" => 8,
+            "OUTBOUND_STATS" => 32,
+            _ => panic!("unexpected statistics map {name}"),
+        };
+        info
+    }
+
+    fn open_stats_fixture(name: &str) -> anyhow::Result<(OwnedFd, [u32; 6])> {
+        Ok((
+            std::fs::File::open("/dev/null")?.into(),
+            stats_metadata_fixture(name),
+        ))
+    }
+
+    fn prepared(root: &Path) -> PerCpuStats {
+        prepare_percpu_stats(root, || Ok(()), open_stats_fixture).unwrap()
+    }
+
+    fn assert_source_error(fixture: &SysfsFixture) {
+        let mut opened = 0;
+        let result = prepare_percpu_stats(
+            fixture.root(),
+            || Ok(()),
+            |name| {
+                opened += 1;
+                open_stats_fixture(name)
+            },
+        );
+        let error = result.err().expect("invalid CPU source was accepted");
+        assert!(
+            error
+                .to_string()
+                .contains(&fixture.root().join("possible").display().to_string())
+        );
+        assert_eq!(opened, 0, "CPU source failure must precede map opening");
+    }
+
+    #[test]
+    fn prepare_percpu_stats_uses_possible_population_not_present_directories() {
+        let fixture = SysfsFixture::new(Some("0-63\n"), &(0..32).collect::<Vec<_>>());
+        let stats = prepared(fixture.root());
+        assert_eq!((stats.occupancy.len(), stats.outbound.len()), (512, 2048));
+    }
+
+    #[test]
+    fn prepare_percpu_stats_counts_sparse_possible_members() {
+        for (mask, present, lengths) in [
+            ("0,2-3\n", &[0, 2, 3][..], (24, 96)),
+            ("0,2-3,8\n", &[0, 2, 3, 8][..], (32, 128)),
+            ("7\n", &[7][..], (8, 32)),
+        ] {
+            let fixture = SysfsFixture::new(Some(mask), present);
+            let stats = prepared(fixture.root());
+            assert_eq!(
+                (stats.occupancy.len(), stats.outbound.len()),
+                lengths,
+                "{mask}"
+            );
+        }
+    }
+
+    #[test]
+    fn prepare_percpu_stats_rejects_missing_or_unreadable_possible_before_opening() {
+        for possible_is_directory in [false, true] {
+            let fixture = SysfsFixture::new(None, &[0, 1, 2]);
+            if possible_is_directory {
+                std::fs::create_dir(fixture.root().join("possible")).unwrap();
+            }
+            assert_source_error(&fixture);
+        }
+    }
+
+    #[test]
+    fn prepare_percpu_stats_rejects_noncanonical_possible_lists() {
+        for input in [
+            "", ",", "0,", ",0", "x", "+1", "01", "-1", "2-1", "0,0", "0-2,2-3", "1,0", "0-1-2",
+        ] {
+            let fixture = SysfsFixture::new(Some(input), &[0]);
+            assert_source_error(&fixture);
+        }
+    }
+
+    #[test]
+    fn checked_possible_parser_and_percpu_size_reject_overflow_without_allocating() {
+        let half = usize::MAX / 2;
+        for input in [
+            format!("{}0", usize::MAX),
+            format!("0-{}", usize::MAX),
+            format!("0-{half},{}-{}", half + 1, usize::MAX),
+        ] {
+            assert!(parse_possible_cpus(&input).is_err(), "{input}");
+        }
+        assert_eq!(percpu_buffer_len(1, 9).unwrap(), 16);
+        for (count, value_size) in [
+            ((usize::MAX / 8) + 1, 8),
+            (1, usize::MAX),
+            ((isize::MAX as usize / 8) + 1, 8),
+        ] {
+            assert!(
+                percpu_buffer_len(count, value_size).is_err(),
+                "{count} x {value_size}"
+            );
+        }
+    }
+
+    #[test]
+    fn prepare_percpu_stats_rejects_each_percpu_map_layout_field() {
+        let fixture = SysfsFixture::new(Some("0\n"), &[0]);
+        for map in ["CONN_STATE_OCCUPANCY", "OUTBOUND_STATS"] {
+            for (field, value) in [(0, 1), (2, 8), (3, 16)] {
+                let expected = stats_metadata_fixture(map);
+                let mut actual = expected;
+                actual[field] = value;
+                let result = prepare_percpu_stats(
+                    fixture.root(),
+                    || Ok(()),
+                    |name| {
+                        let (fd, info) = open_stats_fixture(name)?;
+                        Ok((fd, if name == map { actual } else { info }))
+                    },
+                );
+                let error = result
+                    .err()
+                    .expect("invalid per-CPU layout was accepted")
+                    .to_string();
+                assert!(error.contains(map), "{error}");
+                for (label, info) in [("expected", expected), ("actual", actual)] {
+                    assert!(
+                        error.contains(&format!(
+                            "{label} type={} key={} value={}",
+                            info[0], info[2], info[3]
+                        )),
+                        "{error}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn prepare_percpu_stats_propagates_metadata_query_errors_for_each_map() {
+        let fixture = SysfsFixture::new(Some("0\n"), &[0]);
+        for failed_map in ["CONN_STATE_OCCUPANCY", "OUTBOUND_STATS"] {
+            let result = prepare_percpu_stats(
+                fixture.root(),
+                || Ok(()),
+                |name| {
+                    anyhow::ensure!(name != failed_map, "synthetic metadata query failure");
+                    open_stats_fixture(name)
+                },
+            );
+            let error = result.err().expect("metadata query failure was ignored");
+            let text = format!("{error:#}");
+            assert!(text.contains(failed_map), "{text}");
+            assert!(text.contains("synthetic metadata query failure"), "{text}");
+        }
+    }
 
     fn encode(counters: OutboundStatsCounters) -> Vec<u8> {
         [

--- a/doc/en/reference/cli.md
+++ b/doc/en/reference/cli.md
@@ -173,6 +173,8 @@ honk-tool bpf stats [--pin-root PATH]
 
 The implementation opens pins with raw `bpf(2)` operations; it does not use aya, load programs, or attach hooks. `stats` prints conn-state and auxiliary-map overflow/failure counters, the `CONN_STATE_OCCUPANCY` insert/delete gauge, and non-zero per-outbound packet/byte counters. Map reads normally require root or suitable BPF capabilities.
 
+`stats` requires a readable, genuine `/sys/devices/system/cpu/possible` export. It sizes per-CPU buffers from that mask's population, never the present/online CPU count. `CONN_STATE_OCCUPANCY` and `OUTBOUND_STATS` must be per-CPU arrays with 4-byte keys and 8-byte and 32-byte values, respectively. An unreadable or invalid CPU list, or incompatible map metadata, fails before per-CPU lookup; there is no guessed CPU-count fallback.
+
 ### `diagnose`
 
 ```text
@@ -187,6 +189,8 @@ honk-tool diagnose [--api URL] [--secret TOKEN] [--pin-root PATH] [--tproxy-mark
 | `--tproxy-mark VALUE` | `134217728` (`0x08000000`) | Expected fwmark in the `daens` policy rule. |
 
 The check is read-only. It looks for an engine process (`honk-core`, `honk`, or `dae`), `/var/run/netns/daens`, `/sys/class/net/dae0`, the fwmark rule inside `daens`, required pinned maps, readable occupancy/overflow statistics, and a successful HTTP response from `<api>/version`. The API check prints `[ok]` with the body for a 2xx status, or `[FAIL]` with the status text for a non-2xx status. Standard output ends with `diagnose: all checks passed` or `diagnose: N issue(s) found`. Failed checks cause exit status `1` and an error message with the issue count; all checks passing gives exit status `0`.
+
+The statistics check has the same possible-CPU file and pinned-map layout prerequisites as `bpf stats`. A preparation failure prints `[FAIL] map stats read`, contributes to the issue count, and causes a nonzero exit.
 
 ### `geosite` and `geoip`
 

--- a/doc/zh/reference/cli.md
+++ b/doc/zh/reference/cli.md
@@ -173,6 +173,8 @@ honk-tool bpf stats [--pin-root PATH]
 
 实现通过原始 `bpf(2)` 操作打开 pin；不使用 aya、不加载程序，也不挂载 hook。`stats` 打印 conn-state 与辅助 map 的溢出/插入失败计数、`CONN_STATE_OCCUPANCY` 插入/删除水位计，以及非零的每出站包/字节计数。读取 map 通常需要 root 或合适的 BPF capability。
 
+`stats` 要求 `/sys/devices/system/cpu/possible` 可读且为内核的真实导出文件。每 CPU 缓冲区按该掩码中的 CPU 数量分配，不采用 present 或 online CPU 数量。`CONN_STATE_OCCUPANCY` 和 `OUTBOUND_STATS` 必须为每 CPU 数组，键均为 4 字节，值分别为 8 字节和 32 字节。CPU 列表不可读、格式无效或 map 元数据不兼容时，命令在每 CPU 查找前报错，不回退到猜测的 CPU 数量。
+
 ### `diagnose`
 
 ```text
@@ -187,6 +189,8 @@ honk-tool diagnose [--api URL] [--secret TOKEN] [--pin-root PATH] [--tproxy-mark
 | `--tproxy-mark VALUE` | `134217728`（`0x08000000`） | `daens` 策略规则中预期的 fwmark。 |
 
 该检查只读。它查找引擎进程（`honk-core`、`honk` 或 `dae`）、`/var/run/netns/daens`、`/sys/class/net/dae0`、`daens` 内的 fwmark 规则、必需的 pin map、可读取的占用/溢出统计，并检查 `<api>/version` 是否返回成功的 HTTP 响应。API 返回 2xx 状态码时打印 `[ok]` 和响应正文；返回非 2xx 状态码时打印 `[FAIL]` 和状态文本。标准输出末尾为 `diagnose: all checks passed` 或 `diagnose: N issue(s) found`。存在失败检查时，退出状态为 `1`，错误信息包含问题数量；全部通过时，退出状态为 `0`。
+
+统计检查与 `bpf stats` 对 possible CPU 文件和 pin map 布局的要求相同。准备失败时打印 `[FAIL] map stats read`，计入问题数量，并以非零状态退出。
 
 ### `geosite` 与 `geoip`
 


### PR DESCRIPTION
## Problem

`honk-tool bpf stats` sized its per-CPU lookup buffers by counting `cpuN` directories under `/sys/devices/system/cpu`, which is the set of **present** CPUs, and assumed one CPU when that enumeration failed. `BPF_MAP_LOOKUP_ELEM` on a per-CPU map writes one value, rounded up to 8 bytes, for every **possible** CPU. Where possible exceeds present, the kernel writes past the allocation (#224).

## How I fixed it

One commit. The count comes from `/sys/devices/system/cpu/possible`, parsed as the range list it is (`0`, `0-3`, `0,2-3`, with the trailing newline), and it is the population of that set, not the highest index plus one, because that is what `num_possible_cpus()` is. A failed or malformed read stops the command with an error naming the file instead of guessing. Before allocating, the pinned map's type and `value_size` are checked against what the buffer assumes, and a mismatch refuses with both sizes named. The overflow block still prints before the per-CPU maps are opened, so a host missing one of those pins reports what it can.

## Verified

- `cargo fmt --all -- --check`, `cargo clippy --all --all-targets -- -D warnings`, `cargo test -p honk-tool`, and the workspace gate: exit 0 (2143 tests passed, 0 failed).
- Failing-first: the range parser table (`0`, `0-3`, `0,2-3`, `0-1,3`, empty, descending, overlapping, non-canonical), the buffer-length arithmetic against the aligned value size, and the sysfs-failure path.
- Reviewer ablation with the tests kept: making the count the highest index plus one fails the parser and buffer tests by assertion.
- A cold reader measured the kernel side on this host with a guard-page probe under `sudo`: `BPF_MAP_TYPE_PERCPU_ARRAY` and `PERCPU_HASH` both succeed at `num_possible_cpus() * round_up(value_size, 8)` and return `EFAULT` one byte short; a `value_size` of 9 needs 16 bytes per CPU. The new arithmetic matches.
- Not executed, and not claimed: an undersized lookup on a host where the possible set exceeds the present set. That needs such a host plus root and a pinned per-CPU map; the defect there is inferred from the kernel's copy loop, which the probe above confirms.

Closes #224.

---

- [x] `just fmt`, `just lint` and `just test-ci` pass.
- [x] I updated `doc/en/` and `doc/zh/` if I changed documented behaviour.
- [x] If I used AI: it followed `CONTRIBUTING.md` and `AGENTS.md`, and Verified shows what I ran, not guesses.
