### PR TITLE
fix(routing): parse hexadecimal DSCP and omit unreachable code

### DIFF
--- a/crates/honk-core/src/control/routing_matcher/codegen.rs
+++ b/crates/honk-core/src/control/routing_matcher/codegen.rs
@@ -324,10 +324,22 @@ pub fn emit_routing_program(
     }
 
     for rule in &plan.rules {
+        // BPF rejects structurally unreachable instructions before evaluating predicates.
+        if rule
+            .conditions
+            .iter()
+            .any(|condition| !condition.not && predicate_is_empty(&condition.predicate))
+        {
+            continue;
+        }
         asm.source(rule.id + 1, rule.source.as_str());
         let fail = asm.label();
         let mut failure_ready: Option<(u8, u8)> = None;
-        for condition in &rule.conditions {
+        for condition in rule
+            .conditions
+            .iter()
+            .filter(|condition| !predicate_is_empty(&condition.predicate))
+        {
             let pass = asm.label();
             emit_condition(&mut asm, condition, pass, fail, &fds, &caches)?;
             if let Some(kind) = FactKind::of(&condition.predicate) {
@@ -349,6 +361,9 @@ pub fn emit_routing_program(
         asm.st_imm(R7, RULE_ID, rule.id as i32)?;
         asm.mov_imm(R0, 0)?;
         asm.exit()?;
+        if failure_ready.is_none() {
+            return asm.finish();
+        }
         asm.bind(fail);
         (caches.must_ready, caches.may_ready) = failure_ready.unwrap_or_default();
     }
@@ -456,6 +471,21 @@ fn validate_plan(plan: &RoutingPushPlan) -> anyhow::Result<()> {
     Ok(())
 }
 
+fn predicate_is_empty(predicate: &KernelPredicate) -> bool {
+    match predicate {
+        KernelPredicate::DestinationPort(ranges) | KernelPredicate::SourcePort(ranges) => {
+            ranges.is_empty()
+        }
+        KernelPredicate::Protocol(mask) | KernelPredicate::IpVersion(mask) => *mask == 0,
+        KernelPredicate::Dscp(values) => values.is_empty(),
+        KernelPredicate::ProcessName(names) => names.is_empty(),
+        KernelPredicate::Domain(_)
+        | KernelPredicate::DestinationIp(_)
+        | KernelPredicate::SourceIp(_)
+        | KernelPredicate::Mac(_) => false,
+    }
+}
+
 fn emit_condition(
     asm: &mut Assembler,
     condition: &KernelCondition,
@@ -514,14 +544,10 @@ fn emit_predicate(
         }
         KernelPredicate::Dscp(values) => {
             asm.ldx_w(R0, R6, INPUT_DSCP)?;
-            if values.is_empty() {
-                asm.ja(on_false)?;
-            } else {
-                for value in values {
-                    asm.jump(BPF_JEQ, R0, *value as i32, on_true)?;
-                }
-                asm.ja(on_false)?;
+            for value in values {
+                asm.jump(BPF_JEQ, R0, *value as i32, on_true)?;
             }
+            asm.ja(on_false)?;
         }
         KernelPredicate::ProcessName(names) => {
             emit_process_names(asm, names, on_true, on_false)?;
@@ -538,13 +564,9 @@ fn emit_mask_scalar(
     on_false: Label,
 ) -> anyhow::Result<()> {
     asm.ldx_w(R0, R6, offset)?;
-    if mask == 0 {
-        asm.ja(on_false)?;
-    } else {
-        asm.and_imm(R0, mask)?;
-        asm.jump(BPF_JNE, R0, 0, on_true)?;
-        asm.ja(on_false)?;
-    }
+    asm.and_imm(R0, mask)?;
+    asm.jump(BPF_JNE, R0, 0, on_true)?;
+    asm.ja(on_false)?;
     Ok(())
 }
 
@@ -556,10 +578,6 @@ fn emit_port_ranges(
     on_false: Label,
 ) -> anyhow::Result<()> {
     asm.ldx_w(R0, R6, offset)?;
-    if ranges.is_empty() {
-        asm.ja(on_false)?;
-        return Ok(());
-    }
     for range in ranges {
         let next = asm.label();
         let inside = asm.label();
@@ -580,10 +598,6 @@ fn emit_process_names(
     on_true: Label,
     on_false: Label,
 ) -> anyhow::Result<()> {
-    if names.is_empty() {
-        asm.ja(on_false)?;
-        return Ok(());
-    }
     for bytes in names {
         let next_name = asm.label();
         asm.ldx_w(R4, R6, INPUT_PNAME_LEN)?;

--- a/crates/honk-core/src/ebpf/real/routing/tests.rs
+++ b/crates/honk-core/src/ebpf/real/routing/tests.rs
@@ -580,6 +580,53 @@ fn four_mode_golden_policies() {
 
 #[test]
 #[ignore = "requires root, Linux 6.12+, and HONK_ROUTING_TEST_OBJECT"]
+fn empty_scalar_predicates_preserve_rule_reachability() {
+    let config = honk_config::parser::parse_dae_config(
+        r#"
+        routing {
+            l4proto(icmp) -> block
+            !ipversion(9) && dport(8443) -> proxy(must)
+            dport(443) -> block
+            !dscp(invalid) -> direct(must)
+            dport(80) -> block
+            fallback: block
+        }
+        "#,
+    )
+    .unwrap();
+    let router = Router::new(&config.routing.rules, "block").unwrap();
+    let ids = HashMap::from([
+        ("direct".into(), 0),
+        ("block".into(), 1),
+        ("proxy".into(), 2),
+    ]);
+    let plan = RoutingPushPlan::compile(&router, &ids, "block", DialMode::Ip).unwrap();
+    let mut backend = RealEbpfBackend::load_routing_test_fixture(&object()).unwrap();
+    backend.publish_routing_plan(&plan, &[]).unwrap();
+    for (port, outbound, must, rule_id) in [(8443, 2, 1, 1), (443, 1, 0, 2), (80, 0, 1, 3)] {
+        let mut connection = golden::connection();
+        connection.dst_port = port;
+        assert_eq!(
+            router.route_with_must(&connection),
+            (["direct", "block", "proxy"][outbound as usize], must != 0),
+        );
+        let actual = backend.run_routing_test(&input(&connection)).unwrap();
+        assert_eq!(actual.status, 0);
+        assert_eq!(
+            actual.decision,
+            RoutingDecision {
+                outbound,
+                mark: 0,
+                must,
+                domain_final: 1,
+                rule_id,
+            },
+        );
+    }
+}
+
+#[test]
+#[ignore = "requires root, Linux 6.12+, and HONK_ROUTING_TEST_OBJECT"]
 fn large_prefix_fact_policy() {
     let ids = outbound_ids();
     let mut backend = RealEbpfBackend::load_routing_test_fixture(&object()).unwrap();

--- a/crates/honk-core/src/routing/golden.rs
+++ b/crates/honk-core/src/routing/golden.rs
@@ -208,9 +208,10 @@ pub(crate) fn fixtures() -> (Router, Vec<GoldenCase>) {
         ),
         (
             "dscp",
-            json!(["8", "46"]),
+            json!(["8", "0x2e", "0X04"]),
             vec![
                 (sample(|c| c.dscp = Some(8)), true),
+                (sample(|c| c.dscp = Some(4)), true),
                 (sample(|c| c.dscp = Some(46)), true),
                 (sample(|c| c.dscp = Some(63)), false),
                 (sample(|c| c.dscp = None), false),

--- a/crates/honk-core/src/routing/mod.rs
+++ b/crates/honk-core/src/routing/mod.rs
@@ -688,7 +688,14 @@ fn append_conditions(
             predicate: CompiledPredicate::Dscp(
                 dscps
                     .iter()
-                    .filter_map(|value| value.trim().parse().ok())
+                    .filter_map(|value| {
+                        let value = value.trim();
+                        value
+                            .strip_prefix("0x")
+                            .or_else(|| value.strip_prefix("0X"))
+                            .map_or_else(|| value.parse(), |hex| u8::from_str_radix(hex, 16))
+                            .ok()
+                    })
                     .collect(),
             ),
         });

--- a/doc/en/design/routing.md
+++ b/doc/en/design/routing.md
@@ -143,6 +143,12 @@ constant comparisons, masks, map lookups and terminal result writes. It owns no
 TLS/QUIC parser, proxy dialer, mode controller, health checker, or generic VM.
 Large IP/MAC/domain sets are data indexes, not thousands of inline literals.
 
+The emitter folds empty inline predicates before writing instructions: a positive
+empty predicate makes its whole rule impossible; a negated one adds no condition.
+If a rule becomes unconditional, emission ends at its action. Later rules and the
+fallback must not leave unreachable instructions that the kernel rejects before
+semantic verification. Retained actions keep their original rule IDs and metadata.
+
 Each generation owns separate destination IPv4/IPv6 and source IPv4/IPv6 LPM
 maps, a MAC index and a domain hash map. Family-separated IP maps prevent an IPv6
 prefix from matching a mapped IPv4 flow. A more-specific LPM entry inherits all

--- a/doc/en/reference/routing.md
+++ b/doc/en/reference/routing.md
@@ -40,7 +40,7 @@ routing {
 | `pname(...)` | Substring patterns normalized to 15 bytes, matched against the executable basename from `argv[0]`; when runtime BTF offsets or verifier-safe kernel argv access are unavailable, the cgroup hook uses the calling thread's `comm` synchronously | `process_name` |
 | `mac(...)` | Source MAC address | `mac` |
 | `ipversion(...)` | `4`/`ipv4`, `6`/`ipv6` | `ip_version` |
-| `dscp(...)` | DSCP value | `dscp` |
+| `dscp(...)` | Decimal or `0x`/`0X`-prefixed hexadecimal DSCP value | `dscp` |
 
 Every positive field has a corresponding list under `RoutingCondition.not`; the parser sends `!matcher(...)` there. Within one field, listed values are alternatives.
 

--- a/doc/zh/design/routing.md
+++ b/doc/zh/design/routing.md
@@ -115,6 +115,11 @@ UDP Preparing claim，不能把故障伪装成用户态补判请求。
 和终结结果写入。它不拥有 TLS/QUIC 解析、拨号、mode、健康检查或通用 VM。大的 IP、
 MAC、domain 集合保留为索引，不展开成成千上万条立即数比较。
 
+emitter 在生成指令前折叠空的内联谓词：正向空谓词使整条规则不可能命中，取反空谓词
+不增加条件。规则因此变成无条件时，在其 action 处结束生成；后续规则和 fallback
+不能留下不可达指令，否则内核会在语义验证前拒绝加载。保留的 action 仍使用原始
+RuleId 和元数据。
+
 每一代拥有独立的目的 IPv4/IPv6、源 IPv4/IPv6 LPM maps、MAC 索引和 domain hash map。
 IP 分 family，避免 IPv6 前缀误匹配 mapped IPv4。更具体的 LPM 条目继承所有匹配祖先
 谓词的位，使最长前缀查找不破坏规则顺序。每一代使用完整 `DomainRouting` bitmap，

--- a/doc/zh/reference/routing.md
+++ b/doc/zh/reference/routing.md
@@ -40,7 +40,7 @@ routing {
 | `pname(...)` | 按 15 字节规范化的子串模式，匹配 `argv[0]` 的可执行文件 basename；运行时 BTF 偏移或 cgroup verifier 拒绝内核 argv 读取时，cgroup hook 同步使用调用线程的 `comm` | `process_name` |
 | `mac(...)` | 源 MAC 地址 | `mac` |
 | `ipversion(...)` | `4`/`ipv4`, `6`/`ipv6` | `ip_version` |
-| `dscp(...)` | DSCP 值 | `dscp` |
+| `dscp(...)` | 十进制或带 `0x`/`0X` 前缀的十六进制 DSCP 值 | `dscp` |
 
 每个正向字段在 `RoutingCondition.not` 下都有对应列表；解析器把 `!matcher(...)` 放入该列表。同一字段中的多个值互为备选。
 


### PR DESCRIPTION
## Problem

`dscp(0x4)` is silently discarded by the decimal-only [DSCP parser](https://github.com/daeuniverse/honk/blob/66fc9465c09262ef04c9104c50f42b4e53849901/crates/honk-core/src/routing/mod.rs#L685-L693). The resulting empty predicate leaves an unreachable action in the [generated rule body](https://github.com/daeuniverse/honk/blob/66fc9465c09262ef04c9104c50f42b4e53849901/crates/honk-core/src/control/routing_matcher/codegen.rs#L262-L281), causing initial policy publication to fail with `BPF_PROG_LOAD EXT: unreachable insn`.

## How I fixed it

Accept decimal and `0x`/`0X` hexadecimal DSCP values in shared condition lowering. Fold empty inline predicates before emission, omit impossible rules, and stop emitting after an unconditional action while preserving rule IDs and metadata. Extend the shared positive/negated DSCP goldens, add a real-kernel reachability regression, and update both documentation languages.

## Verified

Both regressions failed before their fixes and passed afterward. The workspace gate passed 2,040 tests with the existing `test_routing_with_config_dae` exclusion; eBPF-enabled workspace clippy, formatting, and five local real-kernel routing tests passed. ARM64/OpenWrt and x86-64/Debian each passed six kernel checks, including 1,452 full-decision comparisons of the supplied 17-rule configuration and 476 golden comparisons. Remote checks used unhooked fixtures; live services/configs were unchanged. Full traffic/netns integration was not run.